### PR TITLE
chore: quality & housekeeping sweep 2026-05-23

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ When a session begins, read in this order. Stop early if a file is missing.
 | Containerization          | Docker (multi-stage, standalone output) | --         |
 | CI/CD                     | GitHub Actions -> GHCR                  | --         |
 | Package Manager           | npm (`package-lock.json`)               | --         |
-| Linter/Formatter          | -- (not configured)                     | --         |
+| Formatter                 | Prettier                                | 3.8        |
 | Test Framework            | vitest                                  | 4.x        |
 
 ## Project Structure
@@ -108,6 +108,7 @@ npm install                # Install dependencies
 npm run dev                # Start Next.js dev server (frontend + API on port 3000)
 
 # Automated Checks (in this order)
+npm run format:check       # Prettier formatting check
 npx tsc --noEmit           # Type checking
 npm test                   # Tests (vitest)
 npm run build              # Production build (Next.js)
@@ -126,10 +127,10 @@ npx gitnexus status        # Check index freshness
 npx gitnexus analyze       # Rebuild index (after structural changes or stale index)
 ```
 
-> **Note:** No linter is configured yet. When added, extend automated checks:
+> **Note:** No linter (ESLint) is configured yet. Formatting is enforced via Prettier (`npm run format:check`). When ESLint is added, extend automated checks:
 >
 > ```bash
-> npm run lint             # Lint + Format (when configured)
+> npm run lint             # Lint (when configured)
 > ```
 
 ## Key Patterns
@@ -314,8 +315,7 @@ Refactoring does NOT happen automatically. Only upon explicit user request, when
 - **`src/components/StashViewer.tsx` (~780 lines)**: Largest frontend component. File display, TOC, access log tab, and metadata display sections could be extracted into sub-components.
 - **`src/components/Settings.tsx` (~560 lines)**: Could extract Welcome Dashboard and Storage Stats sections into dedicated sub-components within a `settings/` directory.
 - **`src/languages.ts` (~340 lines)**: Extension map and content-based detection heuristics are large but stable. Low priority.
-- **No linter**: Adding ESLint would significantly improve code quality assurance.
-- **No Prettier config**: Adding Prettier would enforce consistent formatting.
+- **No linter**: Adding ESLint would significantly improve code quality assurance. (Prettier is already configured for formatting — see `.prettierrc.json`.)
 
 ## Documentation Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,12 @@ This starts the Next.js development server on port 3000 with both the frontend a
 
 1. Fork the repository and create a feature branch from `main`
 2. Make your changes
-3. Run the build to verify everything compiles: `npm run build`
-4. Commit with a clear, descriptive message
+3. Run the automated checks before pushing:
+   - `npm run format:check` — Prettier formatting
+   - `npx tsc --noEmit` — TypeScript type check
+   - `npm test` — vitest test suite
+   - `npm run build` — production build
+4. Commit with a clear, descriptive message (Conventional Commits)
 5. Open a pull request against `main`
 
 ## Project Structure
@@ -36,6 +40,7 @@ See `CLAUDE.md` for detailed architecture documentation.
 ## Code Style
 
 - TypeScript with strict mode
+- Formatting enforced by Prettier (`npm run format` to auto-fix, `npm run format:check` to verify)
 - 2-space indentation, single quotes
 - Functional React components with TypeScript interfaces for props
 - Global CSS with CSS custom properties (no CSS-in-JS)


### PR DESCRIPTION
## Summary

Quality & housekeeping sweep for 2026-05-23. Aligns documentation with the Prettier setup that was introduced in #158 (`.prettierrc.json`, `format` / `format:check` scripts, CI format check) but never propagated into `CLAUDE.md` or `CONTRIBUTING.md`.

**No version bumps.** Out of scope per routine: dependency bumps, security advisories, bot PRs.

## Findings

| # | Pass | File(s) | Finding | Fix | Effort | Status |
| - | ---- | ------- | ------- | --- | ------ | ------ |
| 1 | E (Docs) | `CLAUDE.md`, `CONTRIBUTING.md` | Stale "no linter / Prettier configured" references contradict reality (Prettier 3.8 active since #158). | Updated Tech Stack table, Automated-Checks command list, Refactoring Notes, and contributor workflow. | S | fixed |

## Tooling status

| Tool                       | Active | Ran green |
| -------------------------- | ------ | --------- |
| Prettier (`format:check`)  | yes    | yes       |
| ESLint                     | no     | n/a       |
| `tsc --noEmit`             | yes    | yes       |
| vitest (`npm test`)        | yes    | yes (10 files / 107 tests) |
| `npm run build`            | yes    | yes       |

## Test plan

- [x] `npx prettier --check .`
- [x] `npx tsc --noEmit`
- [x] `npm test`
- [x] `npm run build`

Closes #174


---
_Generated by [Claude Code](https://claude.ai/code/session_01QfYsYP7sqPHPiN4kx9NRcU)_