### PR TITLE
Add MCP onboarding guide and refresh_tools endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,7 +322,9 @@ npm run preview            # Preview production build via Vite
 - Pulls data type schemas from OpenAPI spec (`getOpenApiSpec()`) for shared data model definitions
 - Served at `/api/mcp-spec` as `text/plain`
 - `getMcpOnboardingText(baseUrl)` wraps the MCP spec with self-onboarding instructions (quick start, recommended workflow)
-- Onboarding served at `/api/mcp-onboarding` as `text/plain` (no auth required) and via MCP `onboard` tool
+- Onboarding served at `/api/mcp-onboarding` as `text/plain` (no auth required) for initial AI self-onboarding via REST
+- `getMcpRefreshText(baseUrl)` wraps the MCP spec with update-focused framing for connected AI agents
+- MCP `refresh_tools` tool returns the refresh text so connected AIs can periodically update their tool knowledge
 
 ## Coding Conventions
 
@@ -385,7 +387,7 @@ npm run preview            # Preview production build via Vite
 | `get_stats` | Get storage statistics. |
 | `get_rest_api_spec` | Get the full OpenAPI 3.0 REST API specification (JSON). |
 | `get_mcp_spec` | Get the full MCP specification (markdown with tool schemas and data types). |
-| `onboard` | Self-onboarding tool — returns the full MCP onboarding guide with quick start, workflows, and spec. |
+| `refresh_tools` | Tool update — returns the current MCP tool specification for connected AI agents to stay up-to-date. |
 
 ### Token-Efficient MCP Data Flow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,6 +321,8 @@ npm run preview            # Preview production build via Vite
 - Tool input schemas auto-derived from Zod schemas in `tool-defs.ts` via `zodToJsonSchema()` (no hand-written JSON Schema)
 - Pulls data type schemas from OpenAPI spec (`getOpenApiSpec()`) for shared data model definitions
 - Served at `/api/mcp-spec` as `text/plain`
+- `getMcpOnboardingText(baseUrl)` wraps the MCP spec with self-onboarding instructions (quick start, recommended workflow)
+- Onboarding served at `/api/mcp-onboarding` as `text/plain` (no auth required) and via MCP `onboard` tool
 
 ## Coding Conventions
 
@@ -363,6 +365,7 @@ npm run preview            # Preview production build via Vite
 | `/api/admin/session` | GET | Check admin session status |
 | `/api/openapi` | GET | OpenAPI 3.0 schema |
 | `/api/mcp-spec` | GET | MCP specification (markdown with tool schemas and data types) |
+| `/api/mcp-onboarding` | GET | MCP onboarding guide for AI self-onboarding (wraps mcp-spec with quick start and workflow) |
 | `/api/mcp-tools` | GET | MCP tool summaries (JSON, derived from tool-defs.ts) |
 | `/mcp` | POST | MCP Streamable HTTP endpoint (stateless, auth required) |
 
@@ -382,6 +385,7 @@ npm run preview            # Preview production build via Vite
 | `get_stats` | Get storage statistics. |
 | `get_rest_api_spec` | Get the full OpenAPI 3.0 REST API specification (JSON). |
 | `get_mcp_spec` | Get the full MCP specification (markdown with tool schemas and data types). |
+| `onboard` | Self-onboarding tool — returns the full MCP onboarding guide with quick start, workflows, and spec. |
 
 ### Token-Efficient MCP Data Flow
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,7 @@ import { createStashRouter } from './routes/stashes.js';
 import { createTokenRouter } from './routes/tokens.js';
 import { createAdminRouter } from './routes/admin.js';
 import { getOpenApiSpec } from './openapi.js';
-import { getMcpSpecText } from './mcp-spec.js';
+import { getMcpSpecText, getMcpOnboardingText } from './mcp-spec.js';
 import { getToolSummaries } from './tool-defs.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { createMcpServer } from './mcp-server.js';
