### PR TITLE
Add Table of Contents for multi-markdown stashes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ clawstash/
 │   │   ├── Dashboard.tsx       # Home view with grid/list of stash cards
 │   │   ├── GraphViewer.tsx     # Force-directed tag graph visualization (canvas-based)
 │   │   ├── StashCard.tsx       # Individual stash card component
-│   │   ├── StashViewer.tsx     # Stash detail view with file display, access log, version history
+│   │   ├── StashViewer.tsx     # Stash detail view with file display, TOC, access log, version history
 │   │   ├── StashGraphCanvas.tsx # Stash graph canvas component
 │   │   ├── VersionHistory.tsx  # Version history list, Confluence-style inline comparison radios, restore button
 │   │   ├── VersionDiff.tsx     # GitHub-style diff view (green/red) using jsdiff
@@ -355,6 +355,17 @@ npm run mcp                # Start MCP server (stdio transport)
 - Accessible: `role="dialog"`, `aria-label`, focus management (auto-focus input on open)
 - Resets state (query, results, active index) on each open
 
+### Stash Viewer TOC (src/components/StashViewer.tsx)
+
+- **Table of Contents** for stashes with 2+ markdown files: collapsible panel above file list in the Content tab
+- TOC shown only when `renderPreview` is on and stash has multiple markdown files
+- **File-level entries**: Click to smooth-scroll to the file container (uses `id="stash-file-{index}"` on `.viewer-file` divs)
+- **Heading entries**: Extracts h1–h3 headings from rendered markdown HTML via `extractHeadings()` (DOMParser-based)
+- **Cross-file heading disambiguation**: `renderMarkdown(content, idPrefix)` prepends `f{index}-` prefix to heading IDs when TOC is active, preventing collisions across files
+- Heading extraction runs inside the `renderedContent` useMemo alongside markdown rendering (single DOMParser pass per file, cached)
+- Collapsible via chevron toggle (`tocExpanded` state, default expanded)
+- Accessible: `<nav aria-label="Table of contents">`, semantic anchor links with `href`
+
 ### Stash Editor (src/components/editor/)
 
 - Split into focused sub-components: `StashEditor.tsx` (main form), `FileCodeEditor.tsx`, `TagCombobox.tsx`, `MetadataEditor.tsx`
@@ -530,7 +541,7 @@ Refactoring does NOT happen automatically. Only upon explicit user request, when
 
 - **`src/server/db.ts` (~610 lines)**: Largest file. Token/session management methods could be extracted into a separate `TokenStore` or `AuthStore` class. The `detectLanguage()` function could move to a shared utility.
 - **`src/server/openapi.ts` (~560 lines)**: Large schema definition. Could adopt `@asteasolutions/zod-to-openapi` to generate from Zod schemas in `tool-defs.ts` (currently only MCP spec uses zodToJsonSchema; OpenAPI schemas are still hand-written).
