### PR TITLE
chore: quality & housekeeping sweep 2026-05-17

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,17 +75,17 @@ When a session begins, read in this order. Stop early if a file is missing.
 
 | Component | Technology | Version |
 |-----------|-----------|---------|
-| Language | TypeScript (strict mode) | 5.7 |
+| Language | TypeScript (strict mode) | 6 |
 | Framework | Next.js (App Router) | 16 |
 | Frontend | React | 19 |
 | Database | SQLite (better-sqlite3) | 12 |
 | MCP Server | @modelcontextprotocol/sdk | 1.27 |
 | Validation | Zod | 3.24 |
 | Code Editor | react-simple-code-editor, PrismJS | 0.14, 1.30 |
-| Markdown Rendering | marked | 17 |
+| Markdown Rendering | marked | 18 |
 | Diagram Rendering | mermaid (lazy-loaded) | 11 |
-| Diagram Viewer (zoom/pan) | react-zoom-pan-pinch | 3.7 |
-| Text Diffing | diff (jsdiff) | 8 |
+| Diagram Viewer (zoom/pan) | react-zoom-pan-pinch | 4 |
+| Text Diffing | diff (jsdiff) | 9 |
 | Module System | ESM (`"type": "module"`) | -- |
 | Containerization | Docker (multi-stage, standalone output) | -- |
 | CI/CD | GitHub Actions -> GHCR | -- |

--- a/agent_docs/hooks_catalog.md
+++ b/agent_docs/hooks_catalog.md
@@ -100,7 +100,7 @@ Trigger: `Stop`
   ]
 }
 ```
-Trigger: `PreToolUse`. Project commands inserted from CLAUDE.md (no linter / test framework configured yet).
+Trigger: `PreToolUse`. Project commands inserted from CLAUDE.md (no linter configured yet; test framework is vitest -- `npm test`).
 
 ### Block force-push without confirmation
 

--- a/agent_docs/project-structure.md
+++ b/agent_docs/project-structure.md
@@ -81,6 +81,9 @@ clawstash/
 │   │       └── mcp-tools/route.ts      # GET MCP tool summaries
 │   ├── server/                 # Server-side logic (used by API route handlers)
 │   │   ├── db.ts               # SQLite database layer (ClawStashDB class)
+│   │   ├── db-schema.ts        # SQLite table / index definitions
+│   │   ├── db-migrations.ts    # Schema migrations runner
+│   │   ├── db-types.ts         # Shared DB row / domain types
 │   │   ├── singleton.ts        # DB singleton with globalThis for HMR protection
 │   │   ├── auth.ts             # Auth utility (token extraction, validation, scope checking)
 │   │   ├── auth-rate-limit.ts  # In-memory per-IP rate limiter (login, token-validate, session)
@@ -92,7 +95,13 @@ clawstash/
 │   │   ├── mcp.ts              # MCP server stdio transport entry point
 │   │   ├── openapi.ts          # OpenAPI 3.0 schema generator
 │   │   ├── validation.ts       # Zod schemas for API input validation + size limits
-│   │   └── version.ts          # Version check utility (build info + GitHub latest commit)
+│   │   ├── version.ts          # Version check utility (build info + GitHub latest commit)
+│   │   ├── stores/             # Persistence stores split out from db.ts
+│   │   │   ├── _token-hash.ts  # Shared token hashing helper
+│   │   │   ├── session-store.ts # Admin session CRUD
+│   │   │   ├── token-store.ts  # API token CRUD
+│   │   │   └── __tests__/      # Store unit tests (vitest)
+│   │   └── __tests__/          # Server unit tests (vitest, e.g. mcp-spec)
 │   ├── App.tsx                 # Main app component, state management
 │   ├── api.ts                  # API client (fetch wrapper)
 │   ├── types.ts                # Shared TypeScript interfaces
@@ -102,9 +111,13 @@ clawstash/
 │   │   └── useClickOutside.ts  # Click-outside detection hook (used by Sidebar, TagCombobox, MetadataEditor)
 │   ├── utils/
 │   │   ├── clipboard.ts        # Copy-to-clipboard with fallback for non-HTTPS
+│   │   ├── constants.ts        # Shared client/server constants
+│   │   ├── favorites.ts        # Favorite-stash localStorage helpers
 │   │   ├── format.ts           # Date formatting (formatDate, formatDateTime, formatRelativeTime)
+│   │   ├── html.ts             # HTML sanitization helpers
 │   │   ├── markdown.ts         # Markdown rendering for descriptions (Marked + sanitization)
-│   │   └── mermaid.ts          # Lazy-loaded Mermaid renderer (shared util for .mmd files + inline ```mermaid blocks)
+│   │   ├── mermaid.ts          # Lazy-loaded Mermaid renderer (shared util for .mmd files + inline ```mermaid blocks)
+│   │   └── __tests__/          # Util unit tests (vitest: favorites, format, html)
 │   ├── components/
 │   │   ├── Sidebar.tsx         # Left sidebar with search, tag filter, stash list, settings nav
 │   │   ├── Footer.tsx          # App footer with version (fetched from /api/version), build info toggle
