### PR TITLE
chore(dependabot): ignore electron major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     ignore:
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "electron"
+        update-types: ["version-update:semver-major"]
     groups:
       minor-and-patch:
         applies-to: version-updates
@@ -25,6 +27,8 @@ updates:
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "electron"
         update-types: ["version-update:semver-major"]
     groups:
       minor-and-patch:


### PR DESCRIPTION
Add `electron` to the dependabot ignore list (`version-update:semver-major`) in both `/` and `/server` npm sections.

Electron v42 brings breaking changes (macOS notifications API, removed postinstall download, offscreen rendering defaults, removed `quotas` option). Keeping major bumps out of auto-merge until a coordinated migration.

`eslint` major was already ignored — same treatment for `electron`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xupk85ALQ9jRbELni36GPy)_