### PR TITLE
Fix tap-on-node not triggering popup on mobile graph views

### DIFF
--- a/src/components/GraphViewer.tsx
+++ b/src/components/GraphViewer.tsx
@@ -954,7 +954,8 @@ export default function GraphViewer({ stashes, tags, onFilterTag, onSelectStash,
 
         if (dragRef.current) {
           e.preventDefault();
-          isTouchDragging = true;
+          const moveDist = Math.sqrt((touch.clientX - touchStartPos.x) ** 2 + (touch.clientY - touchStartPos.y) ** 2);
+          if (moveDist > 8) isTouchDragging = true;
           const { x: wx, y: wy } = screenToWorld(sx, sy, canvas);
           dragRef.current.node.x = wx - dragRef.current.offsetX;
           dragRef.current.node.y = wy - dragRef.current.offsetY;

--- a/src/components/StashGraphCanvas.tsx
+++ b/src/components/StashGraphCanvas.tsx
@@ -898,7 +898,8 @@ export default function StashGraphCanvas({ onSelectStash, analyzeStashId, onAnal
 
         if (dragRef.current) {
           e.preventDefault();
-          isTouchDragging = true;
+          const moveDist = Math.sqrt((touch.clientX - touchStartPos.x) ** 2 + (touch.clientY - touchStartPos.y) ** 2);
+          if (moveDist > 8) isTouchDragging = true;
           const { x: wx, y: wy } = screenToWorld(sx, sy, canvas);
           dragRef.current.node.x = wx - dragRef.current.offsetX;
           dragRef.current.node.y = wy - dragRef.current.offsetY;


### PR DESCRIPTION
Add 8px movement threshold before treating a touch as a drag in both GraphViewer and StashGraphCanvas. Previously any touchmove (even sub-pixel finger jitter) would set isTouchDragging=true, which prevented onTouchEnd from recognizing the gesture as a tap.

https://claude.ai/code/session_01MRYiuj8bFFzMmpgh6BfYMc

## Summary

Brief description of the changes.

## Changes

-

## Testing

How were these changes tested?

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Build succeeds (`npm run build`)
- [ ] Changes are documented (if applicable)
