### PR TITLE
GitNexus Code Review Round 2/3: subtle issues & regressions

### DIFF
--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -17,10 +17,15 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  // Each search bumps this; only the latest search may write results.
+  // Prevents an in-flight request from a previous query (or a previous
+  // open of the overlay) from overwriting newer results.
+  const searchGenRef = useRef(0);
 
   // Focus input when opened, reset state
   useEffect(() => {
     if (open) {
+      searchGenRef.current++;
       setQuery('');
       setResults([]);
       setActiveIndex(0);
@@ -37,15 +42,18 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
       setLoading(false);
       return;
     }
+    const gen = ++searchGenRef.current;
     setLoading(true);
     try {
       const res = await api.listStashes({ search: q, limit: 12 });
+      if (gen !== searchGenRef.current) return;
       setResults(res.stashes);
       setActiveIndex(0);
     } catch {
+      if (gen !== searchGenRef.current) return;
       setResults([]);
     } finally {
-      setLoading(false);
+      if (gen === searchGenRef.current) setLoading(false);
     }
   }, []);
 

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -543,13 +543,33 @@ export class ClawStashDB {
     console.log(`[DB] ${pending.length} migration(s) applied successfully`);
   }
 
+  private safeParseTags(raw: unknown): string[] {
+    if (typeof raw !== 'string') return [];
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed.filter(t => typeof t === 'string') : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private safeParseMetadata(raw: unknown): Record<string, unknown> {
+    if (typeof raw !== 'string') return {};
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
   private rowToStash(row: Record<string, unknown>): Omit<Stash, 'files'> {
     return {
       id: row.id as string,
       name: (row.name as string) || '',
       description: (row.description as string) || '',
-      tags: JSON.parse(row.tags as string),
-      metadata: JSON.parse(row.metadata as string),
+      tags: this.safeParseTags(row.tags),
+      metadata: this.safeParseMetadata(row.metadata),
       version: (row.version as number) || 1,
       archived: (row.archived as number) === 1,
       created_at: row.created_at as string,
@@ -562,7 +582,7 @@ export class ClawStashDB {
       id: row.id as string,
       name: (row.name as string) || '',
       description: (row.description as string) || '',
-      tags: JSON.parse(row.tags as string),
+      tags: this.safeParseTags(row.tags),
       version: (row.version as number) || 1,
       archived: (row.archived as number) === 1,
       created_at: row.created_at as string,
@@ -1669,8 +1689,11 @@ export class ClawStashDB {
       `);
 
       // Insert stashes
+      // Coerce archived strictly: only true/1 mean archived. Strings like
+      // "false" / "0" must NOT be treated as truthy (they are by `?:`).
       for (const s of data.stashes) {
-        insertStash.run(s.id, s.name, s.description, s.tags, s.metadata, s.version ?? 1, s.archived ? 1 : 0, s.created_at, s.updated_at);
+        const archivedFlag = s.archived === true || s.archived === 1 ? 1 : 0;
+        insertStash.run(s.id, s.name, s.description, s.tags, s.metadata, s.version ?? 1, archivedFlag, s.created_at, s.updated_at);
         stashCount++;
       }
 

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -109,14 +109,19 @@ ${TOKEN_EFFICIENT_GUIDE}`,
     }
   );
 
-  // List stashes with optional filtering
+  // List stashes with optional filtering.
+  // When a search query is given, route to FTS5 ranked search to match REST
+  // /api/stashes behavior — otherwise MCP clients silently get a slower,
+  // unranked LIKE scan with different result ordering than the REST endpoint.
   const listDef = getToolDef('list_stashes');
   server.tool(
     listDef.name,
     listDef.description,
     listDef.schema.shape,
     async ({ search, tag, archived, page, limit }) => {
-      const result = db.listStashes({ search, tag, archived, page, limit });
+      const result = search
+        ? db.searchStashes(search, { tag, archived, page, limit })
+        : db.listStashes({ tag, archived, page, limit });
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };


### PR DESCRIPTION
Closes #90
Part of #87
Follow-up to #89

## Focus
Deeper logic errors, race conditions, fragile parsing paths, inconsistencies between REST and MCP. No regressions from Round 1.

## Approach
1. GitNexus re-indexed (2018 nodes, 3498 edges, 171 flows)
2. Deeper reads: db.ts (versions, archive, FTS, import), mcp-server.ts, validation.ts, SearchOverlay, VersionHistory
3. Cypher schema exploration for anti-patterns
4. Impact analysis before each fix — `rowToStash` identified as CRITICAL (8 affected processes), but only an internal-defensive change without signature break
5. Build + tsc green after every commit

## Findings

| Sev | Description | Fix |
|-----|-------------|-----|
| P1  | `rowToStash` / `rowToListItem`: `JSON.parse` directly on tags/metadata → 1 corrupt row crashes the entire read path with an opaque 500 | `db.ts` — `safeParseTags` / `safeParseMetadata` with fallback `[]` / `{}` |
| P1  | `importAllData`: `s.archived ? 1 : 0` → JSON roundtrip with `"false"` is truthy → ALL stashes archived after import | `db.ts` — strict check `=== true \|\| === 1` |
| P2  | MCP `list_stashes(search="...")` uses slow LIKE scan, REST `/api/stashes?search=...` uses FTS5 — same tool description, different behavior | `mcp-server.ts` — routing identical to REST |
| P2  | `SearchOverlay` race: pending fetch could overwrite results after re-open | `SearchOverlay.tsx` — generation counter |

## Open P3 (for Round 3)

- `updateStashRelations` loads all other stashes per update (N² scaling)
- `tokens/validate` POST returns `valid: false` for admin sessions (csa_*) — is this intentional? Docs unclear
- `db.ts.detectLanguage` duplicates `languages.ts` mapping
- Middleware fallback IP `'unknown'` shares the rate-limit bucket
- `StashViewer` module-level mutable `slugCounts` / `headingIdPrefix` — fragile, currently race-free
- `updateStash.changeSummary` inverted semantics (V_n stores next-change instead of own-change) — UI does not use the field yet, so currently invisible

## Test evidence
- `npx tsc --noEmit` → green
- `npm run build` → green, all routes built
- `gitnexus_detect_changes` → 13 changed symbols, 12 affected processes — all "touched", none "broken". The high risk level reflects reach, not breakage.

## GitNexus impact highlights

| Symbol | Risk | Notes |
|--------|------|-------|
| `rowToStash` | CRITICAL | 8 processes — internal defensive, return shape unchanged |
| `importAllData` | LOW | only `/admin/import` POST affected |
| MCP `list_stashes` | n/a | additive fields (`query`, `relevance`, `snippets`) — backward compatible |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> _Translated from German on 2026-04-26._