@@ -45,6 +45,11 @@ app.get('/api/openapi', (req, res) => {
 // MCP spec (human/AI-readable, includes data types from OpenAPI)
 app.get('/api/mcp-spec', (req, res) => {
   res.type('text/plain; charset=utf-8').send(getMcpSpecText(getBaseUrl(req)));
+});
+
+// MCP onboarding (AI self-onboarding guide with full spec, no auth required)
+app.get('/api/mcp-onboarding', (req, res) => {
+  res.type('text/plain; charset=utf-8').send(getMcpOnboardingText(getBaseUrl(req)));
 });
 
 // MCP tool summaries (structured JSON for frontend, derived from tool-defs.ts)

--- a/server/mcp-server.ts
+++ b/server/mcp-server.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ClawStashDB } from './db.js';
 import { getOpenApiSpec } from './openapi.js';
-import { getMcpSpecText, getMcpOnboardingText } from './mcp-spec.js';
+import { getMcpSpecText, getMcpOnboardingText, getMcpRefreshText } from './mcp-spec.js';
 import { TOKEN_EFFICIENT_GUIDE } from './shared-text.js';
 import { getToolDef } from './tool-defs.js';
 
@@ -248,14 +248,14 @@ ${TOKEN_EFFICIENT_GUIDE}`,
     }
   );
 
-  // Onboard — self-onboarding guide with full spec
-  const onboardDef = getToolDef('onboard');
+  // Refresh tools — current spec for already-connected AI agents to stay up-to-date
+  const refreshDef = getToolDef('refresh_tools');
   server.tool(
-    onboardDef.name,
-    onboardDef.description,
-    onboardDef.schema.shape,
+    refreshDef.name,
+    refreshDef.description,
+    refreshDef.schema.shape,
     async () => {
-      const text = getMcpOnboardingText(baseUrl || `http://localhost:${process.env.PORT || '3001'}`);
+      const text = getMcpRefreshText(baseUrl || `http://localhost:${process.env.PORT || '3001'}`);
       return {
         content: [{ type: 'text', text }],
       };

--- a/server/mcp-server.ts
+++ b/server/mcp-server.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ClawStashDB } from './db.js';
 import { getOpenApiSpec } from './openapi.js';
-import { getMcpSpecText } from './mcp-spec.js';
+import { getMcpSpecText, getMcpOnboardingText } from './mcp-spec.js';
 import { TOKEN_EFFICIENT_GUIDE } from './shared-text.js';
 import { getToolDef } from './tool-defs.js';
 
@@ -244,6 +244,20 @@ ${TOKEN_EFFICIENT_GUIDE}`,
       const spec = getMcpSpecText(baseUrl || `http://localhost:${process.env.PORT || '3001'}`);
       return {
         content: [{ type: 'text', text: spec }],
+      };
+    }
+  );
+
+  // Onboard — self-onboarding guide with full spec
+  const onboardDef = getToolDef('onboard');
+  server.tool(
+    onboardDef.name,
+    onboardDef.description,
+    onboardDef.schema.shape,
+    async () => {
+      const text = getMcpOnboardingText(baseUrl || `http://localhost:${process.env.PORT || '3001'}`);
+      return {
+        content: [{ type: 'text', text }],
       };
     }
   );

--- a/server/mcp-spec.ts
+++ b/server/mcp-spec.ts
@@ -82,3 +82,49 @@ ${dataTypesSection}`;
   mcpSpecCache.set(baseUrl, result);
   return result;
 }
+
+// ---------------------------------------------------------------------------
+// MCP Onboarding Text — wraps the spec with self-onboarding instructions
+// ---------------------------------------------------------------------------
+
+const onboardingCache = new Map<string, string>();
+
+export function getMcpOnboardingText(baseUrl: string): string {
+  const cached = onboardingCache.get(baseUrl);
+  if (cached) return cached;
+
+  const spec = getMcpSpecText(baseUrl);
+
+  const result = `# ClawStash MCP Onboarding Guide
+
+## How to Use This Document
+You are reading the ClawStash MCP onboarding specification. This document contains everything you need to connect and interact with this ClawStash instance via MCP (Model Context Protocol).
+
+**Re-read this document periodically** by calling the \`onboard\` MCP tool or fetching \`${baseUrl}/api/mcp-onboarding\` — tool definitions and capabilities may change over time.
+
+## Quick Start
+
+1. **Endpoint:** \`POST ${baseUrl}/mcp\`
+2. **Transport:** Streamable HTTP (stateless)
+3. **Auth:** \`Authorization: Bearer <token>\` — token needs \`mcp\` scope
+4. **First steps after connecting:**
+   - Call \`get_stats\` to see what's stored
+   - Call \`list_tags\` to discover content categories
+   - Call \`list_stashes\` to browse available stashes
+   - Call \`search_stashes\` to find specific content by keyword
+
+## Recommended Workflow
+
+1. **Discover** — Use \`list_stashes\`, \`list_tags\`, or \`search_stashes\` to find relevant stashes (returns summaries only, no file content).
+2. **Inspect** — Use \`read_stash\` to get metadata and file list with sizes (no content by default).
+3. **Read** — Use \`read_stash_file\` to selectively read only the files you need (most token-efficient).
+4. **Store** — Use \`create_stash\` or \`update_stash\` to save new data. Use descriptive names, descriptions, and tags for discoverability.
+5. **Refresh** — Call the \`onboard\` tool again whenever you need to re-check available tools and capabilities.
+
+---
+
+${spec}`;
+
+  onboardingCache.set(baseUrl, result);
+  return result;
+}

