### PR TITLE
feat: comfort sweep 2026-05-23 — Ctrl+S save, error toasts, copy-name button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,6 +103,9 @@ export default function App() {
   // Favorite stash ids — persisted to localStorage (key `clawstash_favorite_stashes`).
   // Held as Set<string> for O(1) lookups during sort + per-card render.
   const [favoriteIds, setFavoriteIds] = useState<ReadonlySet<string>>(() => loadFavoriteIds());
+  // Global error toast for operation failures (archive, delete, select).
+  const [errorToast, setErrorToast] = useState<string | null>(null);
+  const errorToastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Global Alt+K shortcut for quick search
   useEffect(() => {
@@ -298,6 +301,13 @@ export default function App() {
     }
   }, []);
 
+  // Cleanup error toast timer on unmount
+  useEffect(() => {
+    return () => {
+      if (errorToastTimerRef.current) clearTimeout(errorToastTimerRef.current);
+    };
+  }, []);
+
   // Generation counter so an older in-flight listStashes() resolution
   // cannot overwrite results from a newer typed-search. Without this, a
   // fast typer's earlier (slower) request can win the race and the UI
@@ -364,6 +374,13 @@ export default function App() {
     });
   }, [tags]);
 
+  /** Show a transient error toast that auto-dismisses after 4 s. */
+  const showError = useCallback((message: string) => {
+    setErrorToast(message);
+    if (errorToastTimerRef.current) clearTimeout(errorToastTimerRef.current);
+    errorToastTimerRef.current = setTimeout(() => setErrorToast(null), 4000);
+  }, []);
+
   const handleSelectStash = async (id: string) => {
     try {
       const stash = await api.getStash(id);
@@ -373,6 +390,7 @@ export default function App() {
       setSidebarOpen(false);
     } catch (err) {
       console.error('Failed to load stash:', err);
+      showError('Failed to load stash. Please try again.');
     }
   };
 
@@ -397,6 +415,7 @@ export default function App() {
       loadStashes();
     } catch (err) {
       console.error('Failed to archive stash:', err);
+      showError(archived ? 'Failed to archive stash.' : 'Failed to unarchive stash.');
     }
   };
 
@@ -433,6 +452,7 @@ export default function App() {
       loadTags();
     } catch (err) {
       console.error('Failed to delete stash:', err);
+      showError('Failed to delete stash. Please try again.');
     }
   };
 
