### PR TITLE
refactor: extract pure helpers + named constant (Round 3/3) #133

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -76,6 +76,9 @@ Review findings not immediately fixed. **Only work on these upon explicit reques
 | 104 | 2026-05-10 | Code Smells | P2 | src/server/db.ts | SearchStore + VersionStore extractions need cross-store callbacks (updateStash, listStashes, getStash). Apply Strategy/DI pattern in Round 2/3 before extracting these. | Accepted | #129 Round 1/3 Refactor |
 | 105 | 2026-05-10 | Code Smells | P2 | src/server/openapi.ts (697 LoC) | One 690-LoC function. Adopt `@asteasolutions/zod-to-openapi` to generate OpenAPI from existing Zod schemas in `tool-defs.ts` (mcp-spec.ts already uses zodToJsonSchema). Round 2/3 pattern application. | Accepted | #129 Round 1/3 Refactor |
 | 106 | 2026-05-10 | Code Smells | P2 | src/components/StashViewer.tsx (783) + Settings.tsx (559) + MermaidDiagram.tsx (401) | Sub-component extraction (TOC, access-log, metadata sections / Welcome dashboard, Storage Stats / Toolbar, render, zoom). Round 3/3 composition refactor. | Accepted | #129 Round 1/3 Refactor |
+| 108 | 2026-05-10 | Security | P2 | src/components/StashViewer.tsx:156 ↔ src/utils/markdown.ts:44 | Two `sanitizeHtml` implementations diverge on inline-`style` attribute stripping (markdown.ts strips, StashViewer.tsx does not). Consolidating is a behavior change, not a behavior-invariant refactor — needs security review before unification. | Deferred | #133 Round 3/3 Refactor |
+| 109 | 2026-05-10 | Code Smells | P3 | src/server/version.ts:97,150 | Magic literals `5000` (GitHub fetch timeout) and `60 * 1000` (failed-fetch retry window) — extract as `GITHUB_FETCH_TIMEOUT_MS` / `FAILED_FETCH_RETRY_MS`. Low value at single-use scale. | Deferred | #133 Round 3/3 Refactor |
+| 110 | 2026-05-10 | Code Smells | P3 | src/server/db.ts:logAccess | 5 positional params (`stashId`, `source`, `action`, `ip?`, `userAgent?`) — Object/Builder candidate. Private method, public types unaffected; defer until next time the signature changes. | Deferred | #133 Round 3/3 Refactor |
 
 ## Done
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,19 +1,10 @@
 import { useState, useEffect } from 'react';