--- a/server/mcp-spec.ts
+++ b/server/mcp-spec.ts
@@ -100,7 +100,7 @@ export function getMcpOnboardingText(baseUrl: string): string {
 ## How to Use This Document
 You are reading the ClawStash MCP onboarding specification. This document contains everything you need to connect and interact with this ClawStash instance via MCP (Model Context Protocol).
 
-**Re-read this document periodically** by calling the \`onboard\` MCP tool or fetching \`${baseUrl}/api/mcp-onboarding\` — tool definitions and capabilities may change over time.
+**Once connected via MCP**, call the \`refresh_tools\` tool periodically to stay up-to-date — tool definitions and capabilities may change over time. You can also re-fetch this document at \`${baseUrl}/api/mcp-onboarding\`.
 
 ## Quick Start
 
@@ -119,12 +119,38 @@ You are reading the ClawStash MCP onboarding specification. This document contai
 2. **Inspect** — Use \`read_stash\` to get metadata and file list with sizes (no content by default).
 3. **Read** — Use \`read_stash_file\` to selectively read only the files you need (most token-efficient).
 4. **Store** — Use \`create_stash\` or \`update_stash\` to save new data. Use descriptive names, descriptions, and tags for discoverability.
-5. **Refresh** — Call the \`onboard\` tool again whenever you need to re-check available tools and capabilities.
+5. **Refresh** — Call the \`refresh_tools\` MCP tool whenever you need to re-check available tools and capabilities.
 
 ---
 
 ${spec}`;
 
   onboardingCache.set(baseUrl, result);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// MCP Refresh Text — spec with update-focused framing for connected AI agents
+// ---------------------------------------------------------------------------
+
+const refreshCache = new Map<string, string>();
+
+export function getMcpRefreshText(baseUrl: string): string {
+  const cached = refreshCache.get(baseUrl);
+  if (cached) return cached;
+
+  const spec = getMcpSpecText(baseUrl);
+
+  const result = `# ClawStash MCP Tool Update
+
+**Call \`refresh_tools\` periodically to stay up-to-date.** Tool definitions and capabilities may change over time.
+
+For initial onboarding (before MCP is connected), use the REST endpoint: \`GET ${baseUrl}/api/mcp-onboarding\`
+
+---
+
+${spec}`;
+
+  refreshCache.set(baseUrl, result);
   return result;
 }

--- a/server/openapi.ts
+++ b/server/openapi.ts
@@ -527,6 +527,16 @@ export function getOpenApiSpec(baseUrl: string): OpenApiSpec {
           },
         },
       },
