### PR TITLE
feat(mermaid): zoom, pan, fullscreen for diagram viewer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **clawstash** (2148 symbols, 3843 relationships, 185 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **clawstash** (2153 symbols, 3846 relationships, 186 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **clawstash** (2153 symbols, 3846 relationships, 186 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **clawstash** (2188 symbols, 3895 relationships, 189 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@
 | Code Editor | react-simple-code-editor, PrismJS | 0.14, 1.30 |
 | Markdown Rendering | marked | 17 |
 | Diagram Rendering | mermaid (lazy-loaded) | 11 |
+| Diagram Viewer (zoom/pan) | react-zoom-pan-pinch | 3.7 |
 | Text Diffing | diff (jsdiff) | 8 |
 | Module System | ESM (`"type": "module"`) | — |
 | Containerization | Docker (multi-stage, standalone output) | — |
@@ -314,6 +315,7 @@ npx gitnexus analyze       # Rebuild index (after structural changes or stale in
 - Errors render inline as `.mermaid-error` blocks (red border, message + source echoed) — no app crash
 - Toggle Raw ⇄ Preview reuses the existing `renderPreview` toggle (Mermaid is part of `RENDERABLE_LANGUAGES`)
 - Theme: ClawStash is dark-only today; `mermaid.initialize` is called once with `theme: 'dark'`. Re-render hook is in place (deps include `renderedContent`/`renderPreview`/`activeTab`) so future theme switching can re-init + force re-hydration trivially.
+- **Zoom/pan toolbar** for the standalone `.mmd` viewer (`MermaidDiagram` component): + / − / Fit / 1:1 / Reset / Fullscreen buttons, current zoom % display, mouse-wheel zoom with Ctrl/Cmd modifier, pinch zoom on touch, drag to pan. Keyboard shortcuts (`+` / `-` / `0` / `f` / `Esc`) when the viewer has focus or is fullscreen. Initial render auto-fits to width; persistent zoom per stash file via `localStorage["clawstash_mermaid_zoom_${stash.id}:${filename}"]`. Powered by `react-zoom-pan-pinch`. Inline ` ```mermaid ` blocks in Markdown intentionally stay as static SVGs (separate DOM hydration path; small diagrams in practice).
 
 ### Language Utility (src/languages.ts)
 
@@ -473,7 +475,7 @@ If `CLAUDE.md` exceeds ~40,000 characters: extract the largest section into `age
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **clawstash** (2148 symbols, 3843 relationships, 185 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **clawstash** (2153 symbols, 3846 relationships, 186 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -475,7 +475,7 @@ If `CLAUDE.md` exceeds ~40,000 characters: extract the largest section into `age
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **clawstash** (2153 symbols, 3846 relationships, 186 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **clawstash** (2188 symbols, 3895 relationships, 189 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -4,7 +4,7 @@ Session-spanning project knowledge. **Read at session start, update during work.
 
 ## Architecture Decisions
 
-_(No entries yet)_
+- **Mermaid viewer zoom/pan/fullscreen (#100, 2026-04-26)** — chose `react-zoom-pan-pinch` over `panzoom` (anvaka) and `svg-pan-zoom`: React 19 compatible, native pinch + Ctrl/Cmd-modifier wheel zoom, programmatic API via wrapper ref (`zoomIn`/`zoomOut`/`setTransform`). Enhanced standalone `MermaidDiagram` component only; inline ` ```mermaid ` markdown blocks stay as static SVG (separate DOM hydration path; small diagrams in practice). Persistent zoom via `localStorage["clawstash_mermaid_zoom_${stash.id}:${filename}"]`. Initial render auto-fits to width unless a stored zoom exists.
 
 ## Gotchas & Pitfalls
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.2.5",
         "react-simple-code-editor": "^0.14.1",
+        "react-zoom-pan-pinch": "^3.7.0",
         "tsx": "^4.19.0",
         "uuid": "^14.0.0",
         "zod": "^3.24.0",
@@ -4460,6 +4461,20 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz",
+      "integrity": "sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.2.5",
     "react-simple-code-editor": "^0.14.1",
+    "react-zoom-pan-pinch": "^3.7.0",
     "tsx": "^4.19.0",
     "uuid": "^14.0.0",
     "zod": "^3.24.0",

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -1,29 +1,87 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  TransformComponent,
+  TransformWrapper,
+  type ReactZoomPanPinchContentRef,
+  type ReactZoomPanPinchRef,
+} from 'react-zoom-pan-pinch';
 import { renderMermaid } from '../utils/mermaid';
 
 interface Props {
   code: string;
   className?: string;
+  /**
+   * When provided, the current zoom level is persisted to
+   * `localStorage["clawstash_mermaid_zoom_${storageKey}"]` and restored on
+   * subsequent renders. Omit for transient/preview cases.
+   */
+  storageKey?: string;
 }
 
-interface State {
+interface RenderState {
   loading: boolean;
   svg?: string;
   error?: string;
 }
 
+const STORAGE_PREFIX = 'clawstash_mermaid_zoom_';
+const MIN_SCALE = 0.1;
+const MAX_SCALE = 10;
+const ANIMATION_MS = 200;
+const PERSIST_DEBOUNCE_MS = 300;
+
+function loadStoredScale(key: string | undefined): number | null {
+  if (!key || typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_PREFIX + key);
+    if (!raw) return null;
+    const n = parseFloat(raw);
+    return Number.isFinite(n) && n >= MIN_SCALE && n <= MAX_SCALE ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveScale(key: string, scale: number): void {
+  try {
+    window.localStorage.setItem(STORAGE_PREFIX + key, String(scale));
+  } catch {
+    /* ignore quota / disabled storage */
+  }
+}
+
 /**
- * Renders a Mermaid diagram from a source string.
+ * Renders a Mermaid diagram from a source string with a zoom/pan toolbar,
+ * fullscreen toggle and persistent zoom level (per `storageKey`).
+ *
  * Lazy-loads the `mermaid` library on first use, displays an inline error
  * block on syntax/render failure (no app crash), and re-renders when the
  * `code` prop changes.
+ *
+ * Controls:
+ * - Toolbar: − / zoom% / + / Fit / 1:1 / Reset / Fullscreen
+ * - Mouse wheel zoom (Ctrl/Cmd modifier)
+ * - Pinch zoom on touch
+ * - Drag to pan
+ * - Keyboard (when viewer has focus or is fullscreen):
+ *   `+` / `=` zoom in, `-` zoom out, `0` fit, `f` toggle fullscreen, `Esc` exit fullscreen
  */
-export default function MermaidDiagram({ code, className }: Props) {
-  const [state, setState] = useState<State>({ loading: true });
+export default function MermaidDiagram({ code, className, storageKey }: Props) {
+  const [state, setState] = useState<RenderState>({ loading: true });
+  const [scale, setScale] = useState(1);
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
+  const wrapperRef = useRef<ReactZoomPanPinchContentRef | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const initializedRef = useRef(false);
+
+  // Render mermaid SVG (lazy-loaded). Re-runs on `code` change.
   useEffect(() => {
     let cancelled = false;
     setState({ loading: true });
+    initializedRef.current = false;
     renderMermaid(code).then((result) => {
       if (cancelled) return;
       setState({ loading: false, svg: result.svg, error: result.error });
@@ -33,22 +91,229 @@ export default function MermaidDiagram({ code, className }: Props) {
     };
   }, [code]);
 
+  // Compute "fit-to-width" scale based on container vs. natural SVG width.
+  const computeFitScale = useCallback((): number => {
+    const cont = containerRef.current?.getBoundingClientRect();
+    const svg = contentRef.current?.querySelector('svg');
+    if (!cont || !svg) return 1;
+    const rect = svg.getBoundingClientRect();
+    const viewBoxWidth = svg.viewBox?.baseVal?.width;
+    // Use natural (un-transformed) width: prefer viewBox over current rect
+    // (rect reflects the current transform, viewBox is intrinsic).
+    const w = viewBoxWidth || rect.width || cont.width;
+    if (!w) return 1;
+    const fit = (cont.width - 32) / w; // 32px breathing room on each side
+    return Math.min(MAX_SCALE, Math.max(MIN_SCALE, fit));
+  }, []);
+
+  const fitToWidth = useCallback(() => {
+    const s = computeFitScale();
+    wrapperRef.current?.setTransform(0, 0, s, ANIMATION_MS);
+  }, [computeFitScale]);
+
+  const actualSize = useCallback(() => {
+    wrapperRef.current?.setTransform(0, 0, 1, ANIMATION_MS);
+  }, []);
+
+  // After SVG injection: restore stored zoom or auto fit-to-width.
+  useEffect(() => {
+    if (state.loading || state.error || !state.svg) return;
+    if (initializedRef.current) return;
+    const stored = loadStoredScale(storageKey);
+    // Wait one frame so the SVG has its bounding rect available.
+    const id = requestAnimationFrame(() => {
+      const target = stored ?? computeFitScale();
+      wrapperRef.current?.setTransform(0, 0, target, 0);
+      setScale(target);
+      initializedRef.current = true;
+    });
+    return () => cancelAnimationFrame(id);
+  }, [state, storageKey, computeFitScale]);
+
+  // Cleanup persist timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+    };
+  }, []);
+
+  // Global Escape handler when fullscreen.
+  useEffect(() => {
+    if (!isFullscreen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setIsFullscreen(false);
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isFullscreen]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      switch (e.key) {
+        case '+':
+        case '=':
+          e.preventDefault();
+          wrapperRef.current?.zoomIn();
+          break;
+        case '-':
+          e.preventDefault();
+          wrapperRef.current?.zoomOut();
+          break;
+        case '0':
+          e.preventDefault();
+          fitToWidth();
+          break;
+        case 'f':
+        case 'F':
+          e.preventDefault();
+          setIsFullscreen((v) => !v);
+          break;
+        default:
+          break;
+      }
+    },
+    [fitToWidth],
+  );
+
+  const handleTransformed = useCallback(
+    (_ref: ReactZoomPanPinchRef, s: { scale: number; positionX: number; positionY: number }) => {
+      setScale(s.scale);
+      if (storageKey) {
+        if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+        persistTimerRef.current = setTimeout(() => {
+          saveScale(storageKey, s.scale);
+        }, PERSIST_DEBOUNCE_MS);
+      }
+    },
+    [storageKey],
+  );
+
   if (state.loading) {
     return <div className={`mermaid-loading ${className || ''}`}>Rendering diagram…</div>;
   }
   if (state.error) {
     return (
       <div className={`mermaid-error ${className || ''}`} role="alert">
-        <div className="mermaid-error-title"><strong>Mermaid syntax error</strong></div>
+        <div className="mermaid-error-title">
+          <strong>Mermaid syntax error</strong>
+        </div>
         <div className="mermaid-error-message">{state.error}</div>
         <pre className="mermaid-error-source">{code}</pre>
       </div>
     );
   }
-  return (
+
+  const zoomPct = Math.round(scale * 100);
+
+  const viewer = (
     <div
-      className={`mermaid-diagram ${className || ''}`}
-      dangerouslySetInnerHTML={{ __html: state.svg || '' }}
-    />
+      ref={containerRef}
+      className={`mermaid-viewer${isFullscreen ? ' mermaid-viewer-fullscreen' : ''} ${className || ''}`}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      role="region"
+      aria-label="Mermaid diagram viewer"
+    >
+      <div className="mermaid-toolbar" role="toolbar" aria-label="Diagram zoom controls">
+        <button
+          type="button"
+          className="btn btn-sm btn-ghost"
+          onClick={() => wrapperRef.current?.zoomOut()}
+          title="Zoom out (-)"
+          aria-label="Zoom out"
+        >
+          −
+        </button>
+        <span className="mermaid-zoom-display" aria-live="polite" aria-label={`Zoom ${zoomPct} percent`}>
+          {zoomPct}%
+        </span>
+        <button
+          type="button"
+          className="btn btn-sm btn-ghost"
+          onClick={() => wrapperRef.current?.zoomIn()}
+          title="Zoom in (+)"
+          aria-label="Zoom in"
+        >
+          +
+        </button>
+        <button
+          type="button"
+          className="btn btn-sm btn-ghost"
+          onClick={fitToWidth}
+          title="Fit to width (0)"
+          aria-label="Fit to width"
+        >
+          Fit
+        </button>
+        <button
+          type="button"
+          className="btn btn-sm btn-ghost"
+          onClick={actualSize}
+          title="Actual size (1:1)"
+          aria-label="Actual size"
+        >
+          1:1
+        </button>
+        <button
+          type="button"
+          className="btn btn-sm btn-ghost"
+          onClick={fitToWidth}
+          title="Reset"
+          aria-label="Reset view"
+        >
+          ⟳
+        </button>
+        <button
+          type="button"
+          className="btn btn-sm btn-ghost"
+          onClick={() => setIsFullscreen((v) => !v)}
+          title={isFullscreen ? 'Exit fullscreen (Esc)' : 'Fullscreen (f)'}
+          aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+        >
+          {isFullscreen ? '⤢' : '⛶'}
+        </button>
+      </div>
+      <TransformWrapper
+        ref={wrapperRef}
+        initialScale={1}
+        minScale={MIN_SCALE}
+        maxScale={MAX_SCALE}
+        limitToBounds={false}
+        centerOnInit={false}
+        wheel={{ activationKeys: ['Control', 'Meta'], step: 0.1 }}
+        pinch={{ step: 5 }}
+        panning={{ velocityDisabled: true }}
+        doubleClick={{ disabled: true }}
+        onTransformed={handleTransformed}
+      >
+        <TransformComponent
+          wrapperClass="mermaid-transform-wrapper"
+          contentClass="mermaid-transform-content"
+        >
+          <div
+            ref={contentRef}
+            className="mermaid-diagram"
+            dangerouslySetInnerHTML={{ __html: state.svg || '' }}
+          />
+        </TransformComponent>
+      </TransformWrapper>
+    </div>
   );
+
+  if (isFullscreen) {
+    return (
+      <div
+        className="mermaid-fullscreen-backdrop"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Mermaid diagram fullscreen"
+      >
+        {viewer}
+      </div>
+    );
+  }
+  return viewer;
 }

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -50,6 +50,14 @@ function saveScale(key: string, scale: number): void {
   }
 }
 
+function clearStoredScale(key: string): void {
+  try {
+    window.localStorage.removeItem(STORAGE_PREFIX + key);
+  } catch {
+    /* ignore */
+  }
+}
+
 /**
  * Renders a Mermaid diagram from a source string with a zoom/pan toolbar,
  * fullscreen toggle and persistent zoom level (per `storageKey`).
@@ -115,6 +123,31 @@ export default function MermaidDiagram({ code, className, storageKey }: Props) {
   const actualSize = useCallback(() => {
     wrapperRef.current?.setTransform(0, 0, 1, ANIMATION_MS);
   }, []);
+
+  // Reset view: clear any persisted custom zoom for this file AND fit to
+  // width. Distinguishes from `Fit` (which only re-fits without forgetting
+  // the stored value) so the user can return to defaults.
+  const resetView = useCallback(() => {
+    if (storageKey) {
+      clearStoredScale(storageKey);
+      pendingScaleRef.current = null;
+      if (persistTimerRef.current) {
+        clearTimeout(persistTimerRef.current);
+        persistTimerRef.current = null;
+      }
+    }
+    fitToWidth();
+  }, [storageKey, fitToWidth]);
+
+  // When the storageKey changes mid-life (e.g. file switched while reusing
+  // the same component instance), the existing `initializedRef` guard would
+  // otherwise prevent the init effect below from picking up the new file's
+  // stored zoom. Reset the guard so the init effect re-runs against the new
+  // key. The render-effect already does this on `code` change; this covers
+  // the storageKey-only case.
+  useEffect(() => {
+    initializedRef.current = false;
+  }, [storageKey]);
 
   // After SVG injection: restore stored zoom or auto fit-to-width.
   useEffect(() => {
@@ -282,8 +315,8 @@ export default function MermaidDiagram({ code, className, storageKey }: Props) {
         <button
           type="button"
           className="btn btn-sm btn-ghost"
-          onClick={fitToWidth}
-          title="Reset"
+          onClick={resetView}
+          title="Reset view (clears saved zoom)"
           aria-label="Reset view"
         >
           ⟳

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -75,6 +75,7 @@ export default function MermaidDiagram({ code, className, storageKey }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
   const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingScaleRef = useRef<number | null>(null);
   const initializedRef = useRef(false);
 
   // Render mermaid SVG (lazy-loaded). Re-runs on `code` change.
@@ -130,14 +131,22 @@ export default function MermaidDiagram({ code, className, storageKey }: Props) {
     return () => cancelAnimationFrame(id);
   }, [state, storageKey, computeFitScale]);
 
-  // Cleanup persist timer on unmount.
+  // Cleanup persist timer on unmount AND flush any pending save so a quick
+  // unmount within the debounce window does not lose the user's last zoom.
   useEffect(() => {
     return () => {
-      if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+      if (persistTimerRef.current) {
+        clearTimeout(persistTimerRef.current);
+        persistTimerRef.current = null;
+      }
+      if (storageKey && pendingScaleRef.current != null) {
+        saveScale(storageKey, pendingScaleRef.current);
+        pendingScaleRef.current = null;
+      }
     };
-  }, []);
+  }, [storageKey]);
 
-  // Global Escape handler when fullscreen.
+  // Global Escape handler + body scroll lock + auto-focus when fullscreen.
   useEffect(() => {
     if (!isFullscreen) return;
     const handler = (e: KeyboardEvent) => {
@@ -146,8 +155,16 @@ export default function MermaidDiagram({ code, className, storageKey }: Props) {
         setIsFullscreen(false);
       }
     };
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    // Defer focus to next frame so the dialog is in the DOM with its new role.
+    const focusId = requestAnimationFrame(() => containerRef.current?.focus());
     document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
+    return () => {
+      document.removeEventListener('keydown', handler);
+      document.body.style.overflow = prevOverflow;
+      cancelAnimationFrame(focusId);
+    };
   }, [isFullscreen]);
 
   const handleKeyDown = useCallback(
@@ -182,9 +199,14 @@ export default function MermaidDiagram({ code, className, storageKey }: Props) {
     (_ref: ReactZoomPanPinchRef, s: { scale: number; positionX: number; positionY: number }) => {
       setScale(s.scale);
       if (storageKey) {
+        pendingScaleRef.current = s.scale;
         if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
         persistTimerRef.current = setTimeout(() => {
-          saveScale(storageKey, s.scale);
+          if (pendingScaleRef.current != null) {
+            saveScale(storageKey, pendingScaleRef.current);
+            pendingScaleRef.current = null;
+          }
+          persistTimerRef.current = null;
         }, PERSIST_DEBOUNCE_MS);
       }
     },
@@ -303,17 +325,25 @@ export default function MermaidDiagram({ code, className, storageKey }: Props) {
     </div>
   );
 
-  if (isFullscreen) {
-    return (
-      <div
-        className="mermaid-fullscreen-backdrop"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Mermaid diagram fullscreen"
-      >
-        {viewer}
-      </div>
-    );
-  }
-  return viewer;
+  // IMPORTANT: keep the JSX tree shape stable across the fullscreen toggle so
+  // React preserves the `TransformWrapper` instance (and therefore the current
+  // zoom/pan state). The outer div is `display: contents` when inline (no box,
+  // no layout impact) and the fullscreen backdrop when fullscreen.
+  return (
+    <div
+      className={isFullscreen ? 'mermaid-fullscreen-backdrop' : 'mermaid-viewer-shell'}
+      role={isFullscreen ? 'dialog' : undefined}
+      aria-modal={isFullscreen ? true : undefined}
+      aria-label={isFullscreen ? 'Mermaid diagram fullscreen' : undefined}
+      onClick={
+        isFullscreen
+          ? (e) => {
+              if (e.target === e.currentTarget) setIsFullscreen(false);
+            }
+          : undefined
+      }
+    >
+      {viewer}
+    </div>
+  );
 }

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -640,7 +640,7 @@ export default function StashViewer({ stash, onEdit, onDelete, onArchive, onBack
                 </div>
                 {showRendered && lang === 'mermaid' ? (
                   <div className="file-rendered file-mermaid">
-                    <MermaidDiagram code={file.content} />
+                    <MermaidDiagram code={file.content} storageKey={`${stash.id}:${file.filename}`} />
                   </div>
                 ) : showRendered && lang === 'markdown' ? (
                   <div className="file-rendered markdown-body" dangerouslySetInnerHTML={{ __html: renderedContent.get(file.id) || '' }} />

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5843,7 +5843,15 @@ body {
   display: block;
 }
 
-/* Fullscreen modal */
+/* Fullscreen modal — outer wrapper.
+   The shell variant (`display: contents`) is rendered inline so the wrapper
+   does not produce a box; the backdrop variant covers the viewport. Keeping
+   the outer element type stable across the toggle preserves the
+   TransformWrapper instance (and therefore the zoom/pan state). */
+.mermaid-viewer-shell {
+  display: contents;
+}
+
 .mermaid-fullscreen-backdrop {
   position: fixed;
   inset: 0;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5766,3 +5766,116 @@ body {
   padding: 0;
   background: var(--bg-primary);
 }
+
+/* Mermaid zoom/pan viewer (standalone .mmd / .mermaid files) */
+.mermaid-viewer {
+  position: relative;
+  width: 100%;
+  max-height: 70vh;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  overflow: hidden;
+  outline: none;
+}
+
+.mermaid-viewer:focus-visible {
+  outline: 2px solid var(--accent-blue, #2f81f7);
+  outline-offset: -2px;
+}
+
+.mermaid-toolbar {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 5;
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  padding: 4px 6px;
+  background: rgba(22, 27, 34, 0.9);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  backdrop-filter: blur(4px);
+}
+
+.mermaid-toolbar .btn {
+  padding: 2px 8px;
+  min-width: 28px;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.mermaid-zoom-display {
+  display: inline-block;
+  min-width: 48px;
+  padding: 0 4px;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.mermaid-transform-wrapper {
+  width: 100% !important;
+  height: 100% !important;
+  min-height: 320px;
+  cursor: grab;
+}
+
+.mermaid-transform-wrapper:active {
+  cursor: grabbing;
+}
+
+/* Within the zoom/pan transform context, the inner .mermaid-diagram should
+   not impose its own padding/border/overflow — the viewer wraps it. */
+.mermaid-transform-content .mermaid-diagram {
+  padding: 16px;
+  border: none;
+  background: transparent;
+  overflow: visible;
+}
+
+.mermaid-transform-content .mermaid-diagram svg {
+  /* Allow natural size inside the transform context: the wrapper scales it. */
+  max-width: none;
+  height: auto;
+  display: block;
+}
+
+/* Fullscreen modal */
+.mermaid-fullscreen-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  padding: 24px;
+}
+
+.mermaid-viewer-fullscreen {
+  flex: 1;
+  max-height: none;
+  height: 100%;
+  background: var(--bg-secondary);
+}
+
+@media (max-width: 640px) {
+  .mermaid-viewer {
+    max-height: 60vh;
+  }
+  .mermaid-toolbar {
+    top: 4px;
+    right: 4px;
+    padding: 2px 4px;
+  }
+  .mermaid-toolbar .btn {
+    min-width: 24px;
+    padding: 2px 6px;
+  }
+  .mermaid-fullscreen-backdrop {
+    padding: 8px;
+  }
+}


### PR DESCRIPTION
Closes #100

## Summary

Wraps the standalone `.mmd` / `.mermaid` diagram viewer (`MermaidDiagram` component, used by `StashViewer`) with an interactive zoom/pan toolbar, fullscreen modal, and persistent per-file zoom level. Powered by `react-zoom-pan-pinch` (React 19 compatible).

Inline ` ```mermaid ` blocks inside Markdown deliberately stay as static SVGs — they go through a separate DOM-hydration path and are typically small. A follow-up issue can convert that path if needed.

## Must-have requirements (all shipped)

- [x] Zoom controls: + / − / Reset buttons, mouse wheel with Ctrl/Cmd modifier, pinch on touch
- [x] Pan/drag when diagram exceeds viewport
- [x] Fullscreen toggle (modal/overlay)
- [x] Current zoom level displayed (e.g. `100%`)

## Nice-to-have (also shipped)

- [x] Fit-to-width / Actual-size buttons (`Fit`, `1:1`)
- [x] Keyboard shortcuts: `+` / `=` zoom in, `-` zoom out, `0` fit, `f` toggle fullscreen, `Esc` exit fullscreen (active when viewer has focus or is fullscreen)
- [x] Persistent zoom per diagram via `localStorage["clawstash_mermaid_zoom_<stashId>:<filename>"]`

## Implementation notes

- New dependency: `react-zoom-pan-pinch ^3.7.0` (peer-dep supports React ^16/^17/^18/^19)
- Mouse-wheel zoom is gated behind Ctrl/Cmd (`wheel.activationKeys: ['Control','Meta']`) so it does not hijack normal page scroll
- Initial render auto-fits to width unless a stored zoom exists for this file
- Zoom value is debounced (300 ms) before being persisted to localStorage to avoid spamming during a pan/zoom interaction
- Mobile: smaller toolbar, 60vh max-height, reduced backdrop padding
- Accessibility: `role="region"`, `role="toolbar"`, `aria-label`s, `aria-live="polite"` on the zoom display, focus-visible outline, Escape closes fullscreen

## Files changed

- `src/components/MermaidDiagram.tsx` — rewritten with `TransformWrapper` + toolbar + fullscreen modal
- `src/components/StashViewer.tsx` — passes `storageKey={` `${stash.id}:${file.filename}` `}`
- `src/styles/app.css` — new `.mermaid-viewer`, `.mermaid-toolbar`, `.mermaid-zoom-display`, `.mermaid-transform-*`, `.mermaid-fullscreen-backdrop` rules + mobile responsive tweaks
- `package.json` / `package-lock.json` — `react-zoom-pan-pinch` added
- `CLAUDE.md`, `MEMORY.md` — docs updated (Tech Stack table, Mermaid section, architecture decision record)

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — clean (Next.js production build)
- Impact analysis (GitNexus): `MermaidDiagram` only consumed by `StashViewer`, prop addition is backwards-compatible

## Test plan

- [ ] Open the `network-map-10.0.0.0-24.mmd` test diagram (large network diagram)
  - [ ] Diagram fits to width on initial render
  - [ ] `+` / `−` buttons zoom in/out, percentage updates
  - [ ] `Fit` re-fits to width; `1:1` shows actual size
  - [ ] Drag pans the diagram when it exceeds viewport
  - [ ] Ctrl/Cmd + mouse wheel zooms (without scrolling the page)
  - [ ] Fullscreen toggle opens a centered modal; Escape closes it
  - [ ] Zoom level survives reload (per-file via localStorage)
- [ ] Open a small diagram — auto-fit still produces a reasonable initial scale (no regression)
- [ ] Mobile: pinch zooms, drag pans, toolbar remains usable
- [ ] Keyboard: focus the viewer, then `+` / `-` / `0` / `f` work; `Esc` exits fullscreen
- [ ] Inline ` ```mermaid ` block in markdown still renders as a static SVG (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)