### PR TITLE
Implement Confluence-style inline version comparison UI

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -17,6 +17,7 @@ Review findings not immediately fixed. **Only work on these upon explicit reques
 | 9 | 2026-02-15 | Code Smells | P2 | src/components/VersionHistory.tsx | Errors in version fetch/view/compare silently ignored — should show error state to user | Deferred | Feature: Version History |
 | 10 | 2026-02-15 | Dependency | P1 | package.json | **Zod 4 upgrade blocked** (PR #7): `@modelcontextprotocol/sdk` v1.x uses `zod-to-json-schema` which is incompatible with Zod v4 (`_parse is not a function`). Zod v4 has native `z.toJSONSchema()` replacement. Revisit when MCP SDK v2 ships (expected Q1 2026). Also requires replacing `zodToJsonSchema()` in `server/mcp-spec.ts` with built-in `z.toJSONSchema({ target: 'openapi-3.0' })` | Deferred | Dependabot PR #7 review |
 | 11 | 2026-02-15 | Dependency | P2 | Dockerfile | **Node 25 Docker image not recommended** (PR #1): Node 25 is non-LTS (odd version). Project targets Node 22 LTS (supported until April 2027). Risk: native addon compatibility (better-sqlite3), undocumented behavior changes. Wait for Node 24 LTS or Node 26 LTS. CI workflow also hardcodes `node-version: "22"` — must be updated in sync | Accepted | Dependabot PR #1 review |
+| 12 | 2026-02-17 | Bugs & Logic | P1 | src/server/db.ts:importAllData | `importAllData()` INSERT for stashes omits `version` column — defaults to 1 regardless of actual version. Imported stash_versions records may reference higher versions, causing version list inconsistency | Deferred | Review: Version History v0 fix |
 
 ## Done
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ clawstash/
 │   │   ├── StashCard.tsx       # Individual stash card component
 │   │   ├── StashViewer.tsx     # Stash detail view with file display, access log, version history
 │   │   ├── StashGraphCanvas.tsx # Stash graph canvas component
-│   │   ├── VersionHistory.tsx  # Version history list, compare selector, restore button
+│   │   ├── VersionHistory.tsx  # Version history list, Confluence-style inline comparison radios, restore button
 │   │   ├── VersionDiff.tsx     # GitHub-style diff view (green/red) using jsdiff
 │   │   ├── SearchOverlay.tsx   # Alt+K quick search overlay with keyboard navigation
 │   │   ├── LoginScreen.tsx     # Password login gate
@@ -198,11 +198,11 @@ npm run mcp                # Start MCP server (stdio transport)
 - `api_tokens` table stores API tokens (SHA-256 hashed, with scopes and prefix)
 - **Version History**: `stash_versions` + `stash_version_files` tables track every version of a stash
 - `stashes` table has `version` column (integer, starts at 1, incremented on every update)
-- `updateStash()` snapshots the current state into `stash_versions` before applying changes (within transaction)
-- `createStash()` sets `version=1` but does NOT create a version record (the stash IS v1; history starts on first update)
-- Auto-migration: existing stashes get `version=1` column added
-- `getStashVersions(id)` returns version list (descending) with file counts and sizes
-- `getStashVersion(id, version)` returns full version snapshot with file content
+- `createStash()` sets `version=1` AND creates a v1 record in `stash_versions` (initial state stored for comparison)
+- `updateStash()` snapshots the current state into `stash_versions` before applying changes (skips if version record already exists, e.g. v1 from creation)
+- Auto-migration: existing stashes get `version=1` column added; stashes without version records get v1 backfilled
+- `getStashVersions(id)` returns version list (descending) with file counts and sizes, includes current live version at top when newer than latest stored
+- `getStashVersion(id, version)` returns full version snapshot with file content; falls back to current live stash data if version matches current version
 - `restoreStashVersion(id, version)` restores an old version as a new update (creates new version)
 
 ### DB Singleton (src/server/singleton.ts)

--- a/src/app/api/stashes/[id]/versions/diff/route.ts
+++ b/src/app/api/stashes/[id]/versions/diff/route.ts
@@ -20,6 +20,7 @@ export async function GET(req: NextRequest, { params }: Params) {
     return NextResponse.json({ error: 'Provide two different positive version numbers as v1 and v2 query parameters' }, { status: 400 });
   }
 
+  // getStashVersion supports both historical versions and the current live version
   const version1 = db.getStashVersion(id, v1);
   const version2 = db.getStashVersion(id, v2);
   if (!version1 || !version2) {

--- a/src/components/shared/Spinner.tsx
+++ b/src/components/shared/Spinner.tsx
@@ -1,6 +1,6 @@
-export default function Spinner() {
+export default function Spinner({ size = 16 }: { size?: number }) {
   return (
-    <svg className="api-spinner" width="16" height="16" viewBox="0 0 24 24" fill="none">
+    <svg className="api-spinner" width={size} height={size} viewBox="0 0 24 24" fill="none">
       <circle style={{ opacity: 0.25 }} cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
       <path style={{ opacity: 0.75 }} fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
     </svg>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4569,9 +4569,19 @@ body {
     gap: 6px;
   }
 
-  .version-select {
+  .version-compare-bar .btn {
     width: 100%;
-    min-width: unset;
+    justify-content: center;
+  }
+
+  .version-radios {
+    width: 48px;
+    gap: 4px;
+  }
+
+  .version-radio input[type="radio"] {
+    width: 14px;
+    height: 14px;
   }
 
   .version-detail-header {
@@ -4866,33 +4876,109 @@ body {
 .version-compare-bar {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 8px;
-  padding: 10px 12px;
+  padding: 10px 14px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius);
-  flex-wrap: wrap;
 }
 
-.version-compare-label {
+.version-compare-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
   color: var(--text-secondary);
-  font-size: 13px;
-  font-weight: 500;
 }
 
-.version-select {
-  background: var(--bg-input);
-  color: var(--text-primary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius);
-  padding: 4px 8px;
-  font-size: 13px;
-  min-width: 160px;
+.version-compare-info strong {
+  color: var(--accent-blue);
+  font-family: var(--font-mono);
 }
 
-.version-select:focus {
-  outline: none;
+.version-compare-arrow {
+  color: var(--text-muted);
+  margin: 0 2px;
+}
+
+.version-compare-hint {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* Confluence-style radio button columns */
+.version-radios {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+  width: 56px;
+  justify-content: center;
+}
+
+.version-radio {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+}
+
+.version-radio input[type="radio"] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--border-color);
+  border-radius: 50%;
+  background: var(--bg-primary);
+  cursor: pointer;
+  transition: border-color 0.15s, background-color 0.15s;
+  margin: 0;
+}
+
+.version-radio input[type="radio"]:hover:not(:disabled) {
   border-color: var(--accent-blue);
+}
+
+.version-radio input[type="radio"]:checked {
+  border-color: var(--accent-blue);
+  background: var(--accent-blue);
+  box-shadow: inset 0 0 0 3px var(--bg-primary);
+}
+
+.version-radio input[type="radio"]:disabled {
+  opacity: 0.25;
+  cursor: not-allowed;
+}
+
+.version-radio-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  width: 24px;
+  text-align: center;
+}
+
+.version-list-header {
+  padding: 6px 14px;
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.version-list-header:hover {
+  background: var(--bg-tertiary);
+}
+
+.version-list-header-text {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.5px;
 }
 
 .version-list {


### PR DESCRIPTION
## Summary

Redesigned the version comparison interface from dropdown selectors to a Confluence-style inline radio button system. Users can now select "From" (older) and "To" (newer) versions directly in the version list, with automatic validation to ensure proper ordering. The UI also auto-selects the two most recent versions for quick comparison and includes a live version indicator.

## Changes

- **VersionHistory.tsx**: 
  - Replaced `diffV1`/`diffV2` state with `compareFrom`/`compareTo` for clearer semantics
  - Added inline radio buttons in version list for selecting comparison versions
  - Implemented `handleFromChange` and `handleToChange` with validation to maintain From < To ordering
  - Auto-select two most recent versions on load for quick comparison
  - Updated compare bar UI with visual feedback showing selected versions
  - Added disabled states for radio buttons (newest version can't be "From", oldest can't be "To")

- **db.ts**:
  - Added Migration 7 to backfill initial version records for stashes created before versioning was implemented
  - Modified `createStash()` to automatically create a v1 version record during stash creation
  - Updated `updateStash()` to skip re-recording versions that were already stored (e.g., v1)
  - Enhanced `getVersions()` to include the current live version at the top if it's newer than the latest stored version
  - Updated `getStashVersion()` to fall back to live stash data if version not found in history

- **app.css**:
  - Redesigned `.version-compare-bar` with flexbox layout and space-between alignment
  - Added `.version-radios`, `.version-radio`, and `.version-radio-label` styles for inline radio buttons
  - Added `.version-list-header` for column headers (From/To/Version/Actions)
  - Styled radio inputs with custom appearance, hover states, and checked states
  - Updated compare info display with arrow indicator and hint text

- **Spinner.tsx**: Added optional `size` prop for flexible spinner sizing

- **CLAUDE.md**: Updated VersionHistory component description to reflect new comparison UI

## Testing

- Existing version history functionality preserved (view, restore operations)
- Radio button validation ensures From < To ordering
- Auto-selection of two most recent versions on load
- Live version indicator shows current state vs. stored versions
- Backfill migration handles stashes without version records
- Duplicate version recording prevented in updateStash

https://claude.ai/code/session_01HyiXJt1kT2VdoF2gKv5KRT