### PR TITLE
chore: Prettier follow-up — git blame ignore + CI format:check

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Prettier baseline reformat — see PR #158
+efc1c31434458eb5c1ee15a0f73ff381c88b712e

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Run Format Check
+        run: npm run format:check
+
       - name: Run Type Check
         run: npx tsc --noEmit
 


### PR DESCRIPTION
## Summary

Two small follow-ups after the Prettier rollout in #158:

- Add `.git-blame-ignore-revs` pointing to the baseline reformat commit (`efc1c31`) so `git blame` skips the noise.
- Add a `npm run format:check` step in `.github/workflows/docker-publish.yml`, placed directly before the Type Check step, to enforce formatting in CI.

## Test plan

- [ ] CI job `check-code` runs `format:check` successfully
- [ ] `git blame` on reformatted files ignores `efc1c31` when `blame.ignoreRevsFile` is honored

https://claude.ai/code/session_01S9CNLeHa9BiJcK6UXdG9bt

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9CNLeHa9BiJcK6UXdG9bt)_