### PR TITLE
Fix version endpoint to use actual build version instead of package.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ clawstash/
 │   ├── mcp-spec.ts             # MCP spec generator (uses tool-defs.ts + zodToJsonSchema + OpenAPI data types)
 │   ├── mcp.ts                  # MCP server stdio transport entry point
 │   ├── openapi.ts              # OpenAPI 3.0 schema generator (uses shared-text.ts for description)
-│   ├── version.ts              # Version check utility (current version + GitHub latest release)
+│   ├── version.ts              # Version check utility (build info + GitHub latest commit comparison)
 │   └── routes/
 │       ├── admin.ts            # Admin auth routes (login/logout/session)
 │       ├── stashes.ts          # REST API route handlers
@@ -232,6 +232,7 @@ npm run preview            # Preview production build via Vite
 
 - Build info injected at compile time via Vite `define` (`__BUILD_INFO__` global)
 - Build info includes: git branch, commit hash (short), build date (ISO string)
+- Vite build plugin also writes `dist/build-info.json` for server-side access (used by `server/version.ts`)
 - Version displayed as date-based format `vYYYYMMDD-HHMM` (derived from build date, not package.json)
 - Build details (branch, commit, date) shown on the right side when toggled, next to GitHub link
 - Mobile: build details shown in separate panel below footer row

