### PR TITLE
refactor: DRY consolidation + externalize timing constants (Round 2/3)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import type { Stash, StashListItem, ViewMode, LayoutMode, SettingsSection, AdminSessionInfo, TagInfo } from './types';
 import { api, setAuthToken } from './api';
 import { loadFavoriteIds, saveFavoriteIds, toggleFavorite } from './utils/favorites';
+import { SEARCH_DEBOUNCE_MS } from './utils/constants';
 import Sidebar from './components/Sidebar';
 import Dashboard from './components/Dashboard';
 import StashViewer from './components/StashViewer';
@@ -261,7 +262,7 @@ export default function App() {
     if (!adminSession || (!adminSession.authenticated && adminSession.authRequired)) return;
     const timer = setTimeout(() => {
       loadStashes();
-    }, 200);
+    }, SEARCH_DEBOUNCE_MS);
     return () => clearTimeout(timer);
   }, [loadStashes, adminSession]);
 

--- a/src/app/api/stashes/[id]/versions/[version]/restore/route.ts
+++ b/src/app/api/stashes/[id]/versions/[version]/restore/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/server/singleton';
-import { checkScope, getAccessSource, getRequestInfo } from '@/app/api/_helpers';
+import { checkScope, getAccessSource, getRequestInfo, parsePositiveInt } from '@/app/api/_helpers';
 
 type Params = { params: Promise<{ id: string; version: string }> };
 
