### PR TITLE
refactor: best-practice sweep 2026-05-23 (security, sanitizer, react keys)

### DIFF
--- a/src/app/api/_helpers.ts
+++ b/src/app/api/_helpers.ts
@@ -106,19 +106,28 @@ export async function parseJsonBody(
 
 /**
  * Extract IP and user agent from request headers for access logging.
- * x-forwarded-for may contain a comma-separated chain; only the first
- * entry (the original client) is recorded to match middleware behavior
- * and avoid leaking spoofed downstream values into logs. Falls back to
- * x-real-ip when XFF is absent (nginx, traefik) so proxies that only
- * forward one or the other still produce useful logs.
+ *
+ * Honours the `TRUST_PROXY` opt-in to stay consistent with `getClientIp`
+ * (rate-limit keying) and `getBaseUrl` (OpenAPI/MCP spec). Without a
+ * trusted proxy boundary, `x-forwarded-for` is attacker-controlled and a
+ * spoofed value would poison the access log (every entry attributable to
+ * an attacker-chosen IP). When `TRUST_PROXY` is set, the first XFF entry
+ * (original client) is used; otherwise we read only `x-real-ip` and fall
+ * back to undefined rather than logging spoofed values.
  */
 export function getRequestInfo(req: NextRequest): {
   ip: string | undefined;
   userAgent: string | undefined;
 } {
-  const xff = req.headers.get('x-forwarded-for');
-  const ip =
-    (xff ? xff.split(',')[0].trim() : '') || req.headers.get('x-real-ip')?.trim() || undefined;
+  const trustProxy = isTrustedProxy();
+  let ip: string | undefined;
+  if (trustProxy) {
+    const xff = req.headers.get('x-forwarded-for');
+    ip = (xff ? xff.split(',')[0].trim() : '') || undefined;
+  }
+  if (!ip) {
+    ip = req.headers.get('x-real-ip')?.trim() || undefined;
+  }
   return {
     ip,
     userAgent: req.headers.get('user-agent') || undefined,

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -272,7 +272,10 @@ function extractHeadings(html: string): TocHeading[] {
     if (anchor) anchor.remove();
     const text = el.textContent?.trim() || '';
     if (el.id && text) {
-      headings.push({ id: el.id, text, depth: parseInt(el.tagName[1]) });
+      // Explicit radix 10 — leading-zero strings are spec-compliantly base 10
+      // in modern JS, but the linter (when added) flags missing radix as a
+      // code-smell, and being explicit removes any historical ambiguity.
+      headings.push({ id: el.id, text, depth: parseInt(el.tagName[1], 10) });
     }
   });
   return headings;

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -215,13 +215,18 @@ function sanitizeHtml(html: string): string {
     .forEach((el) => el.remove());
   doc.querySelectorAll('*').forEach((el) => {
     for (const attr of [...el.attributes]) {
-      const isEventHandler = attr.name.toLowerCase().startsWith('on');
+      // HTML attribute names are case-insensitive; DOMParser preserves the
+      // source casing. Match against a lowered name so `HREF="javascript:..."`
+      // or `xlink:HREF` cannot slip past the URL-scheme check. Mirrors the
+      // sibling sanitiser in utils/markdown.ts.
+      const lowerName = attr.name.toLowerCase();
+      const isEventHandler = lowerName.startsWith('on');
       const isUrlAttr =
-        attr.name === 'href' ||
-        attr.name === 'src' ||
-        attr.name === 'xlink:href' ||
-        attr.name === 'action' ||
-        attr.name === 'formaction';
+        lowerName === 'href' ||
+        lowerName === 'src' ||
+        lowerName === 'xlink:href' ||
+        lowerName === 'action' ||
+        lowerName === 'formaction';
       if (isEventHandler || (isUrlAttr && isUnsafeUrl(attr.value))) {
         el.removeAttribute(attr.name);
       }

--- a/src/components/editor/MetadataEditor.tsx
+++ b/src/components/editor/MetadataEditor.tsx
@@ -43,6 +43,21 @@ export default function MetadataEditor({ entries, onChange, availableKeys }: Pro
   const keyInputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
+  // Stable per-row IDs so React reconciles edits to the correct input when
+  // rows are removed or reordered. Using `key={index}` made remove visually
+  // carry the next row's text into the removed row's slot (React would treat
+  // the row as reused). Pattern mirrors fileIds in StashEditor.tsx. Caller-
+  // driven entries replacement keeps IDs in sync via removeEntry/addEntry —
+  // a bare-length mismatch falls back to padding/truncating at the tail.
+  const idCounter = useRef(0);
+  const entryIds = useRef<number[]>([]);
+  while (entryIds.current.length < entries.length) {
+    entryIds.current.push(idCounter.current++);
+  }
+  if (entryIds.current.length > entries.length) {
+    entryIds.current.length = entries.length;
+  }
+
   const displayEntries = showAll ? entries : entries.slice(0, PREVIEW_COUNT);
   const hasMore = entries.length > PREVIEW_COUNT;
 
@@ -58,12 +73,14 @@ export default function MetadataEditor({ entries, onChange, availableKeys }: Pro
   };
 
   const removeEntry = (index: number) => {
+    entryIds.current.splice(index, 1);
     onChange(entries.filter((_, i) => i !== index));
   };
 
   const addEntry = (key: string) => {
     const trimmed = key.trim();
     if (trimmed && !entries.some((e) => e.key === trimmed)) {
+      entryIds.current.push(idCounter.current++);
       onChange([...entries, { key: trimmed, value: '' }]);
       setShowAll(true);
     }
@@ -88,7 +105,7 @@ export default function MetadataEditor({ entries, onChange, availableKeys }: Pro
       {entries.length > 0 && (
         <div className="metadata-entries">
           {displayEntries.map((entry, index) => (
-            <div key={index} className="metadata-entry-row">
+            <div key={entryIds.current[index]} className="metadata-entry-row">
               <input
                 type="text"
                 value={entry.key}


### PR DESCRIPTION
Closes #182.

## Changes

- **fix(security): respect TRUST_PROXY in access-log IP extraction** — `getRequestInfo()` previously trusted `x-forwarded-for` unconditionally while `getClientIp()` / `getBaseUrl()` gated on `TRUST_PROXY`. A spoofed XFF would poison the access log on a default deploy. Three surfaces are now consistent.
- **fix(security): lowercase attr name in StashViewer sanitizer** — DOMParser preserves source casing; the URL-attribute check (`attr.name === 'href'`) missed `HREF="javascript:..."` / `xlink:HREF`. Mirrors the sibling sanitiser in `utils/markdown.ts`.
- **fix(editor): use stable keys in MetadataEditor row list** — `key={index}` made remove visually carry the next row's text into the removed slot. Ref-tracked per-row counter ID (same pattern as `StashEditor`'s `fileIds`).
- **refactor(maint): add explicit radix to parseInt in extractHeadings** — defensive cleanup, removes lint-trap.

## Verification

- `npx tsc --noEmit` — clean
- `npm test` — 117/117 pass
- `npm run build` — succeeds

## Deferred

- `SwaggerViewer.tsx` loads Swagger UI from `unpkg.com` without SRI / pinned version. Needs vendoring vs. SRI discussion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFjgtpWkJ88t5bZKNzBFkN)_