### PR TITLE
chore(deps): bump Docker GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -72,10 +72,10 @@ jobs:
             type=sha
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile


### PR DESCRIPTION
## Summary

- Bump `docker/login-action` v3 → v4 (#53)
- Bump `docker/metadata-action` v5 → v6 (#54)
- Bump `docker/setup-buildx-action` v3 → v4 (#55)
- Bump `docker/build-push-action` v6 → v7 (#56)

All four updates are Node 24 runtime upgrades with no functional changes. Combined into a single PR to reduce noise from individual Dependabot PRs.

Supersedes #53, #54, #55, #56.

## Test plan

- [ ] CI workflow passes (type-check, build, Docker push)
- [ ] No functional changes — version bumps only

🤖 Generated with [Claude Code](https://claude.com/claude-code)