--- a/server/openapi.ts
+++ b/server/openapi.ts
@@ -187,12 +187,29 @@ export function getOpenApiSpec(baseUrl: string): OpenApiSpec {
         },
         VersionInfo: {
           type: 'object',
-          description: 'Current and latest version information',
+          description: 'Current build info and latest available version from GitHub',
           properties: {
-            current_version: { type: 'string', description: 'Currently running ClawStash version' },
-            latest_version: { type: 'string', nullable: true, description: 'Latest version available on GitHub (null if check failed)' },
-            update_available: { type: 'boolean', description: 'True if the latest version is newer than the current version' },
-            release_url: { type: 'string', nullable: true, description: 'URL to the latest release page on GitHub (null if unavailable)' },
+            current: {
+              type: 'object',
+              description: 'Currently running build',
+              properties: {
+                version: { type: 'string', description: 'Date-based build version (e.g. "v20260215-1628")' },
+                commit_sha: { type: 'string', description: 'Short commit hash of this build' },
+                build_date: { type: 'string', format: 'date-time', description: 'Build timestamp (ISO 8601)' },
+                branch: { type: 'string', description: 'Git branch this was built from' },
+              },
+            },
+            latest: {
+              type: 'object',
+              nullable: true,
+              description: 'Latest commit on the GitHub main branch (null if check failed)',
+              properties: {
+                commit_sha: { type: 'string', description: 'Short commit hash of the latest commit on main' },
+                commit_date: { type: 'string', format: 'date-time', description: 'Commit date (ISO 8601)' },
+                commit_message: { type: 'string', description: 'First line of the commit message' },
+              },
+            },
+            update_available: { type: 'boolean', description: 'True if the latest commit SHA differs from the current build SHA' },
             github_url: { type: 'string', description: 'GitHub repository URL' },
             checked_at: { type: 'string', format: 'date-time', description: 'Timestamp of the last GitHub check' },
           },

--- a/server/tool-defs.ts
+++ b/server/tool-defs.ts
@@ -233,11 +233,11 @@ The response includes:
     name: 'check_version',
     description: `Check the current ClawStash version and whether a newer version is available on GitHub.
 
-Returns the running version, the latest release version (if available), and whether an update is possible. Useful for automated upgrade checks and monitoring.
+Returns the running build version (date-based, e.g. "v20260215-1628"), commit SHA, and build date. Compares against the latest commit on the GitHub main branch to detect available updates.
 
-The latest version is fetched from GitHub releases (with fallback to tags) and cached for 1 hour.`,
+Useful for automated upgrade checks and monitoring. The GitHub check is cached for 1 hour.`,
     schema: z.object({}),
-    returns: '{ current_version, latest_version, update_available, release_url, github_url, checked_at }',
+    returns: '{ current: { version, commit_sha, build_date, branch }, latest: { commit_sha, commit_date, commit_message } | null, update_available, github_url, checked_at }',
   },
 ] satisfies ToolDef[];
 

--- a/server/version.ts
+++ b/server/version.ts
@@ -1,116 +1,114 @@
 /**
- * Version check utility — compares local version against latest GitHub release.
+ * Version check utility — reads local build info and compares against
+ * the latest commit on the GitHub main branch.
  *
- * Uses the GitHub API to fetch the latest release tag. Results are cached
- * for a configurable duration to avoid excessive API calls.
+ * Current version: read from dist/build-info.json (production) or git (development).
+ * Latest version:  fetched from GitHub Commits API (SHA comparison, not semver).
+ * Results are cached for 1 hour to avoid excessive API calls.
  */
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
+import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import path from 'path';
 
 // ---------------------------------------------------------------------------
-// Local version (from package.json)
+// Constants
 // ---------------------------------------------------------------------------
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const pkg = JSON.parse(readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'));
-
-export const CURRENT_VERSION: string = pkg.version;
-
 const GITHUB_OWNER = 'fo0';
 const GITHUB_REPO = 'clawstash';
 const GITHUB_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}`;
-
-// ---------------------------------------------------------------------------
-// Cache
-// ---------------------------------------------------------------------------
-
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
-interface VersionCache {
-  latest_version: string | null;
-  release_url: string | null;
+// ---------------------------------------------------------------------------
+// Build info (current version)
+// ---------------------------------------------------------------------------
+
+interface BuildInfo {
+  branch: string;
+  commitHash: string;
+  buildDate: string;
+}
+
+function formatBuildVersion(isoDate: string): string {
+  const d = new Date(isoDate);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `v${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}-${pad(d.getHours())}${pad(d.getMinutes())}`;
+}
+
+function loadBuildInfo(): BuildInfo {
+  // Production: read from dist/build-info.json (written by Vite build plugin)
+  const buildInfoPath = path.join(__dirname, '..', 'dist', 'build-info.json');
+  if (existsSync(buildInfoPath)) {
+    try {
+      return JSON.parse(readFileSync(buildInfoPath, 'utf-8'));
+    } catch {
+      // Fall through to git
+    }
+  }
+
+  // Development: read directly from git
+  let branch = '';
+  let commitHash = '';
+  try {
+    branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+  } catch {
+    // git not available
+  }
+  try {
+    commitHash = execSync('git rev-parse --short HEAD', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+  } catch {
+    // git not available
+  }
+  return { branch, commitHash, buildDate: new Date().toISOString() };
+}
+
+const buildInfo = loadBuildInfo();
+
+// ---------------------------------------------------------------------------
+// GitHub API — latest commit on main
+// ---------------------------------------------------------------------------
+
+interface LatestCache {
+  commit_sha: string | null;
+  commit_date: string | null;
+  commit_message: string | null;
   checked_at: string;
 }
 
-let cache: VersionCache | null = null;
+let cache: LatestCache | null = null;
 let cacheExpiry = 0;
 
-// ---------------------------------------------------------------------------
-// Semver comparison (major.minor.patch)
-// ---------------------------------------------------------------------------
-
-function parseVersion(v: string): number[] {
-  return v.replace(/^v/, '').split('.').map(Number);
-}
-
-/** Returns true when remote is strictly newer than local. */
-function isNewer(remote: string, local: string): boolean {
-  const r = parseVersion(remote);
-  const l = parseVersion(local);
-  for (let i = 0; i < 3; i++) {
-    const rv = r[i] ?? 0;
-    const lv = l[i] ?? 0;
-    if (rv > lv) return true;
-    if (rv < lv) return false;
-  }
-  return false;
-}
-
-// ---------------------------------------------------------------------------
-// GitHub API fetch
-// ---------------------------------------------------------------------------
-
-async function fetchLatestRelease(): Promise<VersionCache> {
+async function fetchLatestCommit(): Promise<LatestCache> {
   const now = new Date().toISOString();
+  const userAgent = `ClawStash/${formatBuildVersion(buildInfo.buildDate)}`;
 
   try {
-    // Try releases first
-    const releaseRes = await fetch(
-      `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest`,
+    const res = await fetch(
+      `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/commits/main`,
       {
-        headers: { Accept: 'application/vnd.github+json', 'User-Agent': `ClawStash/${CURRENT_VERSION}` },
+        headers: { Accept: 'application/vnd.github+json', 'User-Agent': userAgent },
         signal: AbortSignal.timeout(5000),
       },
     );
 
-    if (releaseRes.ok) {
-      const data = await releaseRes.json() as { tag_name: string; html_url: string };
+    if (res.ok) {
+      const data = await res.json() as {
+        sha: string;
+        commit: { message: string; committer: { date: string } | null };
+      };
       return {
-        latest_version: data.tag_name.replace(/^v/, ''),
-        release_url: data.html_url,
+        commit_sha: data.sha.substring(0, 7),
+        commit_date: data.commit.committer?.date ?? null,
+        commit_message: data.commit.message.split('\n')[0],
         checked_at: now,
       };
     }
 
-    // Fallback: check tags if no releases exist
-    if (releaseRes.status === 404) {
-      const tagsRes = await fetch(
-        `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/tags?per_page=1`,
-        {
-          headers: { Accept: 'application/vnd.github+json', 'User-Agent': `ClawStash/${CURRENT_VERSION}` },
-          signal: AbortSignal.timeout(5000),
-        },
-      );
-
-      if (tagsRes.ok) {
-        const tags = await tagsRes.json() as Array<{ name: string }>;
-        if (tags.length > 0) {
-          const tagName = tags[0].name;
-          return {
-            latest_version: tagName.replace(/^v/, ''),
-            release_url: `${GITHUB_URL}/releases/tag/${tagName}`,
-            checked_at: now,
-          };
-        }
-      }
-    }
-
-    // No release/tag info available
-    return { latest_version: null, release_url: null, checked_at: now };
+    return { commit_sha: null, commit_date: null, commit_message: null, checked_at: now };
   } catch {
-    // Network error, timeout, etc. — return null for latest
-    return { latest_version: null, release_url: null, checked_at: now };
+    return { commit_sha: null, commit_date: null, commit_message: null, checked_at: now };
   }
 }
 
@@ -119,10 +117,18 @@ async function fetchLatestRelease(): Promise<VersionCache> {
 // ---------------------------------------------------------------------------
 
 export interface VersionInfo {
-  current_version: string;
-  latest_version: string | null;
+  current: {
+    version: string;
+    commit_sha: string;
+    build_date: string;
+    branch: string;
+  };
+  latest: {
+    commit_sha: string | null;
+    commit_date: string | null;
+    commit_message: string | null;
+  } | null;
   update_available: boolean;
-  release_url: string | null;
   github_url: string;
   checked_at: string;
 }
@@ -131,15 +137,27 @@ export async function checkVersion(): Promise<VersionInfo> {
   const now = Date.now();
 
   if (!cache || now > cacheExpiry) {
-    cache = await fetchLatestRelease();
+    cache = await fetchLatestCommit();
     cacheExpiry = now + CACHE_TTL_MS;
   }
 
+  const updateAvailable = cache.commit_sha !== null
+    && buildInfo.commitHash !== ''
+    && cache.commit_sha !== buildInfo.commitHash;
+
   return {
-    current_version: CURRENT_VERSION,
-    latest_version: cache.latest_version,
-    update_available: cache.latest_version ? isNewer(cache.latest_version, CURRENT_VERSION) : false,
-    release_url: cache.release_url,
+    current: {
+      version: formatBuildVersion(buildInfo.buildDate),
+      commit_sha: buildInfo.commitHash,
+      build_date: buildInfo.buildDate,
+      branch: buildInfo.branch,
+    },
+    latest: cache.commit_sha ? {
+      commit_sha: cache.commit_sha,
+      commit_date: cache.commit_date,
+      commit_message: cache.commit_message,
+    } : null,
+    update_available: updateAvailable,
     github_url: GITHUB_URL,
     checked_at: cache.checked_at,
   };


### PR DESCRIPTION
- Current version now shows date-based build version (v20260215-1628) matching the footer, plus commit SHA, build date, and branch
- Vite build plugin writes dist/build-info.json for server-side access
- Server reads build-info.json in production, falls back to git in dev
- Latest version check uses GitHub Commits API (SHA comparison) instead of Releases API, matching the project's Docker tag release model
- Update available when current commit SHA differs from latest on main

https://claude.ai/code/session_012Wx63yY4fkELJd194jJSeA

## Summary

Brief description of the changes.

## Changes

-

## Testing

How were these changes tested?

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Build succeeds (`npm run build`)
- [ ] Changes are documented (if applicable)
