### PR TITLE
refine: ux sweep (Next.js)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,6 +106,9 @@ export default function App() {
   // Global error toast for operation failures (archive, delete, select).
   const [errorToast, setErrorToast] = useState<string | null>(null);
   const errorToastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Global success toast for positive feedback (save, archive, restore).
+  const [successToast, setSuccessToast] = useState<string | null>(null);
+  const successToastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Global Alt+K shortcut for quick search
   useEffect(() => {
@@ -301,10 +304,11 @@ export default function App() {
     }
   }, []);
 
-  // Cleanup error toast timer on unmount
+  // Cleanup toast timers on unmount
   useEffect(() => {
     return () => {
       if (errorToastTimerRef.current) clearTimeout(errorToastTimerRef.current);
+      if (successToastTimerRef.current) clearTimeout(successToastTimerRef.current);
     };
   }, []);
 
@@ -381,6 +385,13 @@ export default function App() {
     errorToastTimerRef.current = setTimeout(() => setErrorToast(null), 4000);
   }, []);
 
+  /** Show a transient success toast that auto-dismisses after 3 s. */
+  const showSuccess = useCallback((message: string) => {
+    setSuccessToast(message);
+    if (successToastTimerRef.current) clearTimeout(successToastTimerRef.current);
+    successToastTimerRef.current = setTimeout(() => setSuccessToast(null), 3000);
+  }, []);
+
   const handleSelectStash = async (id: string) => {
     try {
       const stash = await api.getStash(id);
@@ -413,6 +424,7 @@ export default function App() {
         setSelectedStash(updated);
       }
       loadStashes();
+      showSuccess(archived ? 'Stash archived.' : 'Stash unarchived.');
     } catch (err) {
       console.error('Failed to archive stash:', err);
       showError(archived ? 'Failed to archive stash.' : 'Failed to unarchive stash.');
@@ -450,6 +462,7 @@ export default function App() {
       pushUrl('/');
       loadStashes();
       loadTags();
+      showSuccess('Stash deleted.');
     } catch (err) {
       console.error('Failed to delete stash:', err);
       showError('Failed to delete stash. Please try again.');
@@ -459,6 +472,7 @@ export default function App() {
   const handleSaveStash = async (savedId?: string) => {
     try {
       const stashId = savedId || selectedStash?.id;
+      const isNew = !selectedStash;
       if (stashId) {
         const updated = await api.getStash(stashId);
         setSelectedStash(updated);
@@ -470,6 +484,7 @@ export default function App() {
       }
       loadStashes();
       loadTags();
+      showSuccess(isNew ? 'Stash created.' : 'Stash saved.');
     } catch (err) {
       console.error('Failed to reload stash after save:', err);
       setView('home');
@@ -693,6 +708,20 @@ export default function App() {
         onClose={() => setSearchOpen(false)}
         onSelectStash={handleSelectStash}
       />
+      {successToast && (
+        <div
+          className="app-success-toast"
+          role="status"
+          aria-live="polite"
+          onClick={() => setSuccessToast(null)}
+          title="Click to dismiss"
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+            <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z" />
+          </svg>
+          {successToast}
+        </div>
+      )}
       {errorToast && (
         <div
           className="app-error-toast"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -410,6 +410,13 @@ export default function Sidebar({
             {showArchived ? 'Showing archived' : 'Show archived'}
           </button>
 
+          {stashes.length > 0 && (
+            <div className="sidebar-list-count" aria-live="polite">
+              {stashes.length} stash{stashes.length !== 1 ? 'es' : ''}
+              {(search || filterTag) && ' matching'}
+            </div>
+          )}
+
           <div className="sidebar-list">
             {stashes.map((stash) => (
               <div

--- a/src/components/editor/StashEditor.tsx
+++ b/src/components/editor/StashEditor.tsx
@@ -42,6 +42,9 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
   // Keep a ref to handleSave so the Ctrl/Cmd+S listener always calls the
   // latest version without being recreated on every render.
   const handleSaveRef = useRef<() => void>(() => {});
+  // Track whether the user has made any edits since the editor opened.
+  // Used by the beforeunload handler to warn about unsaved changes.
+  const dirtyRef = useRef(false);
 
   // useRef(initialValue) re-evaluates `initialValue` on every render but only
   // keeps the FIRST render's result. The naive `.map(() => counter++)` form
@@ -84,6 +87,7 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
   // from the dep list also avoids recreating the callback on every keystroke.
   const handleNameChange = useCallback(
     (newName: string) => {
+      dirtyRef.current = true;
       setName(newName);
       if (firstFileManuallyEdited) return;
       setFiles((prev) => {
@@ -103,17 +107,20 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
   );
 
   const addFile = () => {
+    dirtyRef.current = true;
     setFiles([...files, { filename: '', content: '', language: '' }]);
     fileIds.current.push(fileIdCounter.current++);
   };
 
   const removeFile = (index: number) => {
     if (files.length === 1) return;
+    dirtyRef.current = true;
     setFiles(files.filter((_, i) => i !== index));
     fileIds.current.splice(index, 1);
   };
 
   const updateFile = useCallback((index: number, field: keyof FileInput, value: string) => {
+    dirtyRef.current = true;
     setFiles((prev) => {
       const updated = [...prev];
       updated[index] = { ...updated[index], [field]: value };
@@ -151,9 +158,11 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
 
       if (stash) {
         await api.updateStash(stash.id, payload);
+        dirtyRef.current = false;
         onSave(stash.id);
       } else {
         const created = await api.createStash(payload);
+        dirtyRef.current = false;
         onSave(created.id);
       }
     } catch (err) {
@@ -178,6 +187,17 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  // Warn before navigating away (browser back, tab close) with unsaved edits.
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (dirtyRef.current) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
   }, []);
 
   return (
@@ -234,7 +254,10 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
           </label>
           <textarea
             value={description}
-            onChange={(e) => setDescription(e.target.value)}
+            onChange={(e) => {
+              dirtyRef.current = true;
+              setDescription(e.target.value);
+            }}
             placeholder="Describe what this stash contains and what it's used for..."
             className="form-textarea description-textarea"
             rows={2}
@@ -255,7 +278,14 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
             Tags
             <InfoIcon tooltip="Tags to categorize your stash. Type to search existing tags or create new ones. Press Enter or comma to add. Tags let you filter and find stashes quickly." />
           </label>
-          <TagCombobox tags={tags} onChange={setTags} availableTags={availableTags} />
+          <TagCombobox
+            tags={tags}
+            onChange={(t) => {
+              dirtyRef.current = true;
+              setTags(t);
+            }}
+            availableTags={availableTags}
+          />
         </div>
 
         <div className="form-group">
@@ -266,7 +296,10 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
           </label>
           <MetadataEditor
             entries={metadataEntries}
-            onChange={setMetadataEntries}
+            onChange={(e) => {
+              dirtyRef.current = true;
+              setMetadataEntries(e);
+            }}
             availableKeys={availableMetaKeys}
           />
         </div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -540,6 +540,14 @@ body {
   color: var(--text-primary);
 }
 
+.sidebar-list-count {
+  padding: 4px 16px 2px;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
 .sidebar-list {
   flex: 1;
   overflow-y: auto;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1383,7 +1383,9 @@ body {
 .relative-time {
   cursor: pointer;
   border-bottom: 1px dashed transparent;
-  transition: border-color 0.15s, color 0.15s;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
 }
 
 .relative-time:hover {
@@ -6200,6 +6202,27 @@ body {
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+}
+
+/* === Global Success Toast === */
+.app-success-toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  background: var(--bg-card);
+  border: 1px solid rgba(63, 185, 80, 0.4);
+  border-radius: var(--radius);
+  color: #7ee787;
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 2000;
+  cursor: pointer;
+  max-width: 360px;
 }
 
 /* === Global Error Toast === */


### PR DESCRIPTION
## UX Refinement Sweep — 2026-05-28

| # | Refinement | Category | Files | Size |
|---|-----------|----------|-------|------|
| 1 | **Success toast** — positive feedback for save/archive/delete ops | Quality/Feedback | `App.tsx`, `app.css` | S |
| 2 | **Unsaved changes warning** — `beforeunload` prompt in editor | Comfort | `StashEditor.tsx` | S |
| 3 | **Sidebar stash count** — visible result count with filter hint | Comfort/Feedback | `Sidebar.tsx`, `app.css` | S |

### Verification

- `npx tsc --noEmit` — pass
- `npm run build` — pass
- `npm test` — 117/117 pass
- `npm run format:check` — pass (1 pre-existing warning in unrelated file)

Closes #203


---
_Generated by [Claude Code](https://claude.ai/code/session_01NgyN6Cpj2naXQTL8yyb123)_