### PR TITLE
Clarify ClawStash purpose and positioning in OpenClaw ecosystem

### DIFF
--- a/server/shared-text.ts
+++ b/server/shared-text.ts
@@ -3,20 +3,26 @@
  * Single source of truth — edit here, all specs update automatically.
  */
 
-export const CLAWSTASH_PURPOSE = `ClawStash is an AI-optimized stash storage system — dynamic RAG instead of static context.
+export const CLAWSTASH_PURPOSE = `ClawStash is an AI-optimized stash system — a data vault for AI agents.
 
-A data/documentation vault for everything that doesn't fit in .md files: too large, too much, structured data, reference material.
+Instead of stuffing everything into static context, agents fetch information dynamically from ClawStash when they need it. Saves tokens, keeps context lean.
 
-**Use cases:**
-- **Reference Material** — API specs, docs, guides retrieved on demand instead of always loaded in context
-- **Project Snapshots** — Code, configs, logs stored without cluttering the workspace
-- **Structured Data** — Lists, tables, datasets that don't work well in Markdown
-- **Shared Information** — Data exchanged between different tools and agents
+**We use it for:**
+- 📝 **Thought storage** — capturing ideas, tagged by author
+- 📋 **Project tracking** — todo lists, roadmap, current steps
+- 📄 **Reference material** — API specs, prompts, docs that are only needed on-demand
+- 🔗 **Graph relations** — tags show connections between stashes
 
-**Core principle:** Instead of stuffing everything into static context (MEMORY.md, TOOLS.md etc.), retrieve information dynamically from ClawStash when needed. Saves tokens and keeps context lean.`;
+**Not for:**
+- 🔑 Secrets/passwords → use 1Password
+- 💾 Code repositories → use GitHub
+- 🧠 Operational agent memory → use MEMORY.md & daily notes
+- 📁 Large binary files → text/code only
+
+**Important:** ClawStash doesn't replace or compete with OpenClaw's internal mechanisms (Memory, Sessions, Config). It's a complement — an external data store that agents tap into when needed, like a reference book alongside their own memory.`;
 
 /** Plain-text version (no markdown) for OpenAPI info.description and contexts that don't render markdown. */
-export const CLAWSTASH_PURPOSE_PLAIN = `ClawStash — AI-optimized stash storage system — dynamic RAG instead of static context. A data/documentation vault for everything that doesn't fit in .md files: API specs, project snapshots, structured data, shared information between tools and agents. Retrieve information dynamically when needed instead of keeping everything in static context. Saves tokens and keeps context lean. Features: Text and file storage with name, description, tags, metadata. REST API + MCP Server + Web UI. Full-text search. Token-based authentication.`;
+export const CLAWSTASH_PURPOSE_PLAIN = `ClawStash — AI-optimized stash system — a data vault for AI agents. Instead of stuffing everything into static context, agents fetch information dynamically when needed. Saves tokens, keeps context lean. Use it for: thought storage (ideas tagged by author), project tracking (todos, roadmap, steps), reference material (API specs, prompts, docs on-demand), graph relations (tags show connections). NOT for: secrets/passwords (use 1Password), code repos (use GitHub), operational agent memory (use MEMORY.md & daily notes), or large binary files (text/code only). ClawStash complements but doesn't replace OpenClaw's internal mechanisms — it's an external data store agents tap into when needed.`;
 
 /** Token-efficient usage guide shared between MCP server description and MCP spec output. */
 export const TOKEN_EFFICIENT_GUIDE = `1. Use list_stashes or search_stashes to browse/find stashes (returns summaries only, no file content).


### PR DESCRIPTION
## Summary

Updated the ClawStash purpose and description text to better clarify its role as a complementary data vault for AI agents, with explicit guidance on what it should and shouldn't be used for.

## Changes

- Rewrote `CLAWSTASH_PURPOSE` to emphasize dynamic information retrieval over static context, with concrete use cases (thought storage, project tracking, reference material, graph relations)
- Added explicit "Not for" section clarifying that ClawStash doesn't replace secrets management (1Password), code repositories (GitHub), operational memory (MEMORY.md), or large binary files
- Added clarification that ClawStash complements but doesn't compete with OpenClaw's internal mechanisms (Memory, Sessions, Config)
- Updated `CLAWSTASH_PURPOSE_PLAIN` to match the revised messaging in a plain-text format suitable for API documentation
- Improved tone and structure for better clarity and user guidance

## Testing

No testing needed — these are documentation/messaging changes to shared text constants used in API specs and UI descriptions.

## Checklist

- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [x] Changes are documented (messaging clarification is the primary change)

https://claude.ai/code/session_014RmhAyhUSb7qhU425g7tWp