+import { formatBuildVersion } from '../utils/format';
 
 interface BuildInfo {
   buildDate: string;
   commitHash: string;
   branch: string;
-}
-
-function formatBuildVersion(isoDate: string): string | null {
-  const d = new Date(isoDate);
-  // `new Date(undefined)` / `new Date('garbage')` → Invalid Date → all
-  // getUTC*() return NaN → "vNaNNaNNaN-NaNNaN" rendered in the UI.
-  // Return null instead so the caller can fall back to the default UI.
-  if (Number.isNaN(d.getTime())) return null;
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `v${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}-${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}`;
 }
 
 export default function Footer() {

--- a/src/components/VersionDiff.tsx
+++ b/src/components/VersionDiff.tsx
@@ -1,91 +1,10 @@
 import { useMemo } from 'react';
-import { diffLines } from 'diff';
 import type { StashVersion } from '../types';
+import { computeFileDiffs } from './version-diff-utils';
 
 interface Props {
   v1: StashVersion;
   v2: StashVersion;
-}
-
-interface FileDiff {
-  filename: string;
-  status: 'added' | 'removed' | 'modified' | 'unchanged';
-  hunks: DiffHunk[];
-}
-
-interface DiffHunk {
-  lines: DiffLine[];
-}
-
-interface DiffLine {
-  type: 'add' | 'remove' | 'context';
-  content: string;
-  oldLineNo?: number;
-  newLineNo?: number;
-}
-
-function computeFileDiffs(v1: StashVersion, v2: StashVersion): FileDiff[] {
-  const v1Files = new Map(v1.files.map(f => [f.filename, f.content]));
-  const v2Files = new Map(v2.files.map(f => [f.filename, f.content]));
-  const allFilenames = new Set([...v1Files.keys(), ...v2Files.keys()]);
-  const diffs: FileDiff[] = [];
-
-  for (const filename of allFilenames) {
-    const oldContent = v1Files.get(filename);
-    const newContent = v2Files.get(filename);
-
-    if (oldContent === undefined && newContent !== undefined) {
-      // File added
-      const lines = newContent.split('\n');
-      diffs.push({
-        filename,
-        status: 'added',
-        hunks: [{
-          lines: lines.map((line, i) => ({ type: 'add', content: line, newLineNo: i + 1 })),
-        }],
-      });
-    } else if (oldContent !== undefined && newContent === undefined) {
-      // File removed
-      const lines = oldContent.split('\n');
-      diffs.push({
-        filename,
-        status: 'removed',
-        hunks: [{
-          lines: lines.map((line, i) => ({ type: 'remove', content: line, oldLineNo: i + 1 })),
-        }],
-      });
-    } else if (oldContent !== undefined && newContent !== undefined) {
-      if (oldContent === newContent) {
-        diffs.push({ filename, status: 'unchanged', hunks: [] });
-        continue;
-      }
-      // Modified — compute line diff
-      const changes = diffLines(oldContent, newContent);
-      const lines: DiffLine[] = [];
-      let oldLine = 1;
-      let newLine = 1;
-
-      for (const change of changes) {
-        const changeLines = change.value.replace(/\n$/, '').split('\n');
-        for (const line of changeLines) {
-          if (change.added) {
-            lines.push({ type: 'add', content: line, newLineNo: newLine++ });
-          } else if (change.removed) {
-            lines.push({ type: 'remove', content: line, oldLineNo: oldLine++ });
-          } else {
-            lines.push({ type: 'context', content: line, oldLineNo: oldLine++, newLineNo: newLine++ });
-          }
-        }
-      }
-
-      diffs.push({ filename, status: 'modified', hunks: [{ lines }] });
-    }
-  }
-
-  // Sort: modified first, then added, then removed, then unchanged
-  const order = { modified: 0, added: 1, removed: 2, unchanged: 3 };
-  diffs.sort((a, b) => order[a.status] - order[b.status]);
-  return diffs;
 }
 
 function MetaDiff({ label, oldVal, newVal }: { label: string; oldVal: string; newVal: string }) {

--- a/src/components/__tests__/version-diff-utils.test.ts
+++ b/src/components/__tests__/version-diff-utils.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeFileDiffs,
+  diffAddedFile,
+  diffRemovedFile,
+  diffModifiedFile,
+  STATUS_ORDER,
+} from '../version-diff-utils';
+import type { StashVersion, StashVersionFile } from '../../types';
+
+// Minimal StashVersion fixture — only the fields `computeFileDiffs` reads.
+function v(files: { filename: string; content: string }[]): StashVersion {
+  const versionFiles: StashVersionFile[] = files.map((f, i) => ({
+    filename: f.filename,
+    content: f.content,
+    language: '',
+    sort_order: i,
+  }));
+  return {
+    id: 'x',
+    stash_id: 's',
+    name: '',
+    description: '',
+    tags: [],
+    metadata: {},
+    version: 1,
+    created_by: 'system',
+    created_at: '2026-01-01T00:00:00Z',
+    files: versionFiles,
+  };
+}
+
+describe('STATUS_ORDER', () => {
+  it('sorts modified < added < removed < unchanged', () => {
+    expect(STATUS_ORDER.modified).toBeLessThan(STATUS_ORDER.added);
+    expect(STATUS_ORDER.added).toBeLessThan(STATUS_ORDER.removed);
+    expect(STATUS_ORDER.removed).toBeLessThan(STATUS_ORDER.unchanged);
+  });
+});
+
+describe('diffAddedFile', () => {
+  it('emits one add line per source line, 1-indexed by newLineNo', () => {
+    const r = diffAddedFile('a.txt', 'hello\nworld');
+    expect(r.status).toBe('added');
+    expect(r.filename).toBe('a.txt');
+    expect(r.hunks).toHaveLength(1);
+    expect(r.hunks[0].lines).toEqual([
+      { type: 'add', content: 'hello', newLineNo: 1 },
+      { type: 'add', content: 'world', newLineNo: 2 },
+    ]);
+  });
+});
+
+describe('diffRemovedFile', () => {
+  it('emits one remove line per source line, 1-indexed by oldLineNo', () => {
+    const r = diffRemovedFile('a.txt', 'gone\naway');
+    expect(r.status).toBe('removed');
+    expect(r.hunks[0].lines).toEqual([
+      { type: 'remove', content: 'gone', oldLineNo: 1 },
+      { type: 'remove', content: 'away', oldLineNo: 2 },
+    ]);
+  });
+});
+
+describe('diffModifiedFile', () => {
+  it('preserves context lines and tags adds/removes', () => {
+    const r = diffModifiedFile('a.txt', 'a\nb\nc', 'a\nB\nc');
+    expect(r.status).toBe('modified');
+    const types = r.hunks[0].lines.map(l => l.type);
+    expect(types).toContain('add');
+    expect(types).toContain('remove');
+    expect(types).toContain('context');
+  });
+
+  it('counts old/new line numbers independently', () => {
+    const r = diffModifiedFile('a.txt', 'keep\nold', 'keep\nnew\nextra');
+    const adds = r.hunks[0].lines.filter(l => l.type === 'add');
+    const removes = r.hunks[0].lines.filter(l => l.type === 'remove');
+    expect(adds.length).toBeGreaterThan(0);
+    expect(removes.length).toBeGreaterThan(0);
+    // every add line carries newLineNo, every remove carries oldLineNo
+    for (const a of adds) expect(typeof a.newLineNo).toBe('number');
+    for (const rm of removes) expect(typeof rm.oldLineNo).toBe('number');
+  });
+});
+
+describe('computeFileDiffs', () => {
+  it('classifies added / removed / modified / unchanged across versions', () => {
+    const v1 = v([
+      { filename: 'kept.txt', content: 'same' },
+      { filename: 'gone.txt', content: 'old' },
+      { filename: 'changed.txt', content: 'a\nb' },
+    ]);
+    const v2 = v([
+      { filename: 'kept.txt', content: 'same' },
+      { filename: 'new.txt', content: 'fresh' },
+      { filename: 'changed.txt', content: 'a\nB' },
+    ]);
+    const diffs = computeFileDiffs(v1, v2);
+    const byName = Object.fromEntries(diffs.map(d => [d.filename, d.status]));
+    expect(byName).toEqual({
+      'changed.txt': 'modified',
+      'new.txt': 'added',
+      'gone.txt': 'removed',
+      'kept.txt': 'unchanged',
+    });
+  });
+
+  it('sorts modified, then added, then removed, then unchanged', () => {
+    const v1 = v([
+      { filename: 'kept', content: 'x' },
+      { filename: 'old', content: 'a' },
+      { filename: 'changed', content: 'a' },
+    ]);
+    const v2 = v([
+      { filename: 'kept', content: 'x' },
+      { filename: 'new', content: 'b' },
+      { filename: 'changed', content: 'b' },
+    ]);
+    const order = computeFileDiffs(v1, v2).map(d => d.status);
+    expect(order).toEqual(['modified', 'added', 'removed', 'unchanged']);
+  });
+
+  it('returns empty array when both versions have no files', () => {
+    expect(computeFileDiffs(v([]), v([]))).toEqual([]);
+  });
+
+  it('treats identical-content same-name files as unchanged with empty hunks', () => {
+    const v1 = v([{ filename: 'same.txt', content: 'foo\nbar' }]);
+    const v2 = v([{ filename: 'same.txt', content: 'foo\nbar' }]);
+    const diffs = computeFileDiffs(v1, v2);
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0].status).toBe('unchanged');
+    expect(diffs[0].hunks).toEqual([]);
+  });
+});

