### PR TITLE
chore(ci): align docker-publish.yml Node version with Dockerfile

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "26"
           cache: "npm"
 
       - name: Install Dependencies


### PR DESCRIPTION
## Summary
- Align workflow's `check-code` job to Node 26, matching `Dockerfile` (`node:26-slim`)
- Closes the CI-vs-container divergence flagged after #156 (which only aligned docs)

## Why
The Docker image is built on Node 26, but the upstream `check-code` job (type-check, lint, build) was pinned to Node 26 only in the container — the workflow setup-node step still used `"22"`. Result: code could pass CI on Node 22 and then fail at runtime on Node 26 (or vice versa for native deps like `better-sqlite3`).

## Test plan
- [x] Workflow YAML syntax unchanged structurally; single value change `"22"` → `"26"`
- [ ] Trigger `workflow_dispatch` on main after merge to verify the build still passes on Node 26

https://claude.ai/code/session_01S9CNLeHa9BiJcK6UXdG9bt

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9CNLeHa9BiJcK6UXdG9bt)_