### PR TITLE
chore(deps): ignore eslint major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
     groups:
       minor-and-patch:
         applies-to: version-updates
@@ -20,6 +23,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
     groups:
       minor-and-patch:
         applies-to: version-updates


### PR DESCRIPTION
Prophylaktisch: ESLint 10 brach in den Schwester-Repos die Plugin-Chain. Auch wenn dieses Repo aktuell keinen direkten eslint nutzt — Ignore vereinheitlicht die dependabot-Configs fleet-weit (gilt für beide npm-Verzeichnisse: `/` und `/server`).

---
_Generated by [Claude Code](https://claude.ai/code/session_019uYsxPAYctqm3sX1RGW1HX)_