--- a/src/components/version-diff-utils.ts
+++ b/src/components/version-diff-utils.ts
@@ -1,0 +1,108 @@
+/**
+ * Pure helpers for `VersionDiff.tsx` — file-level diff computation between
+ * two `StashVersion` snapshots. Extracted so each per-status branch is
+ * named, independently testable, and the dispatcher in `computeFileDiffs`
+ * stays scannable at a glance.
+ */
+import { diffLines } from 'diff';
+import type { StashVersion } from '../types';
+
+export interface FileDiff {
+  filename: string;
+  status: 'added' | 'removed' | 'modified' | 'unchanged';
+  hunks: DiffHunk[];
+}
+
+export interface DiffHunk {
+  lines: DiffLine[];
+}
+
+export interface DiffLine {
+  type: 'add' | 'remove' | 'context';
+  content: string;
+  oldLineNo?: number;
+  newLineNo?: number;
+}
+
+/**
+ * Sort key for the file-diff list: changed entries first, then bulk
+ * adds/removes, then unchanged. Names the previously-inline `order`
+ * literal so callers see the intent without scanning numbers.
+ */
+export const STATUS_ORDER: Record<FileDiff['status'], number> = {
+  modified: 0,
+  added: 1,
+  removed: 2,
+  unchanged: 3,
+};
+
+export function diffAddedFile(filename: string, content: string): FileDiff {
+  const lines = content.split('\n');
+  return {
+    filename,
+    status: 'added',
+    hunks: [{
+      lines: lines.map((line, i) => ({ type: 'add', content: line, newLineNo: i + 1 })),
+    }],
+  };
+}
+
+export function diffRemovedFile(filename: string, content: string): FileDiff {
+  const lines = content.split('\n');
+  return {
+    filename,
+    status: 'removed',
+    hunks: [{
+      lines: lines.map((line, i) => ({ type: 'remove', content: line, oldLineNo: i + 1 })),
+    }],
+  };
+}
+
+export function diffModifiedFile(filename: string, oldContent: string, newContent: string): FileDiff {
+  const changes = diffLines(oldContent, newContent);
+  const lines: DiffLine[] = [];
+  let oldLine = 1;
+  let newLine = 1;
+
+  for (const change of changes) {
+    const changeLines = change.value.replace(/\n$/, '').split('\n');
+    for (const line of changeLines) {
+      if (change.added) {
+        lines.push({ type: 'add', content: line, newLineNo: newLine++ });
+      } else if (change.removed) {
+        lines.push({ type: 'remove', content: line, oldLineNo: oldLine++ });
+      } else {
+        lines.push({ type: 'context', content: line, oldLineNo: oldLine++, newLineNo: newLine++ });
+      }
+    }
+  }
+
+  return { filename, status: 'modified', hunks: [{ lines }] };
+}
+
+export function computeFileDiffs(v1: StashVersion, v2: StashVersion): FileDiff[] {
+  const v1Files = new Map(v1.files.map(f => [f.filename, f.content]));
+  const v2Files = new Map(v2.files.map(f => [f.filename, f.content]));
+  const allFilenames = new Set([...v1Files.keys(), ...v2Files.keys()]);
+  const diffs: FileDiff[] = [];
+
+  for (const filename of allFilenames) {
+    const oldContent = v1Files.get(filename);
+    const newContent = v2Files.get(filename);
+
+    if (oldContent === undefined && newContent !== undefined) {
+      diffs.push(diffAddedFile(filename, newContent));
+    } else if (oldContent !== undefined && newContent === undefined) {
+      diffs.push(diffRemovedFile(filename, oldContent));
+    } else if (oldContent !== undefined && newContent !== undefined) {
+      if (oldContent === newContent) {
+        diffs.push({ filename, status: 'unchanged', hunks: [] });
+      } else {
+        diffs.push(diffModifiedFile(filename, oldContent, newContent));
+      }
+    }
+  }
+
+  diffs.sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status]);
+  return diffs;
+}

