### PR TITLE
docs: translate all German content to English (issues, PRs, comments) #102

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **clawstash** (2098 symbols, 3671 relationships, 180 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **clawstash** (2100 symbols, 3674 relationships, 180 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -602,7 +602,7 @@ If `CLAUDE.md` exceeds ~40,000 characters: extract the largest section into `age
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **clawstash** (2098 symbols, 3671 relationships, 180 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **clawstash** (2100 symbols, 3674 relationships, 180 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 


### PR DESCRIPTION
## Summary

Metadata-only sweep — translates all German content in this public repo's GitHub artifacts (issues, PRs, comments) into clear technical English. No source code changes (the trivial diff in this branch is a GitNexus index stat refresh).

Closes #102

## What was done

| Category | Scanned | Translated | Skipped (English) | Skipped (bot) |
|----------|---------|------------|-------------------|---------------|
| Issues | 15 | 7 | 8 | 0 |
| PRs | 80 | 3 | 77 | 0 |
| Issue comments | 73 | 9 | 27 | 37 |
| PR review comments | 6 | 0 | 0 | 6 |
| Labels | 27 | 0 | 27 | — |
| Milestones | 0 | — | — | — |
| Releases | 0 | — | — | — |

### Translated items
- **Issues (title + body where applicable)**: #62, #87 (body only), #88, #90, #92, #94, #97
- **PRs (title + body)**: #89, #91, #93
- **Issue comments**: 9 (IDs listed in the summary comment on #102)

### Skipped
- All `dependabot[bot]` and `github-advanced-security[bot]` comments — per task constraints
- Items already entirely English (label transitions, `@dependabot recreate`, English-only progress reports)
- Labels — all 27 already English

## Preservation rules followed

- Code blocks, file paths, identifiers, URLs, commit SHAs preserved verbatim
- Markdown structure, headings, lists, tables preserved
- Cross-references (`#NN`, `Closes #NN`), mentions, branch names preserved
- Translated bodies/comments end with `> _Translated from German on 2026-04-26._`
- No issues/PRs closed, reopened, or had labels changed
- No comments deleted

## Verification

- Scanned all issue + PR titles/bodies for German umlauts (`äöüÄÖÜß`) → none found
- Scanned all issue + PR titles/bodies + comments for common German words (`und`, `oder`, `nicht`, `wird`, `werden`, `fehler`, `behoben`, etc.) → none found
- Spot-checked translated items #62, #87, #88, #94, #97, PR #89, PR #91, PR #93, and 9 translated comments — all read naturally in English with footer present

## Test plan

- [x] All translated items have `> _Translated from German on 2026-04-26._` footer
- [x] No German umlauts remain in issues/PRs/comments
- [x] No common German words remain
- [x] Bot comments (37 issue + 6 PR review) correctly skipped
- [x] No issue/PR state changes (no closures, no reopens, no label changes)
- [x] Branch refs and code identifiers preserved verbatim