+      '/api/mcp-onboarding': {
+        get: {
+          tags: ['System'],
+          summary: 'MCP onboarding guide for AI self-onboarding',
+          description: 'Returns the full MCP onboarding guide as markdown text. Includes quick start instructions, recommended workflows, and the complete MCP specification with all tool definitions, input schemas, return types, and data types. No authentication required — designed for AI agents to discover and onboard themselves. The equivalent MCP tool is `onboard`.',
+          responses: {
+            200: { description: 'MCP onboarding guide as text/plain (markdown)' },
+          },
+        },
+      },
       '/api/mcp-tools': {
         get: {
           tags: ['System'],

--- a/server/tool-defs.ts
+++ b/server/tool-defs.ts
@@ -214,6 +214,22 @@ Use this to understand all available MCP tools and how to use them optimally.`,
     schema: z.object({}),
     returns: 'Markdown text with full MCP specification',
   },
+  {
+    name: 'onboard',
+    description: `Self-onboarding tool — returns the full ClawStash MCP onboarding guide.
+
+Call this tool when you first connect to learn all available tools, their schemas, data types, connection details, and recommended workflows.
+Call it again periodically to refresh your knowledge — tool definitions and capabilities may change over time.
+
+The response includes:
+- Quick start instructions (endpoint, auth, first steps)
+- Recommended workflow for discovering and accessing stashes
+- Complete tool reference with input schemas and return types
+- Data type definitions
+- Token-efficient usage patterns`,
+    schema: z.object({}),
+    returns: 'Markdown text with full MCP onboarding guide and specification',
+  },
 ] satisfies ToolDef[];
 
 // ---------------------------------------------------------------------------

--- a/server/tool-defs.ts
+++ b/server/tool-defs.ts
@@ -215,20 +215,19 @@ Use this to understand all available MCP tools and how to use them optimally.`,
     returns: 'Markdown text with full MCP specification',
   },
   {
-    name: 'onboard',
-    description: `Self-onboarding tool — returns the full ClawStash MCP onboarding guide.
+    name: 'refresh_tools',
+    description: `Tool update — returns the current MCP tool specification so you can refresh your knowledge.
 
-Call this tool when you first connect to learn all available tools, their schemas, data types, connection details, and recommended workflows.
-Call it again periodically to refresh your knowledge — tool definitions and capabilities may change over time.
+Call this tool periodically to stay up-to-date. Tool definitions, schemas, and capabilities may change over time.
+This is the MCP-side equivalent of the REST onboarding endpoint (GET /api/mcp-onboarding) — use that for initial onboarding before connecting via MCP.
 
 The response includes:
-- Quick start instructions (endpoint, auth, first steps)
-- Recommended workflow for discovering and accessing stashes
-- Complete tool reference with input schemas and return types
+- Current tool reference with input schemas and return types
 - Data type definitions
-- Token-efficient usage patterns`,
+- Token-efficient usage patterns
+- Connection and authentication details`,
     schema: z.object({}),
-    returns: 'Markdown text with full MCP onboarding guide and specification',
+    returns: 'Markdown text with current MCP tool specification',
   },
 ] satisfies ToolDef[];
 


### PR DESCRIPTION
## Summary

Adds AI self-onboarding capabilities to the MCP server by introducing a new onboarding guide endpoint and a `refresh_tools` MCP tool. This enables AI agents to discover and understand the MCP API without prior knowledge, and to periodically refresh their tool knowledge as capabilities evolve.

## Changes

- **New `getMcpOnboardingText()` function** in `mcp-spec.ts`: Wraps the MCP spec with self-onboarding instructions including quick start guide, recommended workflow, and connection details
- **New `getMcpRefreshText()` function** in `mcp-spec.ts`: Wraps the MCP spec with update-focused framing for already-connected AI agents
- **New `/api/mcp-onboarding` REST endpoint** in `index.ts`: Serves the onboarding guide as plain text (no authentication required) for initial AI self-discovery
- **New `refresh_tools` MCP tool** in `mcp-server.ts`: Allows connected AI agents to periodically fetch updated tool specifications
- **Updated `tool-defs.ts`**: Added definition for `refresh_tools` tool with description and schema
- **Updated `openapi.ts`**: Added `/api/mcp-onboarding` endpoint to OpenAPI spec documentation
- **Updated `CLAUDE.md`**: Documented the new onboarding and refresh mechanisms

## Testing

- Code compiles without errors
- Build succeeds
- Changes follow existing patterns for spec generation and caching
- New endpoints are properly integrated into routing and OpenAPI documentation

## Checklist

- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [x] Changes are documented (CLAUDE.md updated with new functions and endpoints)

https://claude.ai/code/session_01FUTZRjztEzgXMxnPRTm46S