### PR TITLE
refactor: best-practice sweep (Next.js)

### DIFF
--- a/src/app/api/_helpers.ts
+++ b/src/app/api/_helpers.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/server/singleton';
 import { requireScopeAuth, requireAdminAuth, extractToken } from '@/server/auth';
+import { isTrustedProxy } from '@/server/auth-rate-limit';
 import type { TokenScope } from '@/server/db';
 
 export function checkScope(req: NextRequest, scope: TokenScope) {
@@ -55,9 +56,9 @@ export function getBaseUrl(req: NextRequest): string {
   // proxy boundary. Spoofed values flow into OpenAPI / MCP spec output (the
   // schema's `servers[].url` and example URLs) and are echoed back to clients
   // — useful for an attacker who wants to seed onboarding/spec text with a
-  // phishing host. Mirror `auth-rate-limit.ts:getClientIp`: only honour the
-  // forwarded headers when `TRUST_PROXY=1` (or =true) is explicitly set.
-  const trustProxy = process.env.TRUST_PROXY === '1' || process.env.TRUST_PROXY === 'true';
+  // phishing host. Share the `TRUST_PROXY` opt-in with `getClientIp` so the
+  // two surfaces cannot drift.
+  const trustProxy = isTrustedProxy();
   const proto = (trustProxy && req.headers.get('x-forwarded-proto')) || 'http';
   const host =
     (trustProxy && req.headers.get('x-forwarded-host')) ||

--- a/src/server/auth-rate-limit.ts
+++ b/src/server/auth-rate-limit.ts
@@ -113,8 +113,19 @@ export function resetAuthAttempts(scope: Scope, ip: string): void {
  * a shared `'unknown'` bucket let one attacker exhaust the limit and
  * lock out every legitimate admin on a default Docker deploy.
  */
+/**
+ * `TRUST_PROXY=1` / `=true` opt-in for forwarded headers. Centralised so
+ * both `getClientIp` and `getBaseUrl` (api/_helpers) share one source of
+ * truth — drift between the two surfaces would mean rate-limit IP
+ * extraction and OpenAPI `servers[].url` could disagree about whether
+ * `x-forwarded-*` is trusted.
+ */
+export function isTrustedProxy(): boolean {
+  return process.env.TRUST_PROXY === '1' || process.env.TRUST_PROXY === 'true';
+}
+
 export function getClientIp(req: NextRequest): string {
-  const trustProxy = process.env.TRUST_PROXY === '1' || process.env.TRUST_PROXY === 'true';
+  const trustProxy = isTrustedProxy();
 
   if (trustProxy) {
     const xff = req.headers.get('x-forwarded-for')?.split(',')[0].trim();

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -9,6 +9,7 @@ import { TokenStore } from './stores/token-store';
 import { SessionStore } from './stores/session-store';
 import { VersionStore } from './stores/version-store';
 import { SearchStore } from './stores/search-store';
+import { safeParseTags, safeParseMetadata, clampPagination } from './stores/_parsers';
 import type {
   Stash,
   StashFile,
@@ -101,33 +102,13 @@ export class ClawStashDB {
     applyPendingMigrations(this.db);
   }
 
-  private safeParseTags(raw: unknown): string[] {
-    if (typeof raw !== 'string') return [];
-    try {
-      const parsed = JSON.parse(raw);
-      return Array.isArray(parsed) ? parsed.filter((t) => typeof t === 'string') : [];
-    } catch {
-      return [];
-    }
-  }
-
-  private safeParseMetadata(raw: unknown): Record<string, unknown> {
-    if (typeof raw !== 'string') return {};
-    try {
-      const parsed = JSON.parse(raw);
-      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
-    } catch {
-      return {};
-    }
-  }
-
   private rowToStash(row: Record<string, unknown>): Omit<Stash, 'files'> {
     return {
       id: row.id as string,
       name: (row.name as string) || '',
       description: (row.description as string) || '',
-      tags: this.safeParseTags(row.tags),
-      metadata: this.safeParseMetadata(row.metadata),
+      tags: safeParseTags(row.tags),
+      metadata: safeParseMetadata(row.metadata),
       version: (row.version as number) || 1,
       archived: (row.archived as number) === 1,
       created_at: row.created_at as string,
@@ -140,7 +121,7 @@ export class ClawStashDB {
       id: row.id as string,
       name: (row.name as string) || '',
       description: (row.description as string) || '',
-      tags: this.safeParseTags(row.tags),
+      tags: safeParseTags(row.tags),
       version: (row.version as number) || 1,
       archived: (row.archived as number) === 1,
       created_at: row.created_at as string,
@@ -299,7 +280,7 @@ export class ClawStashDB {
     // Clamp at the DB layer so callers that bypass parsePositiveInt (MCP,
     // direct DB) cannot send `page=0`/negative/non-int and produce a
     // SQLite "OFFSET should be non-negative" error or a `LIMIT 0` page.
-    const { limit, offset } = this.clampPagination(options.page, options.limit, 50);
+    const { limit, offset } = clampPagination(options.page, options.limit, 50);
     const conditions: string[] = [];
     const params: unknown[] = [];
 
@@ -360,21 +341,6 @@ export class ClawStashDB {
 
   rebuildFtsIndex(): void {
     this.search.rebuildIndex();
-  }
-
-  // Clamp pagination params at the DB layer so callers that bypass the REST
-  // route's parsePositiveInt (MCP tool layer, direct DB consumers, future
-  // callers) can never produce SQLite OFFSET errors or empty `LIMIT 0` pages.
-  // Returns sane positive integers with the documented defaults.
-  private clampPagination(
-    page: unknown,
-    limit: unknown,
-    defaultLimit: number,
-  ): { page: number; limit: number; offset: number } {
-    const safePage = typeof page === 'number' && Number.isInteger(page) && page > 0 ? page : 1;
-    const safeLimit =
-      typeof limit === 'number' && Number.isInteger(limit) && limit > 0 ? limit : defaultLimit;
-    return { page: safePage, limit: safeLimit, offset: (safePage - 1) * safeLimit };
   }
 
   searchStashes(
@@ -527,7 +493,7 @@ export class ClawStashDB {
     const rows = this.db.prepare('SELECT tags FROM stashes').all() as { tags: string }[];
     const tagMap = new Map<string, number>();
     for (const row of rows) {
-      const tags = this.safeParseTags(row.tags);
+      const tags = safeParseTags(row.tags);
       for (const tag of tags) {
         tagMap.set(tag, (tagMap.get(tag) || 0) + 1);
       }
@@ -543,7 +509,7 @@ export class ClawStashDB {
     }[];
     const keySet = new Set<string>();
     for (const row of rows) {
-      const meta = this.safeParseMetadata(row.metadata);
+      const meta = safeParseMetadata(row.metadata);
       for (const key of Object.keys(meta)) {
         keySet.add(key);
       }
@@ -561,7 +527,7 @@ export class ClawStashDB {
     const edgeMap = new Map<string, number>();
 
     for (const row of rows) {
-      const tags = this.safeParseTags(row.tags);
+      const tags = safeParseTags(row.tags);
       for (const t of tags) {
         tagCounts.set(t, (tagCounts.get(t) || 0) + 1);
       }
@@ -673,7 +639,7 @@ export class ClawStashDB {
     `);
 
     for (const row of rows) {
-      const otherTags = this.safeParseTags(row.tags);
+      const otherTags = safeParseTags(row.tags);
       const shared = otherTags.filter((t) => tagSet.has(t));
       if (shared.length > 0) {
         const [src, tgt] = [stashId, row.id].sort();
@@ -694,7 +660,7 @@ export class ClawStashDB {
         id: string;
         tags: string;
       }[];
-      const parsed = stashes.map((s) => ({ id: s.id, tags: this.safeParseTags(s.tags) }));
+      const parsed = stashes.map((s) => ({ id: s.id, tags: safeParseTags(s.tags) }));
 
       const insert = this.db.prepare(`
         INSERT INTO stash_relations (id, source_stash_id, target_stash_id, relation_type, weight, metadata)
@@ -784,7 +750,7 @@ export class ClawStashDB {
     const stashTagMap = new Map<string, string[]>();
 
     for (const row of stashRows) {
-      const stashTags = this.safeParseTags(row.tags);
+      const stashTags = safeParseTags(row.tags);
       stashTagMap.set(row.id, stashTags);
 
       nodes.push({
@@ -845,7 +811,7 @@ export class ClawStashDB {
 
     for (const rel of relations) {
       if (stashIds.has(rel.source_stash_id) && stashIds.has(rel.target_stash_id)) {
-        const meta = this.safeParseMetadata(rel.metadata);
+        const meta = safeParseMetadata(rel.metadata);
         const sharedTags = Array.isArray(meta.shared_tags)
           ? ((meta.shared_tags as unknown[]).filter((t) => typeof t === 'string') as string[])
           : [];
@@ -909,7 +875,7 @@ export class ClawStashDB {
             version_number: v.version,
             created_by: v.created_by,
             created_at: v.created_at,
-            change_summary: this.safeParseMetadata(v.change_summary),
+            change_summary: safeParseMetadata(v.change_summary),
           });
           edges.push({
             source: vNodeId,

--- a/src/server/stores/_parsers.ts
+++ b/src/server/stores/_parsers.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared defensive parsers + pagination clamp for the stash data model.
+ *
+ * Centralised so the same contract is enforced in every store and on the
+ * main ClawStashDB facade. Corrupted JSON in tags / metadata columns must
+ * NOT throw out of an endpoint; it falls back to an empty value instead.
+ * Pagination clamping protects SQLite (negative OFFSET / LIMIT 0) when a
+ * caller bypasses the REST route's `parsePositiveInt`.
+ *
+ * Behaviour is bit-for-bit identical to the previous inlined copies in
+ * db.ts, version-store.ts, and search-store.ts.
+ */
+
+export function safeParseTags(raw: unknown): string[] {
+  if (typeof raw !== 'string') return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((t) => typeof t === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+export function safeParseMetadata(raw: unknown): Record<string, unknown> {
+  if (typeof raw !== 'string') return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Clamp pagination params at the DB layer so callers that bypass the REST
+ * route's parsePositiveInt (MCP tool layer, direct DB consumers) cannot
+ * produce SQLite OFFSET errors or empty `LIMIT 0` pages.
+ */
+export function clampPagination(
+  page: unknown,
+  limit: unknown,
+  defaultLimit: number,
+): { page: number; limit: number; offset: number } {
+  const safePage = typeof page === 'number' && Number.isInteger(page) && page > 0 ? page : 1;
+  const safeLimit =
+    typeof limit === 'number' && Number.isInteger(limit) && limit > 0 ? limit : defaultLimit;
+  return { page: safePage, limit: safeLimit, offset: (safePage - 1) * safeLimit };
+}

--- a/src/server/stores/search-store.ts
+++ b/src/server/stores/search-store.ts
@@ -6,19 +6,7 @@ import type {
   StashListItem,
   ListStashesOptions,
 } from '../db-types';
-
-// Defensive parser — duplicated from ClawStashDB so this store is
-// self-contained. Same contract: corrupted JSON in tags row must not
-// throw out of the search endpoint.
-function safeParseTags(raw: unknown): string[] {
-  if (typeof raw !== 'string') return [];
-  try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.filter((t) => typeof t === 'string') : [];
-  } catch {
-    return [];
-  }
-}
+import { safeParseTags, clampPagination } from './_parsers';
 
 function rowToListItem(row: Record<string, unknown>): Omit<StashListItem, 'files' | 'total_size'> {
   return {
@@ -43,20 +31,6 @@ const FTS_SNIPPET_CLOSE = '';
 
 function formatSnippet(raw: string): string {
   return raw.split(FTS_SNIPPET_OPEN).join('**').split(FTS_SNIPPET_CLOSE).join('**');
-}
-
-// Clamp pagination params at the DB layer so callers that bypass the
-// REST route's parsePositiveInt cannot produce SQLite OFFSET errors or
-// empty `LIMIT 0` pages.
-function clampPagination(
-  page: unknown,
-  limit: unknown,
-  defaultLimit: number,
-): { page: number; limit: number; offset: number } {
-  const safePage = typeof page === 'number' && Number.isInteger(page) && page > 0 ? page : 1;
-  const safeLimit =
-    typeof limit === 'number' && Number.isInteger(limit) && limit > 0 ? limit : defaultLimit;
-  return { page: safePage, limit: safeLimit, offset: (safePage - 1) * safeLimit };
 }
 
 /**

--- a/src/server/stores/version-store.ts
+++ b/src/server/stores/version-store.ts
@@ -7,30 +7,7 @@ import type {
   StashVersionListItem,
   UpdateStashInput,
 } from '../db-types';
-
-// Defensive parsers — duplicated from ClawStashDB (intentionally, to keep
-// this module self-contained). Both surfaces enforce the same contract:
-// corrupted JSON in tags / metadata columns must NOT throw out of the
-// version-history endpoint; it falls back to an empty value instead.
-function safeParseTags(raw: unknown): string[] {
-  if (typeof raw !== 'string') return [];
-  try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.filter((t) => typeof t === 'string') : [];
-  } catch {
-    return [];
-  }
-}
-
-function safeParseMetadata(raw: unknown): Record<string, unknown> {
-  if (typeof raw !== 'string') return {};
-  try {
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
-  } catch {
-    return {};
-  }
-}
+import { safeParseTags, safeParseMetadata } from './_parsers';
 
 /**
  * Stash version history and restore (refs #144).


### PR DESCRIPTION
Closes #166

## Summary

Two small DRY refactors on the server data layer. Both behaviour-equivalent, both verified locally.

### 1. Shared parsers + pagination clamp (`refactor(stores)`)

- New `src/server/stores/_parsers.ts` owns the canonical `safeParseTags`, `safeParseMetadata`, and `clampPagination`.
- `ClawStashDB`, `VersionStore`, and `SearchStore` now import the helpers instead of carrying their own copies.
- Private `ClawStashDB.clampPagination` and the inline `safeParse*` functions in `version-store.ts` / `search-store.ts` are removed.

### 2. `TRUST_PROXY` centralisation (`refactor(auth)`)

- New `isTrustedProxy()` helper in `auth-rate-limit.ts` exposes the `'1' || 'true'` opt-in check.
- `api/_helpers.ts:getBaseUrl()` now imports the helper, so rate-limit IP extraction and OpenAPI `servers[].url` cannot drift on a future accepted-value extension (e.g. adding `'yes'`).

## Verification

- `npx tsc --noEmit`: clean
- `npm test`: 107/107 passing (same as baseline)
- `npx next build`: green, all routes generated

## Branch convention

Agent branch `claude/eager-ptolemy-4iZWc`, conventional-commit style commits (`refactor({scope}): ...`), squash-merge per project policy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01331zQtdA4aUfZDpVwJAogH)_