### PR TITLE
test(db): safety-net coverage before VersionStore/SearchStore split (#144)

### DIFF
--- a/src/server/__tests__/db-search.test.ts
+++ b/src/server/__tests__/db-search.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ClawStashDB } from '../db';
+
+/**
+ * Characterization tests for searchStashes / FTS5 / LIKE fallback (refs #144).
+ *
+ * Written before the SearchStore split so the upcoming refactor cannot
+ * regress:
+ *
+ * - FTS5 MATCH path with BM25 ranking (`relevance > 0`)
+ * - Prefix match (`pyth` -> `python`)
+ * - Special-character handling (no throw)
+ * - LIKE-fallback path when buildFtsQuery returns an empty string
+ * - Filter combinations (tag, archived)
+ */
+function makeDb(): ClawStashDB {
+  return new ClawStashDB(':memory:');
+}
+
+describe('ClawStashDB searchStashes', () => {
+  let db: ClawStashDB;
+
+  beforeEach(() => {
+    db = makeDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe('FTS5 BM25 path', () => {
+    it('finds a stash by exact word match in name', () => {
+      db.createStash({
+        name: 'kubernetes-pod-spec',
+        files: [{ filename: 'pod.yaml', content: 'kind: Pod' }],
+      });
+      db.createStash({
+        name: 'unrelated',
+        files: [{ filename: 'x.txt', content: 'lorem ipsum' }],
+      });
+      const r = db.searchStashes('kubernetes');
+      expect(r.total).toBeGreaterThanOrEqual(1);
+      expect(r.stashes.some((s) => s.name === 'kubernetes-pod-spec')).toBe(true);
+    });
+
+    it('finds a stash by word match in file content', () => {
+      db.createStash({
+        name: 'silent',
+        files: [{ filename: 'src.py', content: 'def hardcore_search(): return 42' }],
+      });
+      const r = db.searchStashes('hardcore');
+      expect(r.total).toBeGreaterThanOrEqual(1);
+      expect(r.stashes.some((s) => s.name === 'silent')).toBe(true);
+    });
+
+    it('supports prefix matching (2+ char prefix gets a star)', () => {
+      db.createStash({
+        name: 'python-notes',
+        files: [{ filename: 'a.py', content: 'print()' }],
+      });
+      const r = db.searchStashes('pyth');
+      expect(r.total).toBeGreaterThanOrEqual(1);
+      expect(r.stashes.some((s) => s.name === 'python-notes')).toBe(true);
+    });
+
+    it('returns relevance scores on hits', () => {
+      db.createStash({
+        name: 'rocket science',
+        description: 'about rockets',
+        files: [{ filename: 'a.txt', content: 'rockets are cool' }],
+      });
+      const r = db.searchStashes('rocket');
+      expect(r.stashes.length).toBeGreaterThan(0);
+      // FTS5 BM25 returns negative ranks; the DB layer applies Math.abs
+      expect(r.stashes[0].relevance).toBeGreaterThan(0);
+    });
+
+    it('ranks tighter matches higher than looser ones', () => {
+      db.createStash({
+        name: 'unrelated',
+        description: 'random',
+        files: [{ filename: 'a.txt', content: 'a passing mention of kubernetes here' }],
+      });
+      db.createStash({
+        name: 'kubernetes deep dive',
+        description: 'all about kubernetes',
+        files: [
+          { filename: 'k.md', content: 'kubernetes kubernetes kubernetes deployment manifest' },
+        ],
+      });
+      const r = db.searchStashes('kubernetes');
+      expect(r.stashes.length).toBe(2);
+      // first hit should be the deep dive (more matches in indexed columns)
+      expect(r.stashes[0].name).toBe('kubernetes deep dive');
+      expect(r.stashes[0].relevance).toBeGreaterThan(r.stashes[1].relevance);
+    });
+
+    it('returns empty result for empty query (buildFtsQuery returns "")', () => {
+      db.createStash({
+        name: 'whatever',
+        files: [{ filename: 'a.txt', content: 'x' }],
+      });
+      const r = db.searchStashes('');
+      expect(r).toEqual({ stashes: [], total: 0, query: '' });
+    });
+
+    it('returns empty result for query made entirely of FTS-special chars', () => {
+      db.createStash({
+        name: 'whatever',
+        files: [{ filename: 'a.txt', content: 'x' }],
+      });
+      // All chars stripped by buildFtsQuery sanitizer
+      const r = db.searchStashes('()+-*"');
+      expect(r.total).toBe(0);
+      expect(r.stashes).toEqual([]);
+    });
+
+    it('strips FTS5 operator characters from the query without throwing', () => {
+      db.createStash({
+        name: 'specialchars',
+        files: [{ filename: 'a.txt', content: 'searchable content here' }],
+      });
+      // Operators / quotes / NOT / parens inside the query — the sanitizer
+      // strips them so FTS5 MATCH never sees a malformed expression. The
+      // sanitizer must not throw or return malformed SQL — `total` may be
+      // 0 because FTS5 implicit-AND requires every cleaned token to match.
+      expect(() => {
+        db.searchStashes('"" + () - * ^ ~');
+      }).not.toThrow();
+      // A query with only operators yields an empty cleaned-query and
+      // therefore an empty result set (not a thrown error).
+      const r = db.searchStashes('"" + () - * ^ ~');
+      expect(r.total).toBe(0);
+    });
+
+    it('respects tag filter', () => {
+      db.createStash({
+        name: 'a',
+        tags: ['keep'],
+        files: [{ filename: 'a.txt', content: 'match' }],
+      });
+      db.createStash({
+        name: 'b',
+        tags: ['skip'],
+        files: [{ filename: 'b.txt', content: 'match' }],
+      });
+      const r = db.searchStashes('match', { tag: 'keep' });
+      expect(r.total).toBe(1);
+      expect(r.stashes[0].name).toBe('a');
+    });
+
+    it('respects archived filter', () => {
+      const a = db.createStash({
+        name: 'live',
+        files: [{ filename: 'a.txt', content: 'sharedword' }],
+      });
+      const b = db.createStash({
+        name: 'archived',
+        files: [{ filename: 'b.txt', content: 'sharedword' }],
+      });
+      db.archiveStash(b.id, true);
+
+      const onlyLive = db.searchStashes('sharedword', { archived: false });
+      expect(onlyLive.total).toBe(1);
+      expect(onlyLive.stashes[0].id).toBe(a.id);
+
+      const onlyArchived = db.searchStashes('sharedword', { archived: true });
+      expect(onlyArchived.total).toBe(1);
+      expect(onlyArchived.stashes[0].id).toBe(b.id);
+    });
+
+    it('does not include the FTS sentinel U+E000 / U+E001 in snippets', () => {
+      db.createStash({
+        name: 'snippety',
+        files: [{ filename: 'a.txt', content: 'the rocket flew far and fast' }],
+      });
+      const r = db.searchStashes('rocket');
+      const json = JSON.stringify(r.stashes);
+      // Public marker
+      expect(json).toContain('**');
+      // Private-use sentinels must never leak
+      expect(json).not.toContain('');
+      expect(json).not.toContain('');
+    });
+  });
+
+  describe('pagination', () => {
+    it('clamps invalid page/limit values to safe defaults', () => {
+      db.createStash({
+        name: 'paginated',
+        files: [{ filename: 'a.txt', content: 'paginated content' }],
+      });
+      // Negative + zero should NOT throw an OFFSET error
+      const r1 = db.searchStashes('paginated', { page: 0, limit: 0 });
+      expect(r1.total).toBeGreaterThanOrEqual(1);
+      const r2 = db.searchStashes('paginated', { page: -3, limit: -7 });
+      expect(r2.total).toBeGreaterThanOrEqual(1);
+    });
+
+    it('honours limit', () => {
+      for (let i = 0; i < 5; i++) {
+        db.createStash({
+          name: `multi-${i}`,
+          files: [{ filename: 'a.txt', content: 'manymatches' }],
+        });
+      }
+      const r = db.searchStashes('manymatches', { limit: 2 });
+      expect(r.stashes).toHaveLength(2);
+      expect(r.total).toBe(5);
+    });
+  });
+
+  describe('buildFtsQuery escape behaviour', () => {
+    // buildFtsQuery is private — we exercise it via searchStashes outcomes.
+    it('drops 1-char tokens from prefix expansion to avoid expensive scans', () => {
+      db.createStash({
+        name: 'apple banana',
+        files: [{ filename: 'a.txt', content: 'apple banana' }],
+      });
+      // The 'a' token cannot be 'a*' (would match everything); the longer
+      // 'banana' token still matches.
+      const r = db.searchStashes('a banana');
+      expect(r.total).toBeGreaterThanOrEqual(1);
+    });
+
+    it('rejects queries with more than 50 tokens by returning empty', () => {
+      db.createStash({
+        name: 'tokenized',
+        files: [{ filename: 'a.txt', content: 'tokenized content' }],
+      });
+      const many = Array.from({ length: 60 }, (_, i) => `tok${i}`).join(' ');
+      const r = db.searchStashes(many);
+      expect(r).toEqual({ stashes: [], total: 0, query: many });
+    });
+
+    it('rejects queries longer than 2000 chars by returning empty', () => {
+      const longQuery = 'a'.repeat(2001);
+      const r = db.searchStashes(longQuery);
+      expect(r).toEqual({ stashes: [], total: 0, query: longQuery });
+    });
+  });
+});

--- a/src/server/__tests__/db-stash.test.ts
+++ b/src/server/__tests__/db-stash.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { ClawStashDB } from '../db';
+
+/**
+ * Characterization tests for stash CRUD + FTS sync (refs #144).
+ *
+ * Written as a safety net BEFORE the VersionStore / SearchStore split so
+ * any regression in:
+ *
+ * - row insertion / deletion
+ * - file storage (multi-file, sort_order)
+ * - FTS index synchronization
+ * - cascade behaviour
+ *
+ * shows up immediately after the refactor. The tests use an in-memory
+ * SQLite path so they are deterministic and zero-cost (no fs writes).
+ */
+function makeDb(): ClawStashDB {
+  // ClawStashDB resolves dbPath via better-sqlite3 directly when given
+  // ':memory:'. `path.dirname(':memory:')` is '.', so the mkdir guard
+  // is a no-op for the cwd.
+  return new ClawStashDB(':memory:');
+}
+
+function ftsCount(db: ClawStashDB, stashId: string): number {
+  const inner = (db as unknown as { db: Database.Database }).db;
+  return (
+    inner.prepare('SELECT COUNT(*) AS c FROM stashes_fts WHERE stash_id = ?').get(stashId) as {
+      c: number;
+    }
+  ).c;
+}
+
+function ftsRow(
+  db: ClawStashDB,
+  stashId: string,
+): { name: string; description: string; tags: string; filenames: string; file_content: string } {
+  const inner = (db as unknown as { db: Database.Database }).db;
+  return inner
+    .prepare(
+      'SELECT name, description, tags, filenames, file_content FROM stashes_fts WHERE stash_id = ?',
+    )
+    .get(stashId) as {
+    name: string;
+    description: string;
+    tags: string;
+    filenames: string;
+    file_content: string;
+  };
+}
+
+describe('ClawStashDB stash CRUD + FTS sync', () => {
+  let db: ClawStashDB;
+
+  beforeEach(() => {
+    db = makeDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe('createStash', () => {
+    it('persists row with provided metadata', () => {
+      const s = db.createStash({
+        name: 'Hello',
+        description: 'desc',
+        tags: ['t1', 't2'],
+        metadata: { foo: 'bar' },
+        files: [{ filename: 'a.md', content: 'aaa' }],
+      });
+      const fetched = db.getStash(s.id);
+      expect(fetched).not.toBeNull();
+      expect(fetched!.name).toBe('Hello');
+      expect(fetched!.description).toBe('desc');
+      expect(fetched!.tags).toEqual(['t1', 't2']);
+      expect(fetched!.metadata).toEqual({ foo: 'bar' });
+      expect(fetched!.version).toBe(1);
+      expect(fetched!.files).toHaveLength(1);
+      expect(fetched!.files[0].filename).toBe('a.md');
+      expect(fetched!.files[0].content).toBe('aaa');
+    });
+
+    it('inserts one FTS row per stash containing name/description/tags/files', () => {
+      const s = db.createStash({
+        name: 'Searchable Title',
+        description: 'rocket-science notes',
+        tags: ['python', 'ml'],
+        files: [
+          { filename: 'main.py', content: 'def neural(): pass' },
+          { filename: 'README.md', content: 'docs' },
+        ],
+      });
+      expect(ftsCount(db, s.id)).toBe(1);
+      const fts = ftsRow(db, s.id);
+      expect(fts.name).toBe('Searchable Title');
+      expect(fts.description).toBe('rocket-science notes');
+      expect(fts.tags).toBe('python ml');
+      expect(fts.filenames).toContain('main.py');
+      expect(fts.filenames).toContain('README.md');
+      expect(fts.file_content).toContain('def neural()');
+      expect(fts.file_content).toContain('docs');
+    });
+
+    it('preserves file sort_order based on input array index', () => {
+      const s = db.createStash({
+        name: 'order-test',
+        files: [
+          { filename: 'b.txt', content: '2' },
+          { filename: 'a.txt', content: '1' },
+          { filename: 'c.txt', content: '3' },
+        ],
+      });
+      const fetched = db.getStash(s.id)!;
+      expect(fetched.files.map((f) => f.filename)).toEqual(['b.txt', 'a.txt', 'c.txt']);
+      expect(fetched.files.map((f) => f.sort_order)).toEqual([0, 1, 2]);
+    });
+
+    it('records the initial version (v1) automatically', () => {
+      const s = db.createStash({ name: 'v1', files: [{ filename: 'x.txt', content: 'x' }] });
+      const versions = db.getStashVersions(s.id);
+      // Either one stored v1 OR a "current-" pseudo-entry plus stored v1;
+      // we require that at least one v1 record exists.
+      const v1 = versions.find((v) => v.version === 1);
+      expect(v1).toBeTruthy();
+      expect(v1!.name).toBe('v1');
+    });
+  });
+
+  describe('updateStash', () => {
+    it('updates name + content and syncs FTS', () => {
+      const s = db.createStash({
+        name: 'old',
+        files: [{ filename: 'f.txt', content: 'old-content' }],
+      });
+      const updated = db.updateStash(s.id, {
+        name: 'new',
+        files: [{ filename: 'f.txt', content: 'new-content' }],
+      });
+      expect(updated!.name).toBe('new');
+      expect(updated!.version).toBe(2);
+      expect(updated!.files[0].content).toBe('new-content');
+
+      const fts = ftsRow(db, s.id);
+      expect(fts.name).toBe('new');
+      expect(fts.file_content).toContain('new-content');
+      expect(fts.file_content).not.toContain('old-content');
+    });
+
+    it('returns null when stash does not exist', () => {
+      expect(db.updateStash('does-not-exist', { name: 'x' })).toBeNull();
+    });
+
+    it('preserves unrelated fields on partial update', () => {
+      const s = db.createStash({
+        name: 'n',
+        description: 'd',
+        tags: ['k'],
+        files: [{ filename: 'x.md', content: 'hi' }],
+      });
+      const updated = db.updateStash(s.id, { name: 'n2' });
+      expect(updated!.name).toBe('n2');
+      expect(updated!.description).toBe('d');
+      expect(updated!.tags).toEqual(['k']);
+      expect(updated!.files[0].content).toBe('hi');
+    });
+
+    it('snapshots previous state into stash_versions before applying', () => {
+      const s = db.createStash({
+        name: 'pre',
+        files: [{ filename: 'f.txt', content: 'one' }],
+      });
+      db.updateStash(s.id, { name: 'post', files: [{ filename: 'f.txt', content: 'two' }] });
+      const v1 = db.getStashVersion(s.id, 1);
+      expect(v1).not.toBeNull();
+      expect(v1!.name).toBe('pre');
+      expect(v1!.files[0].content).toBe('one');
+    });
+  });
+
+  describe('deleteStash', () => {
+    it('removes the row and the FTS entry', () => {
+      const s = db.createStash({
+        name: 'doomed',
+        files: [{ filename: 'x.txt', content: 'bye' }],
+      });
+      expect(ftsCount(db, s.id)).toBe(1);
+      expect(db.deleteStash(s.id)).toBe(true);
+      expect(db.getStash(s.id)).toBeNull();
+      expect(ftsCount(db, s.id)).toBe(0);
+    });
+
+    it('returns false for unknown stash id', () => {
+      expect(db.deleteStash('nope')).toBe(false);
+    });
+
+    it('cascades to stash_files (FK ON DELETE CASCADE)', () => {
+      const s = db.createStash({
+        name: 'parent',
+        files: [
+          { filename: 'a.txt', content: 'a' },
+          { filename: 'b.txt', content: 'b' },
+        ],
+      });
+      const inner = (db as unknown as { db: Database.Database }).db;
+      const beforeFiles = (
+        inner.prepare('SELECT COUNT(*) AS c FROM stash_files WHERE stash_id = ?').get(s.id) as {
+          c: number;
+        }
+      ).c;
+      expect(beforeFiles).toBe(2);
+      db.deleteStash(s.id);
+      const afterFiles = (
+        inner.prepare('SELECT COUNT(*) AS c FROM stash_files WHERE stash_id = ?').get(s.id) as {
+          c: number;
+        }
+      ).c;
+      expect(afterFiles).toBe(0);
+    });
+
+    it('cascades to stash_versions and stash_version_files', () => {
+      const s = db.createStash({
+        name: 'parent',
+        files: [{ filename: 'a.txt', content: 'a' }],
+      });
+      // Force an extra version
+      db.updateStash(s.id, { name: 'parent2' });
+
+      const inner = (db as unknown as { db: Database.Database }).db;
+      const versionsBefore = (
+        inner.prepare('SELECT COUNT(*) AS c FROM stash_versions WHERE stash_id = ?').get(s.id) as {
+          c: number;
+        }
+      ).c;
+      expect(versionsBefore).toBeGreaterThanOrEqual(1);
+
+      db.deleteStash(s.id);
+      const versionsAfter = (
+        inner.prepare('SELECT COUNT(*) AS c FROM stash_versions WHERE stash_id = ?').get(s.id) as {
+          c: number;
+        }
+      ).c;
+      expect(versionsAfter).toBe(0);
+
+      const versionFilesAfter = (
+        inner
+          .prepare(
+            'SELECT COUNT(*) AS c FROM stash_version_files WHERE version_id IN (SELECT id FROM stash_versions WHERE stash_id = ?)',
+          )
+          .get(s.id) as { c: number }
+      ).c;
+      expect(versionFilesAfter).toBe(0);
+    });
+  });
+
+  describe('stash files multi-file behaviour', () => {
+    it('replaces full file list on update when files key is provided', () => {
+      const s = db.createStash({
+        name: 'multi',
+        files: [
+          { filename: 'a.txt', content: 'a' },
+          { filename: 'b.txt', content: 'b' },
+        ],
+      });
+      const updated = db.updateStash(s.id, {
+        files: [{ filename: 'only.txt', content: 'only' }],
+      });
+      expect(updated!.files).toHaveLength(1);
+      expect(updated!.files[0].filename).toBe('only.txt');
+    });
+
+    it('keeps file list when files key is absent on update', () => {
+      const s = db.createStash({
+        name: 'keep-files',
+        files: [{ filename: 'a.txt', content: 'a' }],
+      });
+      const updated = db.updateStash(s.id, { name: 'still-here' });
+      expect(updated!.files).toHaveLength(1);
+      expect(updated!.files[0].content).toBe('a');
+    });
+  });
+});

--- a/src/server/__tests__/db-versions.test.ts
+++ b/src/server/__tests__/db-versions.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { ClawStashDB } from '../db';
+
+/**
+ * Characterization tests for version history (refs #144).
+ *
+ * Pins behaviour the upcoming VersionStore split must preserve:
+ *
+ * - getStashVersions returns DESC by version, with a "current-*" pseudo
+ *   entry for the live row when newer than the latest snapshot
+ * - getStashVersion fetches both stored snapshots and synthesises the
+ *   current row when its version is requested
+ * - restoreStashVersion applies name/description/tags/files of the chosen
+ *   version atomically (via updateStash)
+ * - cascade delete removes versions when the parent stash is deleted
+ */
+function makeDb(): ClawStashDB {
+  return new ClawStashDB(':memory:');
+}
+
+describe('ClawStashDB version history', () => {
+  let db: ClawStashDB;
+
+  beforeEach(() => {
+    db = makeDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe('getStashVersions', () => {
+    it('returns versions sorted DESC by version', () => {
+      const s = db.createStash({
+        name: 'v1',
+        files: [{ filename: 'f.txt', content: 'one' }],
+      });
+      db.updateStash(s.id, { name: 'v2' });
+      db.updateStash(s.id, { name: 'v3' });
+
+      const versions = db.getStashVersions(s.id);
+      const numbers = versions.map((v) => v.version);
+      // Strictly decreasing
+      for (let i = 1; i < numbers.length; i++) {
+        expect(numbers[i - 1]).toBeGreaterThan(numbers[i]);
+      }
+      expect(numbers[numbers.length - 1]).toBe(1);
+    });
+
+    it('includes a synthetic current-* row when the live stash is newer than the latest stored snapshot', () => {
+      const s = db.createStash({
+        name: 'first',
+        files: [{ filename: 'f.txt', content: 'x' }],
+      });
+      // Initial v1 snapshot is stored. Now update -> stash.version=2 but
+      // only v1 is in stash_versions (v2 = current live).
+      db.updateStash(s.id, { name: 'second' });
+
+      const versions = db.getStashVersions(s.id);
+      const current = versions.find((v) => v.id.startsWith('current-'));
+      // Either a 'current-' pseudo entry surfaces, OR a snapshot for the
+      // current version was created. Both satisfy the API contract.
+      const top = versions[0];
+      expect(top.version).toBeGreaterThanOrEqual(2);
+      if (current) {
+        expect(current.name).toBe('second');
+      }
+    });
+
+    it('returns empty array for unknown stash', () => {
+      expect(db.getStashVersions('nope')).toEqual([]);
+    });
+
+    it('file_count and total_size reflect stash_version_files', () => {
+      const s = db.createStash({
+        name: 'sized',
+        files: [
+          { filename: 'a.txt', content: 'AAA' }, // 3 bytes
+          { filename: 'b.txt', content: 'BBBB' }, // 4 bytes
+        ],
+      });
+      const versions = db.getStashVersions(s.id);
+      const v1 = versions.find((v) => v.version === 1)!;
+      expect(v1.file_count).toBe(2);
+      expect(v1.total_size).toBe(7);
+    });
+  });
+
+  describe('getStashVersion', () => {
+    it('fetches a stored snapshot by version number', () => {
+      const s = db.createStash({
+        name: 'name-v1',
+        description: 'desc-v1',
+        tags: ['t1'],
+        files: [{ filename: 'f.txt', content: 'content-v1' }],
+      });
+      db.updateStash(s.id, { name: 'name-v2' });
+
+      const v1 = db.getStashVersion(s.id, 1);
+      expect(v1).not.toBeNull();
+      expect(v1!.name).toBe('name-v1');
+      expect(v1!.description).toBe('desc-v1');
+      expect(v1!.tags).toEqual(['t1']);
+      expect(v1!.files).toHaveLength(1);
+      expect(v1!.files[0].content).toBe('content-v1');
+    });
+
+    it('synthesises the current version when not yet snapshotted', () => {
+      const s = db.createStash({
+        name: 'live',
+        files: [{ filename: 'f.txt', content: 'live-content' }],
+      });
+      db.updateStash(s.id, { name: 'live-2' });
+      // stash now has version=2, only v1 is snapshotted as a stored row.
+      const live = db.getStashVersion(s.id, 2);
+      expect(live).not.toBeNull();
+      expect(live!.name).toBe('live-2');
+    });
+
+    it('returns null for unknown version number', () => {
+      const s = db.createStash({
+        name: 'x',
+        files: [{ filename: 'f.txt', content: 'x' }],
+      });
+      expect(db.getStashVersion(s.id, 999)).toBeNull();
+    });
+  });
+
+  describe('restoreStashVersion', () => {
+    it('restores name, description, tags, and files of the chosen version', () => {
+      const s = db.createStash({
+        name: 'original',
+        description: 'orig-desc',
+        tags: ['t1', 't2'],
+        files: [{ filename: 'f.txt', content: 'orig' }],
+      });
+      db.updateStash(s.id, {
+        name: 'changed',
+        description: 'new-desc',
+        tags: ['other'],
+        files: [{ filename: 'f.txt', content: 'changed' }],
+      });
+
+      const restored = db.restoreStashVersion(s.id, 1);
+      expect(restored).not.toBeNull();
+      expect(restored!.name).toBe('original');
+      expect(restored!.description).toBe('orig-desc');
+      expect(restored!.tags).toEqual(['t1', 't2']);
+      expect(restored!.files[0].content).toBe('orig');
+    });
+
+    it('bumps version on restore (restore is an update)', () => {
+      const s = db.createStash({
+        name: 'a',
+        files: [{ filename: 'f.txt', content: 'a' }],
+      });
+      db.updateStash(s.id, { name: 'b' });
+      const before = db.getStash(s.id)!.version;
+      const restored = db.restoreStashVersion(s.id, 1);
+      expect(restored!.version).toBeGreaterThan(before);
+    });
+
+    it('returns null for unknown stash or unknown version', () => {
+      expect(db.restoreStashVersion('nope', 1)).toBeNull();
+      const s = db.createStash({
+        name: 'x',
+        files: [{ filename: 'f.txt', content: 'x' }],
+      });
+      expect(db.restoreStashVersion(s.id, 999)).toBeNull();
+    });
+  });
+
+  describe('cascade delete', () => {
+    it('removes stash_versions and stash_version_files when parent stash is deleted', () => {
+      const s = db.createStash({
+        name: 'p',
+        files: [{ filename: 'f.txt', content: 'x' }],
+      });
+      db.updateStash(s.id, { name: 'p2' });
+
+      const inner = (db as unknown as { db: Database.Database }).db;
+      const beforeVersions = (
+        inner.prepare('SELECT COUNT(*) AS c FROM stash_versions WHERE stash_id = ?').get(s.id) as {
+          c: number;
+        }
+      ).c;
+      expect(beforeVersions).toBeGreaterThan(0);
+
+      db.deleteStash(s.id);
+
+      const afterVersions = (
+        inner.prepare('SELECT COUNT(*) AS c FROM stash_versions WHERE stash_id = ?').get(s.id) as {
+          c: number;
+        }
+      ).c;
+      expect(afterVersions).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds three characterization test files under `src/server/__tests__/` as a safety net before extracting VersionStore + SearchStore from the 1549-LoC `src/server/db.ts` (refs #144):

- `db-stash.test.ts` — `createStash` / `updateStash` / `deleteStash`, FTS sync, multi-file ordering, cascade deletes through `stash_files` / `stash_versions` / `stash_version_files`.
- `db-versions.test.ts` — `getStashVersions` DESC ordering, synthetic `current-*` entries, `getStashVersion` stored + live fallback, `restoreStashVersion` round-trip.
- `db-search.test.ts` — FTS5 BM25 ranking, prefix matching, sentinel-leak protection, tag/archived filters, pagination clamping, token/length guards.

Tests instantiate `ClawStashDB` directly with `':memory:'` so migrations and FTS5 setup are exercised end-to-end (no extra mocking layer that could drift from production schema).

**Numbers:** 66 -> 107 tests green. No production code changed.

## Test plan
- [x] `npm test` -> 107 passed
- [x] `npx tsc --noEmit` -> clean
- [x] All three new files import `ClawStashDB` (not handwritten table stubs) so the safety net travels with future schema migrations.

https://claude.ai/code/session_01S9CNLeHa9BiJcK6UXdG9bt

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9CNLeHa9BiJcK6UXdG9bt)_