### PR TITLE
refactor: best-practice sweep (Next.js)

### DIFF
--- a/src/app/api/_helpers.ts
+++ b/src/app/api/_helpers.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/server/singleton';
 import { requireScopeAuth, requireAdminAuth, extractToken } from '@/server/auth';
-import { isTrustedProxy } from '@/server/auth-rate-limit';
+import { isTrustedProxy, extractClientIp } from '@/server/auth-rate-limit';
 import type { TokenScope } from '@/server/db';
 
 // Canonical auth error responses. Centralised so checkScope / checkAdmin
@@ -119,17 +119,8 @@ export function getRequestInfo(req: NextRequest): {
   ip: string | undefined;
   userAgent: string | undefined;
 } {
-  const trustProxy = isTrustedProxy();
-  let ip: string | undefined;
-  if (trustProxy) {
-    const xff = req.headers.get('x-forwarded-for');
-    ip = (xff ? xff.split(',')[0].trim() : '') || undefined;
-  }
-  if (!ip) {
-    ip = req.headers.get('x-real-ip')?.trim() || undefined;
-  }
   return {
-    ip,
+    ip: extractClientIp(req),
     userAgent: req.headers.get('user-agent') || undefined,
   };
 }

--- a/src/components/StashCard.tsx
+++ b/src/components/StashCard.tsx
@@ -99,8 +99,12 @@ export default function StashCard({
       )}
 
       <div className="stash-card-files">
