### PR TITLE
GitNexus Code Review Round 1/3: obvious bugs & low-hanging fruit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -286,11 +286,11 @@ export default function App() {
     }
   };
 
-  const handleGraphFilterTag = useCallback((tag: string) => {
+  const handleGraphFilterTag = (tag: string) => {
     handleFilterTag(tag);
     setView('home');
     pushUrl('/');
-  }, []);
+  };
 
   const handleGraphView = () => {
     setSelectedStash(null);

--- a/src/app/api/_helpers.ts
+++ b/src/app/api/_helpers.ts
@@ -58,10 +58,15 @@ export async function parseJsonBody(req: NextRequest): Promise<{ data: unknown }
 
 /**
  * Extract IP and user agent from request headers for access logging.
+ * x-forwarded-for may contain a comma-separated chain; only the first
+ * entry (the original client) is recorded to match middleware behavior
+ * and avoid leaking spoofed downstream values into logs.
  */
 export function getRequestInfo(req: NextRequest): { ip: string | undefined; userAgent: string | undefined } {
+  const xff = req.headers.get('x-forwarded-for');
+  const ip = xff ? xff.split(',')[0].trim() || undefined : undefined;
   return {
-    ip: req.headers.get('x-forwarded-for') || undefined,
+    ip,
     userAgent: req.headers.get('user-agent') || undefined,
   };
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,7 +9,7 @@ interface BuildInfo {
 function formatBuildVersion(isoDate: string): string {
   const d = new Date(isoDate);
   const pad = (n: number) => String(n).padStart(2, '0');
-  return `v${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}-${pad(d.getHours())}${pad(d.getMinutes())}`;
+  return `v${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}-${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}`;
 }
 
 export default function Footer() {

--- a/src/server/version.ts
+++ b/src/server/version.ts
@@ -142,8 +142,12 @@ export async function checkVersion(): Promise<VersionInfo> {
   const now = Date.now();
 
   if (!cache || now > cacheExpiry) {
-    cache = await fetchLatestCommit();
-    cacheExpiry = now + CACHE_TTL_MS;
+    const fresh = await fetchLatestCommit();
+    cache = fresh;
+    // Only cache successful fetches for the full TTL; retry failures sooner.
+    cacheExpiry = fresh.commit_sha !== null
+      ? now + CACHE_TTL_MS
+      : now + 60 * 1000;
   }
 
   const updateAvailable = cache.commit_sha !== null


### PR DESCRIPTION
Closes #88
Part of #87

## Focus
Round 1/3 of the GitNexus-based review — obvious bugs, broken logic, inconsistencies.

## Approach
1. GitNexus re-indexed (`npx gitnexus analyze` — already up to date)
2. Architecture overview: 7 modules, 935 symbols, 76 execution flows
3. Hotspots from `git log` (CLAUDE.md, db.ts, StashViewer.tsx, route handlers, mcp-server.ts)
4. Cluster-by-cluster review of the server/components/editor clusters
5. Impact analysis via `gitnexus_impact` before every change — all d=1 callers checked
6. Build + typecheck green after every commit
7. `gitnexus_detect_changes` for verification: 4 changed symbols, 0 affected processes, risk LOW

## Findings by severity

| Sev | Description | Fix |
|-----|-------------|-----|
| P1  | `fetchLatestCommit` cached failed GitHub fetches for 1h, all update checks dead after a single network blip | `version.ts` — failure cache TTL 60s, success stays at 1h |
| P1  | `Footer.formatBuildVersion` uses local time, server uses UTC → users in CET see a different build date than logs | `Footer.tsx` — switch to UTC |
| P1  | `getRequestInfo` logged the full XFF header including proxy chain & spoofable downstream values; inconsistent with middleware | `_helpers.ts` — split & take first IP |
| P2  | `handleGraphFilterTag` `useCallback([])` captured a stale `handleFilterTag` whose closure was frozen on `filterTag === ''` → toggle from Graph view never works | `App.tsx` — useCallback removed |

## Open P3 (for Round 2/3)

- `archived` JSON roundtrip could come in as a string (`"false"` truthy)
- Middleware fallback IP `'unknown'` shares the rate-limit bucket
- FTS queries >2000 characters silently return `[]`
- `db.ts.detectLanguage` duplicates `languages.ts` mapping
- `StashViewer` module-level mutable `slugCounts` / `headingIdPrefix` (fragile, currently race-free)
- `updateStash.changeSummary` semantically inverted (snapshot describes next change, not own change)

## Test evidence

- `npx tsc --noEmit` → green (no output)
- `npm run build` → green, all 23 routes built
- `gitnexus_detect_changes` → 4 changed symbols, 0 affected processes, risk LOW

## GitNexus impact summary

| Symbol | Risk | Direct callers |
|--------|------|----------------|
| `fetchLatestCommit` | LOW | 1 (`checkVersion`) |
| `formatBuildVersion` (Footer) | LOW | 1 (`Footer`) |
| `getRequestInfo` | CRITICAL | 5 route handlers — but signature unchanged, only return value normalized |
| `handleGraphFilterTag` | n/a (inline closure) | only `<GraphViewer onFilterTag>` prop |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> _Translated from German on 2026-04-26._