-- **`src/components/StashViewer.tsx` (~471 lines)**: Largest frontend component. File display, access log tab, and metadata display sections could be extracted into sub-components.
+- **`src/components/StashViewer.tsx` (~650 lines)**: Largest frontend component. File display, TOC, access log tab, and metadata display sections could be extracted into sub-components.
 - **`src/components/Settings.tsx` (~444 lines)**: Could extract Welcome Dashboard and Storage Stats sections into dedicated sub-components within a `settings/` directory.
 - **`src/languages.ts` (~334 lines)**: Extension map (65+ entries) and content-based detection heuristics are large but stable. Low priority.
 - **No linter or test framework**: Adding ESLint + Vitest would significantly improve code quality assurance.

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -96,11 +96,13 @@ const mdParser = new Marked({
     },
     // Open external links in a new tab; keep anchor links in-page
     link({ href, title, text }) {
-      const safeHref = escapeAttr(href);
       const titleAttr = title ? ` title="${escapeAttr(title)}"` : '';
       if (href.startsWith('#')) {
-        return `<a href="${safeHref}"${titleAttr}>${text}</a>`;
+        // Prepend current heading prefix so anchors match prefixed heading IDs
+        const resolvedHref = headingIdPrefix ? `#${headingIdPrefix}${href.slice(1)}` : href;
+        return `<a href="${escapeAttr(resolvedHref)}"${titleAttr}>${text}</a>`;
       }
+      const safeHref = escapeAttr(href);
       return `<a href="${safeHref}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
     },
   },

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -75,6 +75,8 @@ function slugify(text: string): string {
 
 // Track slug occurrences per render pass to disambiguate duplicate headings
 let slugCounts: Map<string, number> = new Map();
+// Prefix prepended to heading IDs for cross-file disambiguation (set before each render)
+let headingIdPrefix = '';
 
 // Dedicated Marked instance — no global mutation
 const mdParser = new Marked({
@@ -87,8 +89,9 @@ const mdParser = new Marked({
       const count = slugCounts.get(slug) || 0;
       slugCounts.set(slug, count + 1);
       if (count > 0) slug = `${slug}-${count}`;
+      const finalSlug = headingIdPrefix + slug;
       const rendered = this.parser.parseInline(tokens);
-      const safeSlug = escapeAttr(slug);
+      const safeSlug = escapeAttr(finalSlug);
       return `<h${depth} id="${safeSlug}"><a class="heading-anchor" href="#${safeSlug}" aria-hidden="true">#</a>${rendered}</h${depth}>\n`;
     },
     // Open external links in a new tab; keep anchor links in-page
@@ -122,11 +125,43 @@ function sanitizeHtml(html: string): string {
 /**
  * Render markdown content to sanitized HTML.
  * Slug counter is reset per call so each file gets independent heading IDs.
+ * Optional idPrefix disambiguates heading IDs across multiple files.
  */
-function renderMarkdown(content: string): string {
+function renderMarkdown(content: string, idPrefix = ''): string {
   slugCounts = new Map();
+  headingIdPrefix = idPrefix;
   const raw = mdParser.parse(content, { async: false }) as string;
   return sanitizeHtml(raw);
+}
+
+interface TocHeading {
+  id: string;
+  text: string;
+  depth: number;
+}
+
+interface TocEntry {
+  fileIndex: number;
+  filename: string;
+  headings: TocHeading[];
+}
+
+/**
+ * Extract h1–h3 headings from rendered markdown HTML for TOC generation.
+ */
+function extractHeadings(html: string): TocHeading[] {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const headings: TocHeading[] = [];
+  doc.querySelectorAll('h1, h2, h3').forEach(el => {
+    // Remove the anchor element so its "#" doesn't appear in the text
+    const anchor = el.querySelector('.heading-anchor');
+    if (anchor) anchor.remove();
+    const text = el.textContent?.trim() || '';
+    if (el.id && text) {
+      headings.push({ id: el.id, text, depth: parseInt(el.tagName[1]) });
+    }
+  });
+  return headings;
 }
 
 /**
@@ -160,6 +195,7 @@ export default function StashViewer({ stash, onEdit, onDelete, onArchive, onBack
   const [accessLog, setAccessLog] = useState<AccessLogEntry[]>([]);
   const [logLoading, setLogLoading] = useState(false);
   const [renderPreview, setRenderPreview] = useState(getRenderPreference);
+  const [tocExpanded, setTocExpanded] = useState(true);
   const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copyAllClipboard = useClipboard();
   const fileClipboard = useClipboardWithKey();
@@ -171,18 +207,35 @@ export default function StashViewer({ stash, onEdit, onDelete, onArchive, onBack
     [stash.files]
   );
 
-  // Memoize rendered markdown/HTML output to avoid re-parsing on every render
-  const renderedContent = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const file of stash.files) {
+  // Memoize rendered markdown/HTML output and TOC entries
+  const { renderedContent, tocEntries } = useMemo(() => {
+    const contentMap = new Map<string, string>();
+    const mdFileIndices: number[] = [];
+    stash.files.forEach((f, i) => {
+      if (resolvedLanguages.get(f.id) === 'markdown') mdFileIndices.push(i);
+    });
+    const needsToc = mdFileIndices.length >= 2;
+    const entries: TocEntry[] = [];
+
+    for (let i = 0; i < stash.files.length; i++) {
+      const file = stash.files[i];
       const lang = resolvedLanguages.get(file.id);
       if (lang === 'markdown') {
-        map.set(file.id, renderMarkdown(file.content));
+        const prefix = needsToc ? `f${i}-` : '';
+        const html = renderMarkdown(file.content, prefix);
+        contentMap.set(file.id, html);
+        if (needsToc) {
+          entries.push({
+            fileIndex: i,
+            filename: file.filename,
+            headings: extractHeadings(html),
+          });
+        }
       } else if (lang === 'markup') {
-        map.set(file.id, buildHtmlPreview(file.content));
+        contentMap.set(file.id, buildHtmlPreview(file.content));
       }
     }
-    return map;
+    return { renderedContent: contentMap, tocEntries: entries };
   }, [stash.files, resolvedLanguages]);
 
   const toggleRenderPreview = useCallback(() => {
@@ -191,6 +244,12 @@ export default function StashViewer({ stash, onEdit, onDelete, onArchive, onBack
       setRenderPreference(next);
       return next;
     });
+  }, []);
+
+  const scrollToId = useCallback((e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+    e.preventDefault();
+    const el = document.getElementById(id);
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, []);
 
   useEffect(() => {
@@ -368,16 +427,62 @@ export default function StashViewer({ stash, onEdit, onDelete, onArchive, onBack
         </button>
       </div>
 
+      {activeTab === 'content' && tocEntries.length > 0 && renderPreview && (
+        <div className="viewer-toc">
+          <button className="viewer-toc-toggle" onClick={() => setTocExpanded(!tocExpanded)}>
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M2 4a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm3.75-1.5a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5Zm0 5a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5Zm0 5a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5ZM3 8a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm-1 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" />
+            </svg>
+            Table of Contents
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" className={`toc-chevron ${tocExpanded ? 'expanded' : ''}`}>
+              <path d="M6.22 3.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L9.94 8 6.22 4.28a.75.75 0 0 1 0-1.06Z" />
+            </svg>
+          </button>
+          {tocExpanded && (
+            <nav className="viewer-toc-nav" aria-label="Table of contents">
+              {tocEntries.map((entry) => (
+                <div key={entry.fileIndex} className="toc-file-group">
+                  <a
+                    className="toc-file-link"
+                    href={`#stash-file-${entry.fileIndex}`}
+                    onClick={(e) => scrollToId(e, `stash-file-${entry.fileIndex}`)}
+                  >
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+                      <path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z" />
+                    </svg>
+                    {entry.filename}
+                  </a>
+                  {entry.headings.length > 0 && (
+                    <ul className="toc-headings">
+                      {entry.headings.map((h, hi) => (
+                        <li key={hi} className={`toc-heading toc-h${h.depth}`}>
+                          <a
+                            href={`#${h.id}`}
+                            onClick={(e) => scrollToId(e, h.id)}
+                          >
+                            {h.text}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              ))}
+            </nav>
+          )}
+        </div>
+      )}
+
       {activeTab === 'content' && (
         <div className="viewer-files">
-          {stash.files.map((file) => {
+          {stash.files.map((file, fileIndex) => {
             const lang = resolvedLanguages.get(file.id) || 'text';
             const renderable = isRenderableLanguage(lang);
             const showRendered = renderable && renderPreview;
             const langLabel = file.language || (lang !== 'text' ? `auto:${getLanguageDisplayName(lang)}` : '');
 
             return (
-              <div key={file.id} className="viewer-file">
+              <div key={file.id} id={`stash-file-${fileIndex}`} className="viewer-file">
                 <div className="file-header">
                   <span className="file-name" title={file.filename}>{file.filename}</span>
                   <div className="file-actions">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1376,6 +1376,94 @@ body {
   border-bottom-color: var(--accent-green);
 }
 
+/* === Table of Contents (multi-markdown stashes) === */
+.viewer-toc {
+  margin-bottom: 20px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.viewer-toc-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 16px;
+  background: var(--bg-secondary);
+  border: none;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.viewer-toc-toggle:hover {
+  background: var(--bg-tertiary);
+}
+
+.toc-chevron {
+  margin-left: auto;
+  transition: transform 0.2s;
+}
+
+.toc-chevron.expanded {
+  transform: rotate(90deg);
+}
+
+.viewer-toc-nav {
+  padding: 8px 16px 12px;
+  background: var(--bg-primary);
+  border-top: 1px solid var(--border-color);
+}
+
+.toc-file-group {
+  margin-bottom: 4px;
+}
+
+.toc-file-group:last-child {
+  margin-bottom: 0;
+}
+
+.toc-file-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.toc-file-link:hover {
+  color: var(--accent-blue);
+}
+
+.toc-headings {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 4px 0;
+}
+
+.toc-heading a {
+  display: block;
+  padding: 2px 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  text-decoration: none;
+  line-height: 1.5;
+}
+
+.toc-heading a:hover {
+  color: var(--accent-blue);
+}
+
+.toc-h1 { padding-left: 18px; }
+.toc-h2 { padding-left: 30px; }
+.toc-h3 { padding-left: 42px; }
+
 /* === Viewer Files === */
 .viewer-files {
   display: flex;
@@ -1387,6 +1475,7 @@ body {
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
   overflow: hidden;
+  scroll-margin-top: 16px;
 }
 
 .file-header {


### PR DESCRIPTION
## Summary

Adds a collapsible Table of Contents (TOC) panel to the Stash Viewer when displaying stashes with 2+ markdown files. The TOC extracts h1–h3 headings from rendered markdown and provides quick navigation via smooth-scrolling links. Heading IDs are automatically disambiguated across files using a prefix scheme to prevent collisions.

## Changes

- **Heading ID disambiguation**: Modified `renderMarkdown()` to accept an optional `idPrefix` parameter. When multiple markdown files are present, each file's headings are prefixed with `f{index}-` to ensure unique IDs across the stash.
- **Heading extraction**: Added `extractHeadings()` function that parses rendered HTML via DOMParser to extract h1–h3 headings with their IDs and text content.
- **TOC data structures**: Introduced `TocHeading` and `TocEntry` interfaces to organize extracted headings by file.
- **TOC rendering**: Added collapsible TOC panel above the file list in the Content tab, visible only when `renderPreview` is enabled and the stash contains 2+ markdown files.
- **Navigation**: Implemented `scrollToId()` callback for smooth-scrolling to file containers and heading anchors.
- **State management**: Added `tocExpanded` state to control TOC visibility; TOC is expanded by default.
- **Styling**: Added comprehensive CSS for the TOC panel, including toggle button, file groups, heading hierarchy indentation, and chevron animation.
- **Accessibility**: TOC nav uses semantic `<nav aria-label="Table of contents">` and anchor links with proper `href` attributes.
- **Documentation**: Updated CLAUDE.md to document the TOC feature and reflect the increased size of StashViewer.tsx.

## Testing

- Verified heading ID prefixing prevents collisions when rendering multiple markdown files
- Confirmed TOC appears only when `renderPreview` is true and stash has 2+ markdown files
- Tested smooth-scrolling navigation to both file containers and individual headings
- Validated TOC collapse/expand toggle functionality
- Confirmed heading extraction correctly filters h1–h3 and removes anchor elements from text content
- Verified styling and responsive layout of TOC panel

## Checklist

- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [x] Changes are documented (CLAUDE.md updated)

https://claude.ai/code/session_01ER6nRd2kJDANvEcYBHfpyH