### PR TITLE
chore(docs): align Node version references with Dockerfile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,7 +296,7 @@ npx gitnexus analyze
 - The SQLite database auto-creates in the `data/` directory on first run
 - DB singleton uses `globalThis` to survive Next.js HMR reloads in development
 - MCP is available as Streamable HTTP at `/mcp` (Next.js route handler) and as stdio via `npm run mcp`
-- Docker uses multi-stage build with Node 22-slim; requires python3/make/g++ for better-sqlite3 native addon compilation
+- Docker uses multi-stage build with Node 26-slim; requires python3/make/g++ for better-sqlite3 native addon compilation
 - Docker volume maps to `/app/data` for database persistence
 - CI/CD pipeline: type-check -> (optional lint) -> (optional test) -> build -> Docker push to GHCR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to ClawStash! Here's how to get started
 
 ## Development Setup
 
-**Prerequisites:** Node.js 22+ (project pins Node 22 LTS in CI and Docker; `better-sqlite3` 12.x requires ≥ 20)
+**Prerequisites:** Node.js 26+ (project pins Node 26 in Docker; `better-sqlite3` 12.x requires ≥ 20)
 
 ```bash
 git clone https://github.com/fo0/clawstash.git

--- a/agent_docs/project-structure.md
+++ b/agent_docs/project-structure.md
@@ -7,7 +7,7 @@ clawstash/
 ├── package.json                # Dependencies and scripts
 ├── tsconfig.json               # TypeScript config (strict, ES2022, Next.js plugin, @/* path alias)
 ├── next.config.ts              # Next.js config (standalone output, better-sqlite3 external)
-├── Dockerfile                  # Multi-stage Docker build (Node 22-slim, Next.js standalone)
+├── Dockerfile                  # Multi-stage Docker build (Node 26-slim, Next.js standalone)
 ├── docker-compose.yml          # Docker Compose deployment
 ├── .env.example                # Environment variables template
 ├── BACKLOG.md                  # Deferred review findings tracker

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,7 +57,7 @@ docker run -p 3000:3000 \
 
 ## Node.js (without Docker)
 
-**Prerequisites:** Node.js 22+ (project pins Node 22 LTS in CI and Docker; `better-sqlite3` 12.x requires ≥ 20)
+**Prerequisites:** Node.js 26+ (project pins Node 26 in Docker; `better-sqlite3` 12.x requires ≥ 20)
 
 ### Development
 
@@ -109,7 +109,7 @@ Triggers on push to `main`/`master` and manual dispatch.
 ## Architecture Notes
 
 - Next.js standalone output mode for minimal Docker images
-- Multi-stage Docker build with Node 22-slim
+- Multi-stage Docker build with Node 26-slim
 - `better-sqlite3` requires native compilation (python3/make/g++ in build stage)
 - Single process serves frontend + API + MCP endpoint
 - SQLite WAL mode for concurrent read performance


### PR DESCRIPTION
## Summary

Dockerfile builds with `node:26-slim` but four docs still claimed Node 22 (follow-up to PR #155).

Aligned to build reality (Dockerfile = truth, since no `.nvmrc` and no `engines.node` in `package.json`):

| File | Change |
|------|--------|
| `CLAUDE.md` | `Node 22-slim` → `Node 26-slim` (Development Notes) |
| `agent_docs/project-structure.md` | Dockerfile comment `Node 22-slim` → `Node 26-slim` |
| `CONTRIBUTING.md` | Prerequisites: `Node.js 22+` / `Node 22 LTS` → `Node.js 26+` / `Node 26` |
| `docs/deployment.md` | Prerequisites + Architecture Notes: `Node 22` → `Node 26` |

## Not touched (intentional)

- `BACKLOG.md:12` — historical record of a Dependabot PR review (Accepted entry from 2026-02-15)
- `docs/api-reference.md:92` — JSON response example for `/api/files`, not a version claim

## Known follow-up (not in this PR)

- `.github/workflows/docker-publish.yml:25` still pins `node-version: "22"` for CI (type-check + build). Diverges from Docker build image. Tracked separately — code change, not docs.

## Test plan

- [x] `grep -n "Node 22\|node 22\|node:22" CLAUDE.md CONTRIBUTING.md agent_docs/project-structure.md docs/deployment.md` returns empty
- [x] Docs-only change, no code/tests/CI affected

https://claude.ai/code/session_01S9CNLeHa9BiJcK6UXdG9bt

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9CNLeHa9BiJcK6UXdG9bt)_