### PR TITLE
Add GitHub-style heading anchors to markdown renderer

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1458,6 +1458,30 @@ body {
   margin-bottom: 12px;
   font-weight: 600;
   line-height: 1.25;
+  scroll-margin-top: 16px;
+  position: relative;
+}
+
+.markdown-body h1[id]:hover,
+.markdown-body h2[id]:hover,
+.markdown-body h3[id]:hover,
+.markdown-body h4[id]:hover,
+.markdown-body h5[id]:hover,
+.markdown-body h6[id]:hover {
+  cursor: pointer;
+}
+
+.markdown-body h1[id]:hover::before,
+.markdown-body h2[id]:hover::before,
+.markdown-body h3[id]:hover::before,
+.markdown-body h4[id]:hover::before,
+.markdown-body h5[id]:hover::before,
+.markdown-body h6[id]:hover::before {
+  content: '#';
+  color: var(--text-tertiary);
+  margin-left: -1.2em;
+  padding-right: 0.2em;
+  position: absolute;
 }
 
 .markdown-body h1 { font-size: 1.8em; padding-bottom: 8px; border-bottom: 1px solid var(--border-color); }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1459,29 +1459,17 @@ body {
   font-weight: 600;
   line-height: 1.25;
   scroll-margin-top: 16px;
-  position: relative;
 }
 
-.markdown-body h1[id]:hover,
-.markdown-body h2[id]:hover,
-.markdown-body h3[id]:hover,
-.markdown-body h4[id]:hover,
-.markdown-body h5[id]:hover,
-.markdown-body h6[id]:hover {
-  cursor: pointer;
+.markdown-body .heading-anchor {
+  color: transparent;
+  text-decoration: none;
+  padding-right: 4px;
+  user-select: none;
 }
 
-.markdown-body h1[id]:hover::before,
-.markdown-body h2[id]:hover::before,
-.markdown-body h3[id]:hover::before,
-.markdown-body h4[id]:hover::before,
-.markdown-body h5[id]:hover::before,
-.markdown-body h6[id]:hover::before {
-  content: '#';
+.markdown-body :is(h1, h2, h3, h4, h5, h6):hover .heading-anchor {
   color: var(--text-tertiary);
-  margin-left: -1.2em;
-  padding-right: 0.2em;
-  position: absolute;
 }
 
 .markdown-body h1 { font-size: 1.8em; padding-bottom: 8px; border-bottom: 1px solid var(--border-color); }


### PR DESCRIPTION
## Summary

Add automatic heading ID generation and anchor link support to the markdown renderer, enabling GitHub-style heading anchors with visual link indicators on hover.

## Changes

- **Heading ID generation**: Implemented `slugify()` function to convert heading text to URL-safe slugs following GitHub conventions (lowercase, strip HTML, remove special chars, spaces → hyphens)
- **Duplicate heading handling**: Track slug occurrences per render pass and append numeric suffixes (e.g., `heading-1`, `heading-2`) to disambiguate duplicate headings
- **Anchor link support**: Modified link renderer to preserve in-page anchor links (starting with `#`) without `target="_blank"`, while external links continue to open in new tabs
- **Visual affordance**: Added CSS styling to display a `#` symbol on heading hover, with `scroll-margin-top` for proper scroll positioning when anchors are clicked
- **Slug counter reset**: Reset slug counter on each `renderMarkdown()` call to ensure independent heading IDs per file

## Testing

Manual testing of markdown rendering with:
- Headings with special characters and HTML markup
- Duplicate heading names
- Internal anchor links (`[link](#heading)`)
- External links (verify they still open in new tab)
- Heading hover interactions and scroll behavior

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Build succeeds (`npm run build`)
- [ ] Changes are documented (if applicable)

https://claude.ai/code/session_01Jij8sm4tnyShZsZnMED8V8