-        {stash.files.map((file, i) => (
-          <div key={i} className="stash-card-file" title={file.filename}>
+        {stash.files.map((file) => (
+          // Filenames are validated to be unique per stash by the server
+          // (see validation.ts FileSchema / DB unique constraint), so they
+          // are a stable React key. Using the array index instead would
+          // break diffing when files are added / reordered in the editor.
+          <div key={file.filename} className="stash-card-file" title={file.filename}>
             <svg
               width="12"
               height="12"

--- a/src/components/VersionHistory.tsx
+++ b/src/components/VersionHistory.tsx
@@ -228,10 +228,13 @@ export default function VersionHistory({ stashId, currentVersion, onRestore }: P
           <p className="version-detail-desc">{selectedVersion.description}</p>
         )}
         <div className="version-detail-files">
-          {selectedVersion.files.map((file, i) => {
+          {selectedVersion.files.map((file) => {
             const lang = resolvePrismLanguage(file.language, file.filename);
             return (
-              <div key={i} className="viewer-file">
+              // Filename is unique per version (enforced by server validation),
+              // so it's a stable React key. The previous `key={i}` would
+              // confuse diffing if the version's file order ever changed.
+              <div key={file.filename} className="viewer-file">
                 <div className="file-header">
                   <span className="file-name">{file.filename}</span>
                   {file.language && <span className="lang-tag">{file.language}</span>}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -26,10 +26,17 @@ const CORS_HEADERS: Record<string, string> = {
 // Security headers — safe defaults that don't break agent/LAN access
 // ---------------------------------------------------------------------------
 
+// `X-Frame-Options: DENY` blocks the admin UI from being rendered inside
+// a third-party `<iframe>`, defending against clickjacking against the
+// login form and any admin-scoped action surface. We use the legacy
+// header (rather than CSP `frame-ancestors`) because it is universally
+// honored by older browsers and is sufficient here — ClawStash never
+// needs to be embedded.
 const SECURITY_HEADERS: Record<string, string> = {
   'X-Content-Type-Options': 'nosniff',
   'Referrer-Policy': 'strict-origin-when-cross-origin',
   'X-DNS-Prefetch-Control': 'off',
+  'X-Frame-Options': 'DENY',
 };
 
 // ---------------------------------------------------------------------------

--- a/src/server/auth-rate-limit.ts
+++ b/src/server/auth-rate-limit.ts
@@ -124,16 +124,25 @@ export function isTrustedProxy(): boolean {
   return process.env.TRUST_PROXY === '1' || process.env.TRUST_PROXY === 'true';
 }
 
-export function getClientIp(req: NextRequest): string {
-  const trustProxy = isTrustedProxy();
-
-  if (trustProxy) {
+/**
+ * Resolve the trustworthy client IP from forwarded / direct headers, or
+ * `undefined` if none are present. Shared by `getClientIp` (rate-limit
+ * keying) and `getRequestInfo` (access-log keying) so the two surfaces
+ * cannot drift on which headers count as trustworthy under `TRUST_PROXY`.
+ */
+export function extractClientIp(req: NextRequest): string | undefined {
+  if (isTrustedProxy()) {
     const xff = req.headers.get('x-forwarded-for')?.split(',')[0].trim();
     if (xff) return xff;
   }
-
   const xRealIp = req.headers.get('x-real-ip')?.trim();
   if (xRealIp) return xRealIp;
+  return undefined;
+}
+
+export function getClientIp(req: NextRequest): string {
+  const ip = extractClientIp(req);
+  if (ip) return ip;
 
   // Per-request random bucket: effectively no rate-limit for THIS request,
   // but other requests still have their own keys. Better than one shared

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,6 +1,19 @@
 import { NextRequest } from 'next/server';
 import type { ClawStashDB, TokenScope } from './db';
 
+/**
+ * Full scope set granted to admin sessions and open-mode callers.
+ *
+ * Hoisted as a single source of truth so admin / open-mode auth paths
+ * cannot drift on which scopes are implicitly granted. A new scope
+ * (e.g. a future `metrics` scope) is added here once and propagates to
+ * both `validateAuth` (admin-session branch) and `requireScopeAuth`
+ * (open-mode branch). Returned as a fresh array each call so callers
+ * can mutate without poisoning the shared constant.
+ */
+const ALL_SCOPES: readonly TokenScope[] = ['read', 'write', 'admin', 'mcp'];
+const allScopes = (): TokenScope[] => [...ALL_SCOPES];
+
 export interface AuthResult {
   authenticated: boolean;
   source: 'admin_session' | 'api_token' | 'open';
@@ -81,7 +94,7 @@ export function validateAuth(db: ClawStashDB, token: string): AuthResult {
       return {
         authenticated: true,
         source: 'admin_session',
-        scopes: ['read', 'write', 'admin', 'mcp'],
+        scopes: allScopes(),
         expiresAt: session.expiresAt ?? null,
       };
     }
@@ -122,7 +135,7 @@ export function requireScopeAuth(
   scope: TokenScope,
 ): AuthResult | null {
   if (!isAuthEnabled()) {
-    return { authenticated: true, source: 'open', scopes: ['read', 'write', 'admin', 'mcp'] };
+    return { authenticated: true, source: 'open', scopes: allScopes() };
   }
 
   const token = extractToken(req);

--- a/src/server/version.ts
+++ b/src/server/version.ts
@@ -100,6 +100,12 @@ interface LatestCache {
 
 let cache: LatestCache | null = null;
 let cacheExpiry = 0;
+// Track an in-flight fetch so concurrent /api/version callers share a single
+// GitHub round-trip. Without this, N parallel requests during a cache miss
+// each kick off their own `fetch` — wasteful and likely to trip the
+// GitHub unauthenticated-API rate limit (60/h/IP) under load. The promise is
+// cleared on settle so the next miss after the TTL window can retry.
+let inFlight: Promise<LatestCache> | null = null;
 
 async function fetchLatestCommit(): Promise<LatestCache> {
   const now = new Date().toISOString();
@@ -158,7 +164,15 @@ export async function checkVersion(): Promise<VersionInfo> {
   const now = Date.now();
 
   if (!cache || now > cacheExpiry) {
-    const fresh = await fetchLatestCommit();
+    // Coalesce concurrent misses onto a single fetch. `fetchLatestCommit`
+    // never throws (it returns a null-commit shape on error), so a finally
+    // is sufficient to clear the slot for the next miss.
+    if (!inFlight) {
+      inFlight = fetchLatestCommit().finally(() => {
+        inFlight = null;
+      });
+    }
+    const fresh = await inFlight;
     cache = fresh;
     // Only cache successful fetches for the full TTL; retry failures sooner.
     cacheExpiry = fresh.commit_sha !== null ? now + CACHE_TTL_MS : now + FAILED_FETCH_RETRY_MS;


### PR DESCRIPTION
Closes #192

## Summary

Five small, equivalence-preserving best-practice refactors. Each is its own commit and was verified independently with `tsc --noEmit`, `vitest`, and a final `next build`.

| # | Commit | Scope | LoC |
|---|--------|-------|-----|
| 1 | `refactor(version): coalesce concurrent latest-commit fetches` | `src/server/version.ts` | +15 / -1 |
| 2 | `refactor(auth): share proxy-aware client IP extraction` | `auth-rate-limit.ts`, `_helpers.ts` | +16 / -16 |
| 3 | `refactor(react): use stable filename keys for file lists` | `StashCard.tsx`, `VersionHistory.tsx` | +11 / -4 |
| 4 | `refactor(security): set X-Frame-Options DENY to block clickjacking` | `src/middleware.ts` | +7 / -0 |
| 5 | `refactor(auth): hoist ALL_SCOPES constant for admin / open-mode paths` | `src/server/auth.ts` | +15 / -2 |

Tie-breaker priority: Security > Correctness > Deprecation > Performance > Maintainability.

## Why

- **#1**: Bursty `/api/version` traffic (dashboard opens, multi-tab) launched N parallel GitHub fetches per cache miss and could trip the 60/h unauth API rate limit.
- **#2**: Two surfaces re-implemented the same `TRUST_PROXY` lookup — drift hazard.
- **#3**: `key={i}` on filename-stable lists confuses React diffing on reorder/insert; the last sweep already flagged this pattern but missed StashCard/VersionHistory.
- **#4**: Admin login + admin actions were iframe-embeddable; missing legacy clickjacking header.
- **#5**: Adding a future scope (e.g. `metrics`) required lockstep edits in two unrelated branches of `auth.ts`.

## Test plan

- [x] `npx tsc --noEmit` after every commit (clean)
- [x] `npm test` after every commit — 117 / 117 pass
- [x] `npx next build` after the last commit — full build succeeds
- [x] `prettier --check` on every changed file — pass (pre-existing `src/styles/app.css` warning is untouched)
- [x] `next lint` no longer applicable in Next.js 16; manual review of changed surfaces only

## Notes

- One PR / one issue / five commits — matches the standard sweep cadence.
- No deferred findings this round.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AfK565VnUS4DRCt9ucwtpJ)_