### PR TITLE
chore: quality & housekeeping sweep 2026-05-24

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,14 @@ data
 .git
 .github
 .env
+.env.*
 *.md
 .dockerignore
+.gitnexus
+.vscode
+.idea
+coverage
+*.log
+*.tsbuildinfo
+.claude
+agent_docs

--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,10 @@ DATABASE_PATH=./data/clawstash.db
 # but no protection either) and OpenAPI / MCP spec URLs use the host
 # header verbatim.
 # TRUST_PROXY=1
+
+# --- Build-time env vars (CI/Docker only) -----------------------------
+# Override the git information embedded into build-info.json. Set by the
+# GitHub Actions workflow so the running container reports the commit
+# that produced it, even though the image has no .git directory.
+# BUILD_COMMIT_SHA=
+# BUILD_BRANCH=

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,8 @@ How were these changes tested?
 
 ## Checklist
 
+- [ ] Formatting passes (`npm run format:check`)
 - [ ] Code compiles without errors (`npx tsc --noEmit`)
+- [ ] Tests pass (`npm test`)
 - [ ] Build succeeds (`npm run build`)
 - [ ] Changes are documented (if applicable)

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -4,12 +4,7 @@ Temporary working context. **Clean up aggressively -- delete when resolved.**
 
 ## Current Work
 
-### GitNexus Code Review -- Round 3/3 (#105, Epic #96)
-
-**Date:** 2026-04-26
-**Branch:** ocean/105-gitnexus-based-code-review-round-3-809m
-
-R1 + R2 detailed working notes archived (see closed PRs #98 and #101). R3 polish-pass diff is summarized in the PR body and BACKLOG entries 86-101.
+_(None)_
 
 ## Open Questions
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1453,7 +1453,9 @@ body {
   cursor: pointer;
   vertical-align: middle;
   opacity: 0;
-  transition: opacity 0.15s, color 0.15s;
+  transition:
+    opacity 0.15s,
+    color 0.15s;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
Closes #194

Quality & housekeeping sweep — 5 small, low-risk fixes touching only project meta-files (CSS formatting, `.env.example`, `.dockerignore`, `SCRATCHPAD.md`, PR template). No runtime code changes.

## Commits

1. `style(css): apply prettier formatting to app.css` — fixes one stale `transition` shorthand, restores `format:check` green.
2. `docs(env): document BUILD_COMMIT_SHA and BUILD_BRANCH` — adds the two undocumented build-time env vars.
3. `chore(docker): expand .dockerignore to exclude dev/agent artifacts` — adds `.env.*`, `.gitnexus`, `coverage`, `.vscode`, `.idea`, `*.log`, `*.tsbuildinfo`, `.claude`, `agent_docs`.
4. `docs(scratchpad): clear stale GitNexus R3 working note` — empties SCRATCHPAD per memory_process.md (work merged 2026-04-26).
5. `docs(github): align PR template checklist with CONTRIBUTING.md` — adds `format:check` and `npm test` to the checklist.

## Test plan

- [x] `npm run format:check` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 11 files / 117 tests pass
- [x] Total diff: 5 files, +22 / -8 LoC

## Out of scope

- 8 open Dependabot PRs (untouched).
- Dependency bumps.
- BACKLOG findings (separate workflow).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuAS6VTws8kXk7G5ib94sq)_