@@ -115,6 +128,8 @@ clawstash/
 │   │   ├── StashGraphCanvas.tsx # Stash graph canvas component
 │   │   ├── VersionHistory.tsx  # Version history list, Confluence-style inline comparison radios, restore button
 │   │   ├── VersionDiff.tsx     # GitHub-style diff view (green/red) using jsdiff
+│   │   ├── version-diff-utils.ts # Pure diff utilities extracted from VersionDiff (unit-tested)
+│   │   ├── __tests__/          # Component unit tests (vitest: version-diff-utils)
 │   │   ├── SearchOverlay.tsx   # Alt+K quick search overlay with keyboard navigation
 │   │   ├── LoginScreen.tsx     # Password login gate
 │   │   ├── MermaidDiagram.tsx  # React wrapper around renderMermaid() for .mmd files

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,12 +31,10 @@
         "@types/adm-zip": "^0.5.8",
         "@types/archiver": "^7.0.0",
         "@types/better-sqlite3": "^7.6.12",
-        "@types/diff": "^8.0.0",
         "@types/node": "^25.8.0",
         "@types/prismjs": "^1.26.6",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.0.0",
-        "@types/uuid": "^11.0.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.6"
       }
@@ -1927,17 +1925,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/diff": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-8.0.0.tgz",
-      "integrity": "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw==",
-      "deprecated": "This is a stub types definition. diff provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "diff": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2004,17 +1991,6 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "*"
-      }
     },
     "node_modules/@upsetjs/venn.js": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -47,12 +47,10 @@
     "@types/adm-zip": "^0.5.8",
     "@types/archiver": "^7.0.0",
     "@types/better-sqlite3": "^7.6.12",
-    "@types/diff": "^8.0.0",
     "@types/node": "^25.8.0",
     "@types/prismjs": "^1.26.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.0.0",
-    "@types/uuid": "^11.0.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   }


### PR DESCRIPTION
Automated quality & housekeeping sweep. Closes #154.

## Changes (4 commits)

1. `chore(deps)`: remove deprecated `@types/diff` and `@types/uuid` stub packages -- both packages ship own types now.
2. `chore(docs)`: sync Tech Stack table versions in `CLAUDE.md` with `package.json` (TS 6, marked 18, react-zoom-pan-pinch 4, diff 9).
3. `chore(docs)`: add missing files/dirs to `agent_docs/project-structure.md` (stores/, db-schema/types/migrations, new utils, test dirs, version-diff-utils).
4. `chore(docs)`: correct stale "no test framework" claim in `agent_docs/hooks_catalog.md` -- vitest IS configured.

## Verification
- `npx tsc --noEmit` -> exit 0
- `npm test` -> 7 files, 66/66 tests passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9CNLeHa9BiJcK6UXdG9bt)_