--- a/src/server/auth-rate-limit.ts
+++ b/src/server/auth-rate-limit.ts
@@ -25,6 +25,7 @@ import type { NextRequest } from 'next/server';
 export const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
 export const RATE_LIMIT_WINDOW_SEC = Math.floor(RATE_LIMIT_WINDOW_MS / 1000);
 const RATE_LIMIT_MAX = 10; // max attempts per window per (scope, ip)
+const RATE_LIMIT_CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes — sweep stale buckets
 
 type Scope = 'login' | 'token-validate';
 
@@ -47,7 +48,7 @@ if (!state.cleanupTimer) {
     for (const [key, entry] of state.attempts) {
       if (now > entry.resetAt) state.attempts.delete(key);
     }
-  }, 5 * 60 * 1000);
+  }, RATE_LIMIT_CLEANUP_INTERVAL_MS);
   // Don't keep the event loop alive for this cleanup interval.
   state.cleanupTimer.unref?.();
 }

--- a/src/server/version.ts
+++ b/src/server/version.ts
@@ -9,6 +9,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { execSync } from 'child_process';
 import path from 'path';
+import { formatBuildVersion } from '../utils/format';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -29,11 +30,12 @@ interface BuildInfo {
   buildDate: string;
 }
 
-function formatBuildVersion(isoDate: string): string {
-  const d = new Date(isoDate);
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `v${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}-${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}`;
-}
+// `formatBuildVersion()` (utils/format) returns `string | null` so the UI
+// callsite can fall back to a default label on a bad build_date. Server
+// callsites here coalesce to 'unknown' to keep the public `version: string`
+// API contract stable; in practice `loadBuildInfo()` already falls back to
+// `new Date().toISOString()`, so the null branch is unreachable.
+const UNKNOWN_VERSION = 'unknown';
 
 function git(cmd: string): string {
   try {
@@ -87,7 +89,7 @@ let cacheExpiry = 0;
 
 async function fetchLatestCommit(): Promise<LatestCache> {
   const now = new Date().toISOString();
-  const userAgent = `ClawStash/${formatBuildVersion(buildInfo.buildDate)}`;
+  const userAgent = `ClawStash/${formatBuildVersion(buildInfo.buildDate) ?? UNKNOWN_VERSION}`;
 
   try {
     const res = await fetch(
@@ -156,7 +158,7 @@ export async function checkVersion(): Promise<VersionInfo> {
 
   return {
     current: {
-      version: formatBuildVersion(buildInfo.buildDate),
+      version: formatBuildVersion(buildInfo.buildDate) ?? UNKNOWN_VERSION,
       commit_sha: buildInfo.commitHash,
       build_date: buildInfo.buildDate,
       branch: buildInfo.branch,

--- a/src/utils/__tests__/format.test.ts
+++ b/src/utils/__tests__/format.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatBuildVersion,
+  formatDate,
+  formatDateTime,
+  formatRelativeTime,
+} from '../format';
+
+describe('formatBuildVersion', () => {
+  it('formats a valid ISO date as vYYYYMMDD-HHMM in UTC', () => {
+    expect(formatBuildVersion('2026-05-10T07:48:59Z')).toBe('v20260510-0748');
+  });
+
+  it('zero-pads single-digit components', () => {
+    expect(formatBuildVersion('2026-01-02T03:04:00Z')).toBe('v20260102-0304');
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(formatBuildVersion('not-a-date')).toBeNull();
+    expect(formatBuildVersion('')).toBeNull();
+  });
+
+  it('uses UTC, not local time', () => {
+    // 23:30 UTC reads as a different local hour in most timezones — pin
+    // the canonical output here so a regression to local-time formatting
+    // is caught even when the test runs in TZ=America/Los_Angeles etc.
+    expect(formatBuildVersion('2026-12-31T23:30:00Z')).toBe('v20261231-2330');
+  });
+});
+
+describe('format helpers — characterization', () => {
+  it('formatDate returns a non-empty string for a valid ISO date', () => {
+    expect(formatDate('2026-05-10T00:00:00Z')).toMatch(/\d/);
+  });
+
+  it('formatDateTime returns a non-empty string for a valid ISO date', () => {
+    expect(formatDateTime('2026-05-10T07:48:59Z')).toMatch(/\d/);
+  });
+
+  it('formatRelativeTime returns "just now" for the current time', () => {
+    expect(formatRelativeTime(new Date().toISOString())).toBe('just now');
+  });
+});

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -39,3 +39,17 @@ export function formatRelativeTime(dateStr: string): string {
   if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
   return formatDate(dateStr);
 }
+
+/**
+ * Format an ISO date string as a vYYYYMMDD-HHMM build-version label (UTC).
+ *
+ * Returns null on Invalid Date so callers can fall back to a default UI
+ * instead of rendering "vNaNNaNNaN-NaNNaN" (`new Date('garbage')` →
+ * Invalid Date → all `getUTC*()` return NaN).
+ */
+export function formatBuildVersion(isoDate: string): string | null {
+  const d = new Date(isoDate);
+  if (Number.isNaN(d.getTime())) return null;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `v${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}-${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}`;
+}


### PR DESCRIPTION
## Round 3/3 — Composition, Readability, Idiomatics

### Refactorings

| ID | Impact | Cluster | Idiom | Description | Status |
|----|--------|---------|-------|-------------|--------|
| A  | R2     | Server / Components | extract-pure / DRY | `formatBuildVersion` → `src/utils/format.ts`; Footer + version.ts import the canonical helper | done |
| B  | R2     | Components          | extract-pure       | Split `computeFileDiffs` into `diffAddedFile` / `diffRemovedFile` / `diffModifiedFile` + named `STATUS_ORDER`; helpers + types moved to `src/components/version-diff-utils.ts` | done |
| C  | R2     | Server (auth)       | extract-constant   | Name `5 * 60 * 1000` cleanup cadence as `RATE_LIMIT_CLEANUP_INTERVAL_MS` | done |

### Idiom justification (1–2 sentences each)

- **A**: Two near-identical implementations of the same UTC pad-and-format helper had drifted (Footer added an Invalid-Date null guard; server didn't). Centralising next to the existing date formatters enforces a single output format and gives both consumers the defensive null-on-invalid behavior.
- **B**: The 60-line `if/else-if` chain inside `computeFileDiffs` mixed three structurally independent diff cases plus a status-priority sort. Splitting each case into a named pure helper turns the loop into a 5-line dispatcher and lets each case be unit-tested in isolation.
- **C**: The cleanup-cadence literal sat next to two already-named timing constants and read as a bare arithmetic expression. Naming it groups all three timing controls in one block at the top of the file and documents the schedule explicitly.

### Cross-round regression check

Pre-flight `gitnexus_impact` (upstream, minConfidence 0.8, depth 3) on R1+R2 surface:

| R1+R2 symbol           | Risk     | Direct callers | Touched in R3? |
|------------------------|----------|----------------|----------------|
| `hashToken`            | CRITICAL | 5              | No             |
| `requireAdminAuth`     | CRITICAL | 1              | No             |
| `requireScopeAuth`     | CRITICAL | 3              | No             |
| `escapeHtml`           | HIGH     | 6              | No             |
| `memoizeByBaseUrl`     | LOW      | 1              | No             |
| `parsePositiveInt`     | CRITICAL | 7              | No             |

R3 changes are confined to `Footer.tsx`, `version.ts`, `auth-rate-limit.ts`, `VersionDiff.tsx` and the new `utils/format.ts` + `components/version-diff-utils.ts`. None of them feed into the prior-round surfaces.

### Deferred (R3 / Backlog)

- **108** — `sanitizeHtml` divergence (StashViewer ↔ markdown.ts): consolidating is a behavior change (style-attr stripping differs), so not a behavior-invariant refactor — needs security review before unification.
- **109** — `version.ts` magic literals `5000` / `60 * 1000`: extract as `GITHUB_FETCH_TIMEOUT_MS` / `FAILED_FETCH_RETRY_MS`. Single-use, low value.
- **110** — `db.ts:logAccess` 5-positional-param signature: Object/Builder candidate. Private method, public types unaffected; defer until next signature change.

Discovery findings that turned out **already-idiomatic** and need no work: `AuthResult.source`, `RenderState`, `SubView`, `MermaidDiagram` keyboard switch (already exhaustive), `favorites.ts` (already immutable). Most "magic literal" hits in `auth-rate-limit.ts`, `MermaidDiagram.tsx`, `constants.ts` were already named (Round 2 covered them).

### Impact (`gitnexus_detect_changes({scope:"staged"})`)

```
summary: { changed_count: 11, affected_count: 1, changed_files: 9, risk_level: "medium" }
changed_symbols: BACKLOG (Open/Done sections), Footer.BuildInfo,
  version.ts (formatBuildVersion, pad, git, fetchLatestCommit, checkVersion)
affected_processes: GET → Pad (5 steps; formatBuildVersion + pad touched)
```

Risk MEDIUM is expected: `formatBuildVersion` participates in the `/api/version` GET process. Output is byte-identical for valid build dates (the only path actually reached in practice — `loadBuildInfo()` falls back to `new Date().toISOString()`), and the unreachable null branch coalesces to `'unknown'` to keep the public `VersionInfo.current.version: string` type stable.

### Behavior invariance

- Existing 50 tests **unchanged** (no test adapted to make a refactor pass).
- New characterization tests: 4 for `formatBuildVersion`, 3 for the rest of `format.ts`, 9 for `version-diff-utils`. Total 66/66 passing.
- Server-side `formatBuildVersion` callers coalesce `null` → `'unknown'` to preserve the public `version: string` API contract; the null branch is unreachable in practice (`buildInfo.buildDate` already falls back to a valid ISO string).

### Quality gate

- typecheck: ok
- test: 66/66 ok
- build: ok
- lint: not configured in this project

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)