### PR TITLE
GitNexus Code Review Round 3/3: polish & cleanup

### DIFF
--- a/src/app/api/_helpers.ts
+++ b/src/app/api/_helpers.ts
@@ -60,11 +60,15 @@ export async function parseJsonBody(req: NextRequest): Promise<{ data: unknown }
  * Extract IP and user agent from request headers for access logging.
  * x-forwarded-for may contain a comma-separated chain; only the first
  * entry (the original client) is recorded to match middleware behavior
- * and avoid leaking spoofed downstream values into logs.
+ * and avoid leaking spoofed downstream values into logs. Falls back to
+ * x-real-ip when XFF is absent (nginx, traefik) so proxies that only
+ * forward one or the other still produce useful logs.
  */
 export function getRequestInfo(req: NextRequest): { ip: string | undefined; userAgent: string | undefined } {
   const xff = req.headers.get('x-forwarded-for');
-  const ip = xff ? xff.split(',')[0].trim() || undefined : undefined;
+  const ip = (xff ? xff.split(',')[0].trim() : '')
+    || req.headers.get('x-real-ip')?.trim()
+    || undefined;
   return {
     ip,
     userAgent: req.headers.get('user-agent') || undefined,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -73,7 +73,12 @@ export function middleware(req: NextRequest) {
 
   // Rate limit login endpoint
   if (pathname === '/api/admin/auth' && req.method === 'POST') {
-    const ip = req.headers.get('x-forwarded-for')?.split(',')[0].trim() || 'unknown';
+    // Prefer x-forwarded-for (set by most proxies). Fall back to x-real-ip
+    // (nginx, traefik) before the shared "unknown" bucket — proxies that
+    // strip XFF but set x-real-ip would otherwise lump every client together.
+    const ip = req.headers.get('x-forwarded-for')?.split(',')[0].trim()
+      || req.headers.get('x-real-ip')?.trim()
+      || 'unknown';
     const { allowed, retryAfter } = checkLoginRateLimit(ip);
     if (!allowed) {
       return NextResponse.json(

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import crypto from 'crypto';
 import path from 'path';
 import fs from 'fs';
+import { detectLanguage } from './detect-language';
 
 export interface StashFile {
   id: string;
@@ -1731,71 +1732,6 @@ export class ClawStashDB {
   close() {
     this.db.close();
   }
-}
-
-function detectLanguage(filename: string): string {
-  const ext = path.extname(filename).toLowerCase();
-  const map: Record<string, string> = {
-    '.js': 'javascript',
-    '.jsx': 'javascript',
-    '.ts': 'typescript',
-    '.tsx': 'typescript',
-    '.py': 'python',
-    '.rb': 'ruby',
-    '.go': 'go',
-    '.rs': 'rust',
-    '.java': 'java',
-    '.kt': 'kotlin',
-    '.cs': 'csharp',
-    '.cpp': 'cpp',
-    '.c': 'c',
-    '.h': 'c',
-    '.hpp': 'cpp',
-    '.php': 'php',
-    '.swift': 'swift',
-    '.sh': 'bash',
-    '.bash': 'bash',
-    '.zsh': 'bash',
-    '.fish': 'bash',
-    '.ps1': 'powershell',
-    '.sql': 'sql',
-    '.html': 'html',
-    '.htm': 'html',
-    '.css': 'css',
-    '.scss': 'scss',
-    '.sass': 'sass',
-    '.less': 'less',
-    '.json': 'json',
-    '.yaml': 'yaml',
-    '.yml': 'yaml',
-    '.xml': 'xml',
-    '.md': 'markdown',
-    '.markdown': 'markdown',
-    '.txt': 'text',
-    '.toml': 'toml',
-    '.ini': 'ini',
-    '.cfg': 'ini',
-    '.conf': 'ini',
-    '.env': 'bash',
-    '.dockerfile': 'docker',
-    '.lua': 'lua',
-    '.r': 'r',
-    '.dart': 'dart',
-    '.scala': 'scala',
-    '.zig': 'zig',
-    '.v': 'v',
-    '.nim': 'nim',
-    '.ex': 'elixir',
-    '.exs': 'elixir',
-    '.erl': 'erlang',
-    '.hs': 'haskell',
-    '.ml': 'ocaml',
-    '.clj': 'clojure',
-    '.lisp': 'lisp',
-    '.vue': 'markup',
-    '.svelte': 'markup',
-  };
-  return map[ext] || '';
 }
 
 export default ClawStashDB;

--- a/src/server/detect-language.ts
+++ b/src/server/detect-language.ts
@@ -1,0 +1,75 @@
+/**
+ * Server-side filename → language tag detection used when persisting files.
+ *
+ * Note: this is intentionally separate from `src/languages.ts`, which maps
+ * to PrismJS grammar keys for the frontend syntax highlighter. The values
+ * stored here are user-facing language labels (e.g. "javascript", not "js")
+ * that the frontend later normalizes via `resolvePrismLanguage`.
+ */
+import path from 'path';
+
+const EXTENSION_MAP: Record<string, string> = {
+  '.js': 'javascript',
+  '.jsx': 'javascript',
+  '.ts': 'typescript',
+  '.tsx': 'typescript',
+  '.py': 'python',
+  '.rb': 'ruby',
+  '.go': 'go',
+  '.rs': 'rust',
+  '.java': 'java',
+  '.kt': 'kotlin',
+  '.cs': 'csharp',
+  '.cpp': 'cpp',
+  '.c': 'c',
+  '.h': 'c',
+  '.hpp': 'cpp',
+  '.php': 'php',
+  '.swift': 'swift',
+  '.sh': 'bash',
+  '.bash': 'bash',
+  '.zsh': 'bash',
+  '.fish': 'bash',
+  '.ps1': 'powershell',
+  '.sql': 'sql',
+  '.html': 'html',
+  '.htm': 'html',
+  '.css': 'css',
+  '.scss': 'scss',
+  '.sass': 'sass',
+  '.less': 'less',
+  '.json': 'json',
+  '.yaml': 'yaml',
+  '.yml': 'yaml',
+  '.xml': 'xml',
+  '.md': 'markdown',
+  '.markdown': 'markdown',
+  '.txt': 'text',
+  '.toml': 'toml',
+  '.ini': 'ini',
+  '.cfg': 'ini',
+  '.conf': 'ini',
+  '.env': 'bash',
+  '.dockerfile': 'docker',
+  '.lua': 'lua',
+  '.r': 'r',
+  '.dart': 'dart',
+  '.scala': 'scala',
+  '.zig': 'zig',
+  '.v': 'v',
+  '.nim': 'nim',
+  '.ex': 'elixir',
+  '.exs': 'elixir',
+  '.erl': 'erlang',
+  '.hs': 'haskell',
+  '.ml': 'ocaml',
+  '.clj': 'clojure',
+  '.lisp': 'lisp',
+  '.vue': 'markup',
+  '.svelte': 'markup',
+};
+
+export function detectLanguage(filename: string): string {
+  const ext = path.extname(filename).toLowerCase();
+  return EXTENSION_MAP[ext] || '';
+}


### PR DESCRIPTION
Closes #92
Part of #87
Follow-up rounds: #89, #91

## Focus
Polish pass — work down remaining P3 findings from Rounds 1+2, light cleanups, no new features.

## Approach
1. GitNexus re-indexed
2. Prioritized P3 backlog from Rounds 1+2
3. Quick scan for last smells
4. Impact + detect_changes
5. Build + tsc green

## Findings & fixes

| Sev | Description | Fix |
|-----|-------------|-----|
| P3  | `detectLanguage` (60-line extension map) lived at the end of `db.ts` (1780 lines) — flagged as a refactor candidate by CLAUDE.md | `db.ts` → new `src/server/detect-language.ts` (pure move, documents separation from `languages.ts`) |
| P3  | Middleware fallback to `'unknown'` bucket on missing XFF → all clients behind XFF-stripping proxies share a single rate-limit bucket | `middleware.ts` + `_helpers.ts` — `x-real-ip` as an intermediate step before 'unknown'/undefined |

## Reasoned deferrals (intentionally not in this round)

- **`updateStash.changeSummary` inverted semantics**: Field is not displayed in the UI yet → no user-visible bug. Refactor as soon as the UI wants to use the field.
- **`StashViewer` module-level mutable `slugCounts` / `headingIdPrefix`**: Currently race-free (sync render in single-threaded JS). A cleaner refactor requires a per-call Marked instance or hooks → larger intervention, separate issue recommended.
- **`updateStashRelations` loads all other stashes (N²)**: Performance issue, not a correctness bug. Optimization via tag index requires schema migration.
- **`tokens/validate` returns false for admin sessions (csa_*)**: Behavior consistent with the tool name ("validate **API token**"). A doc update is more appropriate than a code change.
- **`db.ts.detectLanguage` vs. `languages.ts` mapping**: Different vocabularies (storage vs. PrismJS keys). Merging would change stored data → migration risk. Separation documented in the new module.
- **`buildFtsQuery` >2000 characters silently empty**: Edge case, no real use case. Would only add a `console.warn`.

## Test evidence
- `npx tsc --noEmit` → green
- `npm run build` → green
- `gitnexus_detect_changes` → 4 changed symbols, **0 affected processes**, risk LOW

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> _Translated from German on 2026-04-26._
