### PR TITLE
chore(deps): group github-actions updates to consolidate singletons

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Konsolidiert wöchentliche `github-actions`-Bumps in einen einzigen PR pro Lauf. Spiegelt die bereits aktive `minor-and-patch`/`security`-Gruppierung beim npm-Ecosystem.

---
_Generated by [Claude Code](https://claude.ai/code/session_019uYsxPAYctqm3sX1RGW1HX)_