### PR TITLE
Update workflow to trigger only on manual dispatch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,6 @@
 name: Build and Push Docker image to GHCR
 
 on:
-  push:
-    branches: [main, master]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Remove automatic trigger on push to main and master branches.

## Summary

Brief description of the changes.

## Changes

-

## Testing

How were these changes tested?

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Build succeeds (`npm run build`)
- [ ] Changes are documented (if applicable)