@@ -673,6 +693,20 @@ export default function App() {
         onClose={() => setSearchOpen(false)}
         onSelectStash={handleSelectStash}
       />
+      {errorToast && (
+        <div
+          className="app-error-toast"
+          role="alert"
+          aria-live="assertive"
+          onClick={() => setErrorToast(null)}
+          title="Click to dismiss"
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+            <path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" />
+          </svg>
+          {errorToast}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -337,6 +337,7 @@ export default function StashViewer({
   const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const filesContainerRef = useRef<HTMLDivElement>(null);
   const copyAllClipboard = useClipboard();
+  const titleClipboard = useClipboard();
   const fileClipboard = useClipboardWithKey();
   const apiClipboard = useClipboardWithKey();
 
@@ -522,6 +523,8 @@ export default function StashViewer({
       <div className="sr-only" aria-live="polite">
         {copyAllClipboard.status === 'copied' && 'All files copied to clipboard'}
         {copyAllClipboard.status === 'failed' && 'Copy failed'}
+        {titleClipboard.status === 'copied' && 'Stash name copied to clipboard'}
+        {titleClipboard.status === 'failed' && 'Copy failed'}
         {fileClipboard.copiedKey && 'File copied to clipboard'}
         {fileClipboard.failedKey && 'Copy failed'}
         {apiClipboard.copiedKey && 'API endpoint copied to clipboard'}
@@ -538,6 +541,28 @@ export default function StashViewer({
         <h2 className="viewer-title">
           {title}
           {stash.archived && <span className="viewer-archived-badge">Archived</span>}
+          <button
+            type="button"
+            className="viewer-title-copy-btn"
+            onClick={() => titleClipboard.copy(title)}
+            title={
+              titleClipboard.copied
+                ? 'Copied!'
+                : titleClipboard.status === 'failed'
+                  ? 'Copy failed'
+                  : 'Copy stash name to clipboard'
+            }
+            aria-label="Copy stash name to clipboard"
+          >
+            <CopyButtonContent
+              copied={titleClipboard.copied}
+              failed={titleClipboard.status === 'failed'}
+              size={12}
+              labelCopy=""
+              labelCopied=""
+              labelFailed=""
+            />
+          </button>
         </h2>
         <div className="viewer-actions">
           <button

--- a/src/components/editor/StashEditor.tsx
+++ b/src/components/editor/StashEditor.tsx
@@ -39,6 +39,9 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
   const [availableTags, setAvailableTags] = useState<TagInfo[]>([]);
   const [availableMetaKeys, setAvailableMetaKeys] = useState<string[]>([]);
   const [firstFileManuallyEdited, setFirstFileManuallyEdited] = useState(!!stash);
+  // Keep a ref to handleSave so the Ctrl/Cmd+S listener always calls the
+  // latest version without being recreated on every render.
+  const handleSaveRef = useRef<() => void>(() => {});
 
   // useRef(initialValue) re-evaluates `initialValue` on every render but only
   // keeps the FIRST render's result. The naive `.map(() => counter++)` form
@@ -160,6 +163,23 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
     }
   };
 
+  // Keep ref in sync so the keyboard listener below always invokes the
+  // latest handleSave closure (which closes over fresh `files`, `name`, etc.)
+  // without needing to re-register the listener on every render.
+  handleSaveRef.current = handleSave;
+
+  // Ctrl+S / Cmd+S — save the stash from anywhere inside the editor.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        handleSaveRef.current();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
   return (
     <div className="stash-editor">
       <div className="editor-header">
@@ -175,7 +195,7 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
             className="btn btn-primary"
             onClick={handleSave}
             disabled={saving}
-            title="Save this stash"
+            title="Save this stash (Ctrl+S / Cmd+S)"
           >
             <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
               <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z" />

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6122,3 +6122,24 @@ body {
     scroll-behavior: auto !important;
   }
 }
+
+/* === Global Error Toast === */
+.app-error-toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  background: var(--bg-card);
+  border: 1px solid rgba(218, 54, 51, 0.4);
+  border-radius: var(--radius);
+  color: #ff7b7b;
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 2000;
+  cursor: pointer;
+  max-width: 360px;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1438,6 +1438,34 @@ body {
   white-space: nowrap;
 }
 
+.viewer-title-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  margin-left: 6px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  vertical-align: middle;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+  flex-shrink: 0;
+}
+
+.viewer-title:hover .viewer-title-copy-btn,
+.viewer-title-copy-btn:focus-visible {
+  opacity: 1;
+}
+
+.viewer-title-copy-btn:hover {
+  color: var(--text-secondary);
+}
+
 .viewer-archived-badge {
   display: inline-block;
   margin-left: 8px;


### PR DESCRIPTION
Closes #180

## Summary

Three small comfort / quality improvements from the automated comfort sweep:

- **Ctrl+S / Cmd+S save shortcut** in `StashEditor` — window-level listener reads from a stable ref, no listener churn on re-renders
- **Error toast for archive / delete / select failures** — `handleArchiveStash`, `handleDeleteStash`, `handleSelectStash` were silent on failure; a shared `showError()` helper now surfaces a dismissible toast (4 s auto-dismiss, click to dismiss)
- **Copy-name button in viewer title** — hover-revealed copy icon beside the stash name using existing `useClipboard` + `CopyButtonContent`; keyboard-accessible via `focus-visible`

## Test plan

- [ ] Open a stash in the editor, press Ctrl+S (or Cmd+S on macOS) — stash saves without clicking the button
- [ ] Simulate a network failure (e.g. disable the server) and try to open / archive / delete a stash — red toast appears and auto-dismisses
- [ ] Open a stash viewer, hover over the title — copy icon appears; click it, paste elsewhere to confirm
- [ ] Tab to the copy icon (keyboard nav) — it becomes visible via focus-visible
- [ ] `npm test` — all 117 tests pass
- [ ] `npm run build` — no errors

https://claude.ai/code/session_01TJh1RpZCYDFfNQ2ouAMVqv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJh1RpZCYDFfNQ2ouAMVqv)_