@@ -9,8 +9,8 @@ export async function POST(req: NextRequest, { params }: Params) {
   if (!scope.ok) return scope.response;
 
   const { id, version: versionStr } = await params;
-  const version = parseInt(versionStr, 10);
-  if (!Number.isInteger(version) || version < 1) {
+  const version = parsePositiveInt(versionStr);
+  if (version === undefined) {
     return NextResponse.json({ error: 'Invalid version number' }, { status: 400 });
   }
 

--- a/src/app/api/stashes/[id]/versions/[version]/route.ts
+++ b/src/app/api/stashes/[id]/versions/[version]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/server/singleton';
-import { checkScope, getAccessSource, getRequestInfo } from '@/app/api/_helpers';
+import { checkScope, getAccessSource, getRequestInfo, parsePositiveInt } from '@/app/api/_helpers';
 
 type Params = { params: Promise<{ id: string; version: string }> };
 
@@ -9,8 +9,8 @@ export async function GET(req: NextRequest, { params }: Params) {
   if (!scope.ok) return scope.response;
 
   const { id, version: versionStr } = await params;
-  const version = parseInt(versionStr, 10);
-  if (!Number.isInteger(version) || version < 1) {
+  const version = parsePositiveInt(versionStr);
+  if (version === undefined) {
     return NextResponse.json({ error: 'Invalid version number' }, { status: 400 });
   }
 

--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import type { StashListItem } from '../types';
 import { api } from '../api';
 import { formatRelativeTime } from '../utils/format';
+import { SEARCH_DEBOUNCE_MS } from '../utils/constants';
 
 interface Props {
   open: boolean;
@@ -67,7 +68,7 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
   const handleInputChange = (value: string) => {
     setQuery(value);
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => doSearch(value), 200);
+    debounceRef.current = setTimeout(() => doSearch(value), SEARCH_DEBOUNCE_MS);
   };
 
   // Cleanup debounce on unmount

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -9,6 +9,8 @@ import VersionHistory from './VersionHistory';
 import { Marked } from 'marked';
 import { renderDescriptionMarkdown, isUnsafeUrl } from '../utils/markdown';
 import { renderMermaid } from '../utils/mermaid';
+import { DELETE_CONFIRM_TIMEOUT_MS } from '../utils/constants';
+import { escapeHtml } from '../utils/html';
 import MermaidDiagram from './MermaidDiagram';
 
 interface Props {
@@ -56,16 +58,6 @@ function resolveEffectiveLanguage(file: StashFile): string {
   const fromMeta = resolvePrismLanguage(file.language, file.filename);
   if (fromMeta !== 'text') return fromMeta;
   return detectLanguageFromContent(file.content);
-}
-
-/** Escape a string for safe use inside an HTML attribute value. */
-function escapeAttr(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
-
-/** Escape a string for safe use as HTML body content. */
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
 /**
@@ -121,12 +113,12 @@ const mdParser = new Marked({
       if (count > 0) slug = `${slug}-${count}`;
       const finalSlug = headingIdPrefix + slug;
       const rendered = this.parser.parseInline(tokens);
-      const safeSlug = escapeAttr(finalSlug);
+      const safeSlug = escapeHtml(finalSlug);
       return `<h${depth} id="${safeSlug}"><a class="heading-anchor" href="#${safeSlug}" aria-hidden="true">#</a>${rendered}</h${depth}>\n`;
     },
     // Open external links in a new tab; keep anchor links in-page
     link({ href, title, text }) {
-      const titleAttr = title ? ` title="${escapeAttr(title)}"` : '';
+      const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
       // Strip dangerous schemes (javascript:/vbscript:/data:text/html, with
       // case + control-char obfuscation) before rendering — defence-in-depth
       // alongside the post-render sanitiser.
@@ -134,9 +126,9 @@ const mdParser = new Marked({
       if (cleanHref.startsWith('#')) {
         // Prepend current heading prefix so anchors match prefixed heading IDs
         const resolvedHref = headingIdPrefix && cleanHref !== '#' ? `#${headingIdPrefix}${cleanHref.slice(1)}` : cleanHref;
-        return `<a href="${escapeAttr(resolvedHref)}"${titleAttr}>${text}</a>`;
+        return `<a href="${escapeHtml(resolvedHref)}"${titleAttr}>${text}</a>`;
       }
-      const safeHref = escapeAttr(cleanHref);
+      const safeHref = escapeHtml(cleanHref);
       return `<a href="${safeHref}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
     },
     // Custom code renderer: emit a placeholder div for ```mermaid``` blocks
@@ -151,7 +143,7 @@ const mdParser = new Marked({
       }
       const body = escapeHtml(text.replace(/\n$/, '')) + '\n';
       if (language) {
-        return `<pre><code class="language-${escapeAttr(language)}">${body}</code></pre>\n`;
+        return `<pre><code class="language-${escapeHtml(language)}">${body}</code></pre>\n`;
       }
       return `<pre><code>${body}</code></pre>\n`;
     },
@@ -400,7 +392,7 @@ export default function StashViewer({ stash, onEdit, onDelete, onArchive, onBack
     } else {
       setShowDeleteConfirm(true);
       if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
-      deleteTimerRef.current = setTimeout(() => setShowDeleteConfirm(false), 3000);
+      deleteTimerRef.current = setTimeout(() => setShowDeleteConfirm(false), DELETE_CONFIRM_TIMEOUT_MS);
     }
   };
 

--- a/src/components/VersionHistory.tsx
+++ b/src/components/VersionHistory.tsx
@@ -4,6 +4,7 @@ import { api } from '../api';
 import { formatRelativeTime } from '../utils/format';
 import VersionDiff from './VersionDiff';
 import { highlightCode, resolvePrismLanguage } from '../languages';
+import { DELETE_CONFIRM_TIMEOUT_MS } from '../utils/constants';
 import Spinner from './shared/Spinner';
 
 interface Props {
@@ -94,7 +95,7 @@ export default function VersionHistory({ stashId, currentVersion, onRestore }: P
     if (confirmRestore !== version) {
       setConfirmRestore(version);
       if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
-      confirmTimerRef.current = setTimeout(() => setConfirmRestore(null), 3000);
+      confirmTimerRef.current = setTimeout(() => setConfirmRestore(null), DELETE_CONFIRM_TIMEOUT_MS);
       return;
     }
     setRestoring(true);

--- a/src/components/api/useCopyToast.ts
+++ b/src/components/api/useCopyToast.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { copyToClipboard } from '../../utils/clipboard';
+import { COPY_TOAST_DURATION_MS } from '../../utils/constants';
 
 /**
  * Hook for copy-to-clipboard with auto-dismissing toast notification.
@@ -20,7 +21,7 @@ export function useCopyToast() {
     const success = await copyToClipboard(value);
     setCopyNotice(success ? `"${label}" copied` : 'Copy failed');
     if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setCopyNotice(null), 2000);
+    timerRef.current = setTimeout(() => setCopyNotice(null), COPY_TOAST_DURATION_MS);
   }, []);
 
   return { copyNotice, handleCopy };

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { copyToClipboard } from '../utils/clipboard';
+import { COPY_TOAST_DURATION_MS } from '../utils/constants';
 
 interface UseClipboardOptions {
   feedbackDuration?: number;
@@ -44,7 +45,7 @@ interface UseClipboardReturn {
  * Handles timeout cleanup on unmount and rapid clicks.
  */
 export function useClipboard(options: UseClipboardOptions = {}): UseClipboardReturn {
-  const { feedbackDuration = 2000 } = options;
+  const { feedbackDuration = COPY_TOAST_DURATION_MS } = options;
   const { state, trigger } = useClipboardBase<CopyStatus>('idle', feedbackDuration);
 
   const copy = useCallback(async (text: string) => {
@@ -68,7 +69,7 @@ interface UseClipboardWithKeyReturn {
  * Handles timeout cleanup on unmount and rapid clicks.
  */
 export function useClipboardWithKey(options: UseClipboardOptions = {}): UseClipboardWithKeyReturn {
-  const { feedbackDuration = 2000 } = options;
+  const { feedbackDuration = COPY_TOAST_DURATION_MS } = options;
   const { state, trigger } = useClipboardBase<{ key: string; ok: boolean } | null>(null, feedbackDuration);
 
   const copy = useCallback(async (key: string, text: string) => {

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -1,4 +1,5 @@
 import Prism from 'prismjs';
+import { escapeHtml } from './utils/html';
 
 // Import commonly used language definitions
 // NOTE: Order matters! Base grammars must be imported before dependents.
@@ -214,11 +215,7 @@ export function highlightCode(code: string, language: string): string {
   const prismLang = Prism.languages[language];
   if (!prismLang) {
     // Fallback: escape HTML entities for plain text
-    return code
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
+    return escapeHtml(code);
   }
   return Prism.highlight(code, prismLang, language);
 }

--- a/src/server/__tests__/mcp-spec.test.ts
+++ b/src/server/__tests__/mcp-spec.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { getMcpSpecText, getMcpOnboardingText, getMcpRefreshText } from '../mcp-spec';
+
+/**
+ * Characterization tests for the memoizeByBaseUrl helper (Round 2/3 — refs #131).
+ *
+ * The three spec generators share a single-entry cache keyed by baseUrl.
+ * These tests pin the behaviour callers depend on:
+ *
+ * - Same baseUrl returns the cached string (referential equality).
+ * - Changing baseUrl rebuilds and updates the cache.
+ * - The new baseUrl is reflected in the rebuilt content.
+ */
+describe('mcp-spec memoizeByBaseUrl caching', () => {
+  it('returns the same string instance for repeated baseUrl', () => {
+    const a = getMcpSpecText('http://localhost:3000');
+    const b = getMcpSpecText('http://localhost:3000');
+    expect(a).toBe(b); // referential equality => single-entry cache hit
+  });
+
+  it('rebuilds when baseUrl changes and reflects the new host', () => {
+    const a = getMcpSpecText('http://localhost:3000');
+    const b = getMcpSpecText('https://example.com');
+    expect(a).not.toBe(b);
+    expect(b).toContain('https://example.com');
+  });
+
+  it('caches onboarding and refresh wrappers independently of the spec', () => {
+    const onboardA = getMcpOnboardingText('http://localhost:3000');
+    const onboardB = getMcpOnboardingText('http://localhost:3000');
+    expect(onboardA).toBe(onboardB);
+
+    const refreshA = getMcpRefreshText('http://localhost:3000');
+    const refreshB = getMcpRefreshText('http://localhost:3000');
+    expect(refreshA).toBe(refreshB);
+  });
+});

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -85,26 +85,6 @@ export function isAuthEnabled(): boolean {
 }
 
 /**
- * Check if a token has admin access.
- * Returns true if no ADMIN_PASSWORD is set (open mode) or if token has admin privileges.
- */
-export function requireAdminAuth(db: ClawStashDB, req: NextRequest): AuthResult | null {
-  if (!isAuthEnabled()) {
-    return { authenticated: true, source: 'open', scopes: ['read', 'write', 'admin', 'mcp'] };
-  }
-
-  const token = extractToken(req);
-  if (!token) return null;
-
-  const auth = validateAuth(db, token);
-  if (auth.authenticated && auth.scopes.includes('admin')) {
-    return auth;
-  }
-
-  return null;
-}
-
-/**
  * Check if a token has a specific scope.
  * Returns true if no ADMIN_PASSWORD is set (open mode) or if token has the required scope.
  */
@@ -128,4 +108,15 @@ export function requireScopeAuth(db: ClawStashDB, req: NextRequest, scope: Token
   if (auth.scopes.includes(scope)) return auth;
 
   return null;
+}
+
+/**
+ * Check if a token has admin access.
+ *
+ * Trace-equivalent to `requireScopeAuth(db, req, 'admin')`: both short-circuit
+ * the same way for open-mode, missing token, non-admin scope, and admin scope.
+ * Kept as a named helper so admin-only call sites read clearly.
+ */
+export function requireAdminAuth(db: ClawStashDB, req: NextRequest): AuthResult | null {
+  return requireScopeAuth(db, req, 'admin');
 }

--- a/src/server/mcp-spec.ts
+++ b/src/server/mcp-spec.ts
@@ -10,11 +10,26 @@ import { getOpenApiSpec } from './openapi';
 import { CLAWSTASH_PURPOSE, TOKEN_EFFICIENT_GUIDE } from './shared-text';
 import { TOOL_DEFS } from './tool-defs';
 
-let mcpSpecCache: { key: string; value: string } | null = null;
+/**
+ * Single-entry memoization keyed by baseUrl. Last-write-wins; previous entry
+ * is dropped when the key changes. Bounded growth (one entry per cache var).
+ *
+ * Three MCP spec generators (spec, onboarding, refresh) share this caching
+ * shape. Per-baseUrl variation is rare in practice (typically one production
+ * host) but the cache cheaply absorbs repeated spec re-fetches inside a
+ * single baseUrl without leaking memory across hosts.
+ */
+function memoizeByBaseUrl<T>(generator: (baseUrl: string) => T): (baseUrl: string) => T {
+  let cache: { key: string; value: T } | null = null;
+  return (baseUrl: string): T => {
+    if (cache?.key === baseUrl) return cache.value;
+    const value = generator(baseUrl);
+    cache = { key: baseUrl, value };
+    return value;
+  };
+}
 
-export function getMcpSpecText(baseUrl: string): string {
-  if (mcpSpecCache?.key === baseUrl) return mcpSpecCache.value;
-
+export const getMcpSpecText = memoizeByBaseUrl((baseUrl: string): string => {
   const openapi = getOpenApiSpec(baseUrl);
   const schemas = openapi.components.schemas;
 
@@ -78,19 +93,14 @@ Data type schemas shared with the REST API (OpenAPI). Referenced in tool return 
 
 ${dataTypesSection}`;
 
-  mcpSpecCache = { key: baseUrl, value: result };
   return result;
-}
+});
 
 // ---------------------------------------------------------------------------
 // MCP Onboarding Text — wraps the spec with self-onboarding instructions
 // ---------------------------------------------------------------------------
 
-let onboardingCache: { key: string; value: string } | null = null;
-
-export function getMcpOnboardingText(baseUrl: string): string {
-  if (onboardingCache?.key === baseUrl) return onboardingCache.value;
-
+export const getMcpOnboardingText = memoizeByBaseUrl((baseUrl: string): string => {
   const spec = getMcpSpecText(baseUrl);
 
   const result = `# ClawStash MCP Onboarding Guide
@@ -123,19 +133,14 @@ You are reading the ClawStash MCP onboarding specification. This document contai
 
 ${spec}`;
 
-  onboardingCache = { key: baseUrl, value: result };
   return result;
-}
+});
 
 // ---------------------------------------------------------------------------
 // MCP Refresh Text — spec with update-focused framing for connected AI agents
 // ---------------------------------------------------------------------------
 
-let refreshCache: { key: string; value: string } | null = null;
-
-export function getMcpRefreshText(baseUrl: string): string {
-  if (refreshCache?.key === baseUrl) return refreshCache.value;
-
+export const getMcpRefreshText = memoizeByBaseUrl((baseUrl: string): string => {
   const spec = getMcpSpecText(baseUrl);
 
   const result = `# ClawStash MCP Tool Update
@@ -148,6 +153,5 @@ For initial onboarding (before MCP is connected), use the REST endpoint: \`GET $
 
 ${spec}`;
 
-  refreshCache = { key: baseUrl, value: result };
   return result;
-}
+});

--- a/src/utils/__tests__/html.test.ts
+++ b/src/utils/__tests__/html.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { escapeHtml } from '../html';
+
+describe('escapeHtml', () => {
+  it('escapes the four HTML-significant chars', () => {
+    expect(escapeHtml('a&b<c>d"e')).toBe('a&amp;b&lt;c&gt;d&quot;e');
+  });
+
+  it('escapes ampersand first so other entity prefixes are double-escaped', () => {
+    // Guards against a regression where `&` is replaced after `<`/`>`/`"`,
+    // which would leave the `&` in `&amp;`/`&lt;`/etc. literal in the input.
+    expect(escapeHtml('&amp;')).toBe('&amp;amp;');
+  });
+
+  it('returns input unchanged when no significant chars are present', () => {
+    expect(escapeHtml('hello world 123')).toBe('hello world 123');
+  });
+
+  it('handles empty string', () => {
+    expect(escapeHtml('')).toBe('');
+  });
+
+  it('escapes nested patterns without double-escaping', () => {
+    expect(escapeHtml('<script>alert("xss")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'
+    );
+  });
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,20 @@
+/**
+ * App-wide UI timing constants (milliseconds).
+ *
+ * Centralised so the same intent (debounce, toast, confirm) is tuned once
+ * across all consumers. Module-scoped per-component constants stay where
+ * they are (e.g. mermaid animation, mermaid zoom-persist debounce, session
+ * cleanup interval, version cache TTL).
+ */
+
+/** Search input debounce window — sidebar live-search and search overlay. */
+export const SEARCH_DEBOUNCE_MS = 200;
+
+/** Auto-dismiss for "copied" / "copy failed" toast feedback. */
+export const COPY_TOAST_DURATION_MS = 2000;
+
+/**
+ * Two-click destructive-action confirm timeout — used by delete and restore
+ * flows that ask the user to click twice within this window to commit.
+ */
+export const DELETE_CONFIRM_TIMEOUT_MS = 3000;

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -1,0 +1,17 @@
+/**
+ * Escape a string for safe inclusion in HTML body text or attribute values.
+ * Escapes the four characters HTML treats as syntactically significant.
+ *
+ * The ampersand replacement runs first so subsequent entity insertions
+ * (`&amp;`, `&lt;`, etc.) are not double-escaped.
+ *
+ * Centralised here so all callers (markdown rendering, code highlighting,
+ * stash view) cannot drift on the escape set.
+ */
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,8 +1,5 @@
 import { Marked } from 'marked';
-
-function escapeAttr(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
+import { escapeHtml } from './html';
 
 /**
  * Test whether an attribute value carries a script-bearing URL scheme.
@@ -35,11 +32,11 @@ const descriptionParser = new Marked({
       // Strip dangerous schemes at render time as defence-in-depth alongside
       // the post-render sanitiser. Defaults to '#' so the anchor stays valid.
       const safeHref = isUnsafeUrl(href) ? '#' : href;
-      const titleAttr = title ? ` title="${escapeAttr(title)}"` : '';
+      const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
       if (safeHref.startsWith('#')) {
-        return `<a href="${escapeAttr(safeHref)}"${titleAttr}>${text}</a>`;
+        return `<a href="${escapeHtml(safeHref)}"${titleAttr}>${text}</a>`;
       }
-      return `<a href="${escapeAttr(safeHref)}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
+      return `<a href="${escapeHtml(safeHref)}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
     },
   },
 });


### PR DESCRIPTION
## Round 2/3 — Pattern Application & Abstractions

### Refactorings

| ID | Impact | Cluster | Pattern | Description | Status |
|----|--------|---------|---------|-------------|--------|
| 1  | R2     | Server (auth)        | DRY-delegator         | `requireAdminAuth` → 1-line wrapper over `requireScopeAuth(db, req, 'admin')` | done |
| 2  | R2     | Components/Utils     | DRY-extract-util      | New `src/utils/html.ts` with `escapeHtml`; replace 3 duplicate definitions across `markdown.ts`, `StashViewer.tsx`, `languages.ts` | done |
| 3  | R2     | Server (mcp-spec)    | DRY-extract-helper    | `memoizeByBaseUrl<T>` helper consolidates 3 identical single-entry caches | done |
| 4  | R2     | API routes           | DRY-route-helper      | Replace 2 ad-hoc `parseInt(versionStr, 10)` blocks with existing `parsePositiveInt()` | done |
| 5  | R2     | App-wide             | externalize-config    | Extract 3 duplicated UI timing literals (200/2000/3000 ms) to `src/utils/constants.ts` | done |

### Pattern justification (1–2 sentences each)

- **R1 — DRY-delegator**: `requireAdminAuth` and `requireScopeAuth(db, req, 'admin')` have byte-identical observable behavior across every input (open mode, missing token, admin scope, non-admin scope). The named helper is preserved so admin-only call sites still read clearly without the duplicated control flow.
- **R2 — DRY-extract-util**: 3 implementations of the same 4-char HTML escape lived in 3 files (one of them duplicated locally as `escapeAttr`/`escapeHtml` for a distinction the bodies didn't actually make). Centralising prevents drift on the escape set and removes 13 LoC of copy-paste.
- **R3 — DRY-extract-helper**: 3 module-level `let cache: { key, value } | null` declarations plus identical 2-line check/store blocks differ only by the generator function. A 6-line generic helper makes the caching contract explicit (single-entry, last-write-wins, bounded growth per cache var).
- **R4 — DRY-route-helper**: `parsePositiveInt` already exists and is the canonical positive-integer parser for route params (used in 5 sibling routes). The two version routes were rolling their own validation with identical semantics. Replacing them pins all positive-integer route params to one validator.
- **R5 — externalize-config**: 3 timing values are duplicated as raw integer literals across 6 files. Naming them centrally surfaces intent at every call site, makes timing tweaks atomic, and gives future tests a single import target.

### Cross-round regression check

Pre-flight `gitnexus_impact` on Round-1 surface (db split, stores, hashToken):
- `src/server/db.ts` — MEDIUM, 6 callers; not touched by Round 2.
- `ClawStashDB` — MEDIUM, 6 callers; not touched.
- `TokenStore`, `SessionStore` — MEDIUM, 2 callers each; not touched.
- `hashToken` — CRITICAL, 5 callers; not touched.

Round 2 changes do **not** touch the Round 1 surface. Refactor 1 (auth DRY) only restructures `auth.ts` internally — `validateAdminSession`/`validateApiToken` callers are unchanged.

### Deferred (R3 / Backlog)

- **#104 SearchStore + VersionStore extraction** — explicit Round 2 candidate. Requires DI/Strategy interfaces (`StashReader`/`StashWriter`) for cross-store calls. Estimated ~500–700 LoC + ~25 new characterization tests. Deferred to a focused follow-up PR; bundling here would push past the 500-LoC PR threshold and mix cheap consolidation with structural extraction.
- **#105 zod-to-openapi** — requires a new dependency (`@asteasolutions/zod-to-openapi`); CLAUDE.md mandates user approval. Defer.
- Existing R3 entries in BACKLOG (#52, #57, #58, #95, #96, #88, #89, #90, #102, #103, #106) — out of scope.

### Impact (gitnexus_detect_changes)

```
summary:
  changed_count: 35 symbols across 16 files
  affected_count: 83 (incl. transitive)
  risk_level: critical
```

The CRITICAL rating reflects the high fan-in of `requireScopeAuth` (touched by Refactor 1's internal restructuring) — every authenticated route process appears in `affected_processes`. The change is body-only: signature, return type, and observable behavior are unchanged. All affected processes route through the same auth path as before.

### Behavior invariance

- **Existing tests unchanged**: yes. All 42 pre-existing tests pass without modification.
- **New characterization tests**:
  - `src/utils/__tests__/html.test.ts` — 5 tests for `escapeHtml` (4-char escape set, ampersand-first ordering, empty input, nested patterns).
  - `src/server/__tests__/mcp-spec.test.ts` — 3 tests for `memoizeByBaseUrl` (referential cache hit, baseUrl-change rebuild, independent caches across the 3 generators).

### Quality gate

- typecheck: OK (`npx tsc --noEmit`)
- test: OK (vitest 50/50 passing — was 42, +8 new)
- build: OK (`npm run build` — Next.js production build clean)
- lint: not configured (per CLAUDE.md)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)