### PR TITLE
chore(deps): group dependabot patch/minor + security, isolate majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,31 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/server"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Group dependabot patch/minor + security, isolate majors. Inklusive /server-Group für die Backend-deps.

---
_Generated by [Claude Code](https://claude.ai/code/session_015rCezQxP7hTwcTCj8aLNmR)_