### PR TITLE
ux: a11y best-practice sweep (2026-05-20)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,12 @@
 import type { Metadata, Viewport } from 'next';
 import '../styles/app.css';
 
+// Do NOT set `maximumScale` or `userScalable: false` — disabling pinch-zoom
+// fails WCAG 1.4.4 (Resize text) and harms low-vision users on mobile. The
+// layout is responsive, so the previous "lock" was cosmetic.
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
 };
 
 export const metadata: Metadata = {

--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -117,6 +117,7 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
       <div
         className="search-overlay"
         role="dialog"
+        aria-modal="true"
         aria-label="Quick search stashes"
         onMouseDown={(e) => e.stopPropagation()}
         onKeyDown={handleKeyDown}
@@ -142,18 +143,27 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
           <kbd className="search-overlay-kbd">Esc</kbd>
         </div>
 
-        {loading && query.trim() && <div className="search-overlay-status">Searching...</div>}
+        {loading && query.trim() && (
+          <div className="search-overlay-status" role="status" aria-live="polite">
+            Searching...
+          </div>
+        )}
 
         {!loading && query.trim() && results.length === 0 && (
-          <div className="search-overlay-status">No stashes found</div>
+          <div className="search-overlay-status" role="status" aria-live="polite">
+            No stashes found
+          </div>
         )}
 
         {results.length > 0 && (
-          <div className="search-overlay-results" ref={listRef}>
+          <div className="search-overlay-results" ref={listRef} role="listbox">
             {results.map((stash, idx) => (
-              <div
+              <button
+                type="button"
                 key={stash.id}
                 className={`search-overlay-item ${idx === activeIndex ? 'active' : ''}`}
+                role="option"
+                aria-selected={idx === activeIndex}
                 onMouseEnter={() => setActiveIndex(idx)}
                 onClick={() => handleSelect(stash.id)}
               >
@@ -191,7 +201,7 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
                     {formatRelativeTime(stash.updated_at)}
                   </span>
                 </div>
-              </div>
+              </button>
             ))}
           </div>
         )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -193,10 +193,16 @@ export default function Sidebar({
             </svg>
           </button>
         )}
-        <div className="sidebar-logo" onClick={onGoHome} title="Go to dashboard">
+        <button
+          type="button"
+          className="sidebar-logo"
+          onClick={onGoHome}
+          title="Go to dashboard"
+          aria-label="Go to dashboard"
+        >
           <span className="logo-icon">CS</span>
           <span className="logo-text">ClawStash</span>
-        </div>
+        </button>
         <button
           className="sidebar-graph-btn"
           onClick={onGraphView}

--- a/src/components/api/McpTab.tsx
+++ b/src/components/api/McpTab.tsx
@@ -202,7 +202,7 @@ Parameters: {
       </section>
 
       {copyNotice && (
-        <div className="api-copy-notice-toast">
+        <div className="api-copy-notice-toast" role="status" aria-live="polite">
           <CheckIcon /> {copyNotice}
         </div>
       )}

--- a/src/components/api/RestTab.tsx
+++ b/src/components/api/RestTab.tsx
@@ -188,7 +188,7 @@ print(f"Found {data['total']} stashes")`}</pre>
       </section>
 
       {copyNotice && (
-        <div className="api-copy-notice-toast">
+        <div className="api-copy-notice-toast" role="status" aria-live="polite">
           <CheckIcon /> {copyNotice}
         </div>
       )}

--- a/src/components/api/TokensTab.tsx
+++ b/src/components/api/TokensTab.tsx
@@ -318,7 +318,7 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec }: Props) {
       </section>
 
       {copyNotice && (
-        <div className="api-copy-notice-toast">
+        <div className="api-copy-notice-toast" role="status" aria-live="polite">
           <CheckIcon /> {copyNotice}
         </div>
       )}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -104,6 +104,18 @@ body {
   align-items: center;
   gap: 10px;
   cursor: pointer;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  text-align: left;
+}
+
+.sidebar-logo:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+  border-radius: var(--radius);
 }
 
 .sidebar-graph-btn {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -769,6 +769,13 @@ body {
 }
 
 .search-overlay-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
   padding: 10px 16px;
   cursor: pointer;
   transition: background 0.08s;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -798,6 +798,11 @@ body {
   background: var(--bg-tertiary);
 }
 
+.search-overlay-item:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: -2px;
+}
+
 .search-overlay-item-main {
   display: flex;
   align-items: center;
@@ -6048,5 +6053,19 @@ body {
   }
   .mermaid-fullscreen-backdrop {
     padding: 8px;
+  }
+}
+
+/* === Reduced Motion (WCAG 2.3.3 Animation from Interactions) === */
+/* Honor user OS-level "Reduce Motion" preference: collapse transitions and */
+/* animations to near-instant so vestibular-sensitive users aren't disoriented. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
Closes #168

## Summary
Five accessibility fixes from the autonomous UX sweep on 2026-05-20:

- **SearchOverlay**: list items become `<button role="option">`, dialog gets `aria-modal`, results container gets `role="listbox"` (keyboard reachable, SR-announced selection).
- **Sidebar logo**: `<div onClick>` -> `<button type="button">` with `aria-label` and focus-visible outline.
- **Copy toast** (REST / MCP / Tokens tabs): now `role="status" aria-live="polite"` so SR users hear "copied".
- **Reduced motion**: global `@media (prefers-reduced-motion: reduce)` collapses the 44+ keyframes / 52+ transitions (WCAG 2.3.3).
- **Viewport pinch-zoom**: shipped earlier in `f96d6c3` (WCAG 1.4.4).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` 107/107 passing
- [x] `npm run build` succeeds
- [x] `prettier --check` clean on touched files
- [ ] Manual: Tab through SearchOverlay results, Sidebar logo focusable
- [ ] Manual: Toggle OS "Reduce Motion" and verify overlay no longer slides


---
_Generated by [Claude Code](https://claude.ai/code/session_01NK66MhXmozBcmepTxGxogd)_