### PR TITLE
Replace package.json version with date-based build version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,10 @@ npm run preview            # Preview production build via Vite
 ### Footer (src/components/Footer.tsx)
 
 - Build info injected at compile time via Vite `define` (`__BUILD_INFO__` global)
-- Build info includes: version (from package.json), git branch, build date (ISO string)
+- Build info includes: git branch, commit hash (short), build date (ISO string)
+- Version displayed as date-based format `vYYYYMMDD-HHMM` (derived from build date, not package.json)
+- Build details (branch, commit, date) shown on the right side when toggled, next to GitHub link
+- Mobile: build details shown in separate panel below footer row
 - Type declaration for `__BUILD_INFO__` in `src/vite-env.d.ts`
 
 ### Graph Viewer (src/components/GraphViewer.tsx)

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,6 +2,12 @@ import { useState } from 'react';
 
 const buildInfo = __BUILD_INFO__;
 
+function formatBuildVersion(isoDate: string): string {
+  const d = new Date(isoDate);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `v${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}-${pad(d.getHours())}${pad(d.getMinutes())}`;
+}
+
 export default function Footer() {
   const [showDetails, setShowDetails] = useState(false);
 
@@ -15,13 +21,14 @@ export default function Footer() {
     hour: '2-digit',
     minute: '2-digit',
   });
+  const buildVersion = formatBuildVersion(buildInfo.buildDate);
 
   return (
     <footer className="app-footer">
       <div className="footer-row">
         <div className="footer-left">
-          <span className="footer-title" title={`ClawStash v${buildInfo.version}`}>
-            ClawStash <span className="footer-version">v{buildInfo.version}</span>
+          <span className="footer-title" title={`ClawStash ${buildVersion}`}>
+            ClawStash <span className="footer-version">{buildVersion}</span>
           </span>
           <button
             type="button"
@@ -36,7 +43,9 @@ export default function Footer() {
             </svg>
             <span className="footer-info-label">Build Info</span>
           </button>
+        </div>
 
+        <div className="footer-right">
           {showDetails && (
             <div className="footer-details-desktop">
               {buildInfo.branch && (
@@ -50,6 +59,16 @@ export default function Footer() {
                   {buildInfo.branch}
                 </span>
               )}
+              {buildInfo.commitHash && (
+                <span className="footer-detail" title={`Commit: ${buildInfo.commitHash}`}>
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="12" cy="12" r="3" />
+                    <line x1="3" x2="9" y1="12" y2="12" />
+                    <line x1="15" x2="21" y1="12" y2="12" />
+                  </svg>
+                  {buildInfo.commitHash}
+                </span>
+              )}
               <span className="footer-detail" title={`Built: ${formattedDate} ${formattedTime}`}>
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
@@ -61,9 +80,6 @@ export default function Footer() {
               </span>
             </div>
           )}
-        </div>
-
-        <div className="footer-right">
           <a
             href="https://github.com/fo0/clawstash"
             target="_blank"
@@ -84,6 +100,12 @@ export default function Footer() {
             <div className="footer-mobile-row">
               <span className="footer-mobile-label">Branch:</span>
               <span>{buildInfo.branch}</span>
+            </div>
+          )}
+          {buildInfo.commitHash && (
+            <div className="footer-mobile-row">
+              <span className="footer-mobile-label">Commit:</span>
+              <span>{buildInfo.commitHash}</span>
             </div>
           )}
           <div className="footer-mobile-row">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3830,6 +3830,7 @@ body {
 .footer-right {
   display: flex;
   align-items: center;
+  gap: 12px;
 }
 
 .footer-github-link {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="vite/client" />
 
 interface BuildInfo {
-  version: string;
   branch: string;
+  commitHash: string;
   buildDate: string;
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,19 +1,23 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import { readFileSync } from 'fs';
 import { execSync } from 'child_process';
 
 function getBuildInfo() {
-  const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
   let branch = '';
+  let commitHash = '';
   try {
     branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim();
   } catch {
     // Not a git repo or git not available
   }
+  try {
+    commitHash = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+  } catch {
+    // Not a git repo or git not available
+  }
   return {
-    version: pkg.version as string,
     branch,
+    commitHash,
     buildDate: new Date().toISOString(),
   };
 }


### PR DESCRIPTION
## Summary

Replace the static package.json version with a dynamic date-based version format (`vYYYYMMDD-HHMM`) derived from the build date. Also add commit hash to build info and reorganize footer layout to better display build details.

## Changes

- **Version format**: Changed from `package.json` version to date-based format `vYYYYMMDD-HHMM` generated from build timestamp
- **Build info**: 
  - Removed `version` field from build info
  - Added `commitHash` field (short git hash)
  - Kept `branch` and `buildDate` fields
- **Footer component**:
  - Added `formatBuildVersion()` function to convert ISO date to version string
  - Updated version display to use formatted build version
  - Reorganized layout: moved build details panel into `footer-right` section
  - Added commit hash display in both desktop and mobile views
- **Build config**: Updated `vite.config.ts` to capture git commit hash instead of reading package.json version
- **Type definitions**: Updated `BuildInfo` interface to reflect new fields
- **Styling**: Added `gap: 12px` to `.footer-right` for proper spacing

## Testing

- Code compiles without errors
- Build succeeds with new build info structure
- Footer displays date-based version and commit hash correctly
- Build details toggle works in both desktop and mobile layouts

## Checklist

- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [x] Changes are documented (CLAUDE.md updated)

https://claude.ai/code/session_01Qb2bLJJLtKoNmTzpxv3TM3