### PR TITLE
refine: ux sweep (Next.js)

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import type { StashListItem, LayoutMode } from '../types';
 import { sortStashesWithFavorites } from '../utils/favorites';
 import StashCard from './StashCard';
+import Spinner from './shared/Spinner';
 
 interface Props {
   stashes: StashListItem[];
@@ -49,6 +50,17 @@ export default function Dashboard({
           <span className="stash-count" title="Total number of stashes stored">
             {total} stashes
           </span>
+          {loading && stashes.length > 0 && (
+            <span
+              className="dashboard-refresh-indicator"
+              role="status"
+              aria-live="polite"
+              title="Refreshing stash list"
+            >
+              <Spinner size={12} />
+              <span className="sr-only">Refreshing</span>
+            </span>
+          )}
         </div>
         <div className="dashboard-actions">
           {filterTag && (
@@ -119,16 +131,23 @@ export default function Dashboard({
         </div>
       </div>
 
-      {loading ? (
-        <div className="loading">Loading stashes...</div>
-      ) : stashes.length === 0 ? (
+      {loading && stashes.length === 0 ? (
+        <div className="loading" role="status" aria-live="polite">
+          <Spinner size={18} />
+          <span style={{ marginLeft: 10 }}>Loading stashes...</span>
+        </div>
+      ) : !loading && stashes.length === 0 ? (
         <div className="empty-state">
           <div className="empty-icon">
             <svg width="36" height="36" viewBox="0 0 16 16" fill="currentColor">
               <path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2Z" />
             </svg>
           </div>
-          <p>No stashes yet. Create your first one!</p>
+          <p>
+            {filterTag || showArchived
+              ? 'No stashes match the current filter.'
+              : 'No stashes yet. Create your first one!'}
+          </p>
           <button className="btn btn-new-stash" onClick={onNewStash}>
             <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
               <path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2Z" />
@@ -137,7 +156,14 @@ export default function Dashboard({
           </button>
         </div>
       ) : (
-        <div className={`stash-grid ${layout}`}>
+        // While `loading` is true but we still have a previous result set we
+        // keep the grid visible and overlay a subtle spinner. This avoids the
+        // "flash to empty" jank every time the user toggles a tag filter or
+        // types in the sidebar search field.
+        <div
+          className={`stash-grid ${layout}${loading ? ' stash-grid-refreshing' : ''}`}
+          aria-busy={loading || undefined}
+        >
           {/*
             Keyboard-accessible "new stash" card. Was a bare <div onClick>
             previously, so keyboard-only users (and most assistive tech)

--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -3,6 +3,7 @@ import type { StashListItem } from '../types';
 import { api } from '../api';
 import { formatRelativeTime } from '../utils/format';
 import { SEARCH_DEBOUNCE_MS } from '../utils/constants';
+import Spinner from './shared/Spinner';
 
 interface Props {
   open: boolean;
@@ -145,7 +146,8 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
 
         {loading && query.trim() && (
           <div className="search-overlay-status" role="status" aria-live="polite">
-            Searching...
+            <Spinner size={14} />
+            <span style={{ marginLeft: 8 }}>Searching...</span>
           </div>
         )}
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -242,12 +242,37 @@ export default function Sidebar({
                 placeholder="Search stashes..."
                 value={search}
                 onChange={(e) => onSearch(e.target.value)}
+                // Escape clears the field instead of bubbling up to the global
+                // Escape handler that navigates away — much faster way to reset
+                // search than reaching for the mouse.
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape' && search) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onSearch('');
+                  }
+                }}
                 className="search-input"
-                title="Search by name, filename, or content — Alt+K for quick search"
+                title="Search by name, filename, or content — Esc to clear, Alt+K for quick search"
+                aria-label="Search stashes"
               />
-              <kbd className="search-input-kbd" title="Alt+K for quick search overlay">
-                Alt+K
-              </kbd>
+              {search ? (
+                <button
+                  type="button"
+                  className="search-input-clear"
+                  onClick={() => onSearch('')}
+                  title="Clear search (Esc)"
+                  aria-label="Clear search"
+                >
+                  <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+                  </svg>
+                </button>
+              ) : (
+                <kbd className="search-input-kbd" title="Alt+K for quick search overlay">
+                  Alt+K
+                </kbd>
+              )}
             </div>
           </div>
 

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -18,6 +18,7 @@ import { renderMermaid } from '../utils/mermaid';
 import { DELETE_CONFIRM_TIMEOUT_MS } from '../utils/constants';
 import { escapeHtml } from '../utils/html';
 import MermaidDiagram from './MermaidDiagram';
+import Spinner from './shared/Spinner';
 
 interface Props {
   stash: Stash;
@@ -992,7 +993,10 @@ export default function StashViewer({
             </span>
           </div>
           {logLoading ? (
-            <div className="loading">Loading access log...</div>
+            <div className="loading" role="status" aria-live="polite">
+              <Spinner size={16} />
+              <span style={{ marginLeft: 10 }}>Loading access log...</span>
+            </div>
           ) : accessLog.length === 0 ? (
             <div className="access-log-empty">
               <svg

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -205,6 +205,39 @@ body {
   pointer-events: none;
 }
 
+/* Inline clear button that replaces the Alt+K hint when the field has a
+   value — saves users a sidebar-tag-toggle round-trip just to reset search. */
+.search-input-clear {
+  position: absolute;
+  right: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    background 0.15s,
+    border-color 0.15s;
+}
+
+.search-input-clear:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.search-input-clear:focus-visible {
+  outline: none;
+  border-color: var(--accent-blue);
+  color: var(--text-primary);
+}
+
 /* Sidebar Tag Filter */
 .sidebar-tag-filter {
   position: relative;
@@ -768,8 +801,10 @@ body {
 }
 
 .search-overlay-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 20px 16px;
-  text-align: center;
   color: var(--text-muted);
   font-size: 13px;
 }
@@ -1054,6 +1089,24 @@ body {
 .stash-count {
   font-size: 14px;
   color: var(--text-muted);
+}
+
+/* Inline refresh hint — appears next to the stash count while the list
+   reloads in the background so users get a signal without losing context
+   of the (stale) grid below. Kept subtle and non-blocking. */
+.dashboard-refresh-indicator {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-muted);
+  opacity: 0.85;
+}
+
+/* Soft dim while a refresh is in-flight so the stale rows hint that newer
+   data is on the way without yanking the grid out from under the cursor. */
+.stash-grid-refreshing {
+  opacity: 0.6;
+  transition: opacity 0.15s ease-out;
+  pointer-events: none;
 }
 
 .dashboard-actions {


### PR DESCRIPTION
## Refinements
| # | Existing feature | Area/file | Category | UX gap | Improvement | Effort | Status |
|---|------------------|-----------|----------|--------|-------------|--------|--------|
| 1 | Dashboard stash listing | `src/components/Dashboard.tsx`, `src/styles/app.css` | Feedback / Rendering | Filter toggles and sidebar-search keystrokes replaced the grid with a centred "Loading stashes..." — content flashed, scroll position lost. | Keep stale grid visible with soft dim + inline spinner next to the stash count; only show the centred state on the initial empty load. Empty-state copy is filter-aware. | S | done |
| 2 | Sidebar search field | `src/components/Sidebar.tsx`, `src/styles/app.css` | Hotkey / Affordance | No clear button; Escape did nothing local and bubbled into the global back-to-home handler. | Inline clear (×) button replaces the Alt+K hint when populated; local `Escape` clears the field without propagating. | S | done |
| 3 | Loading indicators (viewer + search overlay) | `src/components/StashViewer.tsx`, `src/components/SearchOverlay.tsx`, `src/styles/app.css` | Polish / Consistency | Access-log tab and search overlay only printed text while VersionHistory / Settings / API tabs already used the shared Spinner. | Reuse the shared `Spinner` with matching `role="status" aria-live="polite"`. | S | done |

## Verification
- `npm ci` — green
- `npx tsc --noEmit` — green
- `npm test` — green (10 files, 107 tests)
- `npx next build` — green
- `npx prettier --check` on changed files — green
- `npx next lint` — not applicable in Next.js 16 (CLI removed)

Closes #170

---
_Generated by [Claude Code](https://claude.ai/code/session_018afJFgYmSNuPvPDaLaMaaK)_