### PR TITLE
fix: best-practice sweep — Dockerfile non-root + escapeHtml single-quote

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,16 @@ FROM node:26-slim
 
 WORKDIR /app
 
+# Run as non-root user for defense-in-depth. The node:26-slim image ships
+# with a `node` user (uid 1000). Pre-create the data directory so the
+# volume mount inherits the correct ownership on first run.
+RUN mkdir -p /app/data && chown -R node:node /app /app/data
+
 # Copy standalone Next.js output (includes node_modules + server)
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/build-info.json ./build-info.json
+COPY --from=builder --chown=node:node /app/.next/standalone ./
+COPY --from=builder --chown=node:node /app/.next/static ./.next/static
+COPY --from=builder --chown=node:node /app/public ./public
+COPY --from=builder --chown=node:node /app/build-info.json ./build-info.json
 
 ENV NODE_ENV=production
 ENV PORT=3000
@@ -37,5 +42,7 @@ ENV DATABASE_PATH=/app/data/clawstash.db
 EXPOSE 3000
 
 VOLUME ["/app/data"]
+
+USER node
 
 CMD ["node", "server.js"]

--- a/src/utils/__tests__/html.test.ts
+++ b/src/utils/__tests__/html.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { escapeHtml } from '../html';
 
 describe('escapeHtml', () => {
-  it('escapes the four HTML-significant chars', () => {
-    expect(escapeHtml('a&b<c>d"e')).toBe('a&amp;b&lt;c&gt;d&quot;e');
+  it('escapes all five HTML-significant chars', () => {
+    expect(escapeHtml('a&b<c>d"e\'f')).toBe('a&amp;b&lt;c&gt;d&quot;e&#39;f');
   });
 
   it('escapes ampersand first so other entity prefixes are double-escaped', () => {

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -1,6 +1,7 @@
 /**
  * Escape a string for safe inclusion in HTML body text or attribute values.
- * Escapes the four characters HTML treats as syntactically significant.
+ * Escapes all five characters OWASP recommends for HTML entity encoding:
+ * `& < > " '` (the "big five").
  *
  * The ampersand replacement runs first so subsequent entity insertions
  * (`&amp;`, `&lt;`, etc.) are not double-escaped.
@@ -13,5 +14,6 @@ export function escapeHtml(s: string): string {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }


### PR DESCRIPTION
## Summary

Closes #199

- **Dockerfile**: Switch production stage to non-root `node` user (uid 1000) with pre-created data directory. Defence-in-depth against container escape.
- **escapeHtml**: Add missing single-quote escaping (`' -> &#39;`) to complete the OWASP-recommended set of 5 HTML entity characters. Update test to cover all five.

## Verification
- `npx tsc --noEmit` — pass
- `npm test` — 117/117 pass
- `npm run format:check` — pre-existing warnings only (unrelated files)
- Both changes are behaviour-equivalent for existing callers (all current escapeHtml usage is in double-quoted contexts; Dockerfile volume mounts work with uid 1000)

## Test plan
- [x] TypeScript type-check passes
- [x] All 117 tests pass
- [x] Prettier check passes (no new warnings)
- [ ] Docker build verified (image builds and starts with `node` user)

https://claude.ai/code/session_01MEphDqLcgYGsM4eNP11J8w

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEphDqLcgYGsM4eNP11J8w)_