### PR TITLE
chore: backlog sweep follow-up (Next.js)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,10 +311,11 @@ npx gitnexus analyze
 
 Refactoring does NOT happen automatically. Only upon explicit user request, when repeated code smells emerge across multiple files in review, or when a feature implementation is significantly harder than expected due to code structure. See `agent_docs/refactoring_guidelines.md` for principles.
 
-- **`src/server/db.ts` (~1850 lines)**: Largest file by far. Strong candidate for splitting: token/session management -> `TokenStore`, version history -> `VersionStore`, FTS methods -> `SearchStore`.
-- **`src/server/openapi.ts` (~680 lines)**: Large schema definition. Could adopt `@asteasolutions/zod-to-openapi` to generate from Zod schemas in `tool-defs.ts`.
-- **`src/components/StashViewer.tsx` (~780 lines)**: Largest frontend component. File display, TOC, access log tab, and metadata display sections could be extracted into sub-components.
-- **`src/components/Settings.tsx` (~560 lines)**: Could extract Welcome Dashboard and Storage Stats sections into dedicated sub-components within a `settings/` directory.
+- **`src/server/db.ts` (~1150 lines)**: Largest server file. Token/session, version history, and FTS logic have already been split into `src/server/stores/` (`TokenStore`, `SessionStore`, `VersionStore`, `SearchStore`); `ClawStashDB` now delegates to them. Further extraction (e.g. tag-graph / relations) is optional and low priority.
+- **`src/server/openapi.ts` (~830 lines)**: Large schema definition (one big function). Could adopt `@asteasolutions/zod-to-openapi` to generate from Zod schemas in `tool-defs.ts` (BACKLOG #105).
+- **`src/components/StashViewer.tsx` (~1090 lines)**: Largest frontend component. File display, TOC, access log tab, and metadata display sections could be extracted into sub-components (BACKLOG #106).
+- **`src/components/Settings.tsx` (~680 lines)**: Could extract Welcome Dashboard and Storage Stats sections into dedicated sub-components within a `settings/` directory (BACKLOG #106).
+- **`src/components/GraphViewer.tsx` / `StashGraphCanvas.tsx` (~1600 lines each)**: Pure layout/draw/physics helpers mixed with the React components — extract-module candidates (BACKLOG #102 / #103).
 - **`src/languages.ts` (~340 lines)**: Extension map and content-based detection heuristics are large but stable. Low priority.
 - **No linter**: Adding ESLint would significantly improve code quality assurance. (Prettier is already configured for formatting — see `.prettierrc.json`.)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -31,7 +31,7 @@ See [authentication.md](authentication.md) for token creation and scopes.
 | `/api/stashes/graph`                   | GET    | Tag relationship graph (`?tag=&depth=&min_weight=&min_count=&limit=`) |
 | `/api/stashes/graph/stashes`           | GET    | Stash relationship graph                                              |
 
-> **`?archived=` query param**: only the literal strings `true` and `false` are honored — any other value (e.g. `?archived=1`, `?archived=yes`) is silently ignored and the route falls back to the default (active stashes only). See BACKLOG #84 for the planned 400-on-invalid behavior.
+> **`?archived=` query param**: only the literal strings `true` and `false` are honored. Any other value (e.g. `?archived=1`, `?archived=yes`) is rejected with `400 Bad Request` and `{ "error": "Invalid 'archived' value. Use 'true' or 'false'." }`. Omit the parameter entirely to use the default (active stashes only).
 
 > **Raw file route response header**: `/api/stashes/:id/files/:filename/raw` returns `Content-Disposition: inline; filename*=UTF-8''…` so non-ASCII filenames are preserved when downloaded.
 


### PR DESCRIPTION
Follow-up backlog sweep (round 2, expanded scope) after PR #206.

## Changes

| # | Entry | Category | Effort | Recommendation | Status |
|---|---|---|---|---|---|
| 1 | `CLAUDE.md` "Refactoring Notes" stale: `db.ts` listed as ~1850 lines + recommended a `TokenStore`/`VersionStore`/`SearchStore` split that **already shipped** (`src/server/stores/`, `db.ts` now ~1150 lines). All file line counts stale. | Docs / Maintainability | S | Update counts, mark store-split done, cross-ref #102/#103/#105/#106 | Implemented |
| 2 | `docs/api-reference.md` still described invalid `?archived=` values as "silently ignored" with a "planned" 400 (BACKLOG #84) — but #84 shipped (route returns 400). | Docs | S | Document current 400 behavior, drop stale "planned" note | Implemented |

Both changes are documentation-only, well under the 50 LoC / 3 file budget (2 files, +6/-5).

## Sweep result

The codebase is in excellent shape after prior rounds (R2.2/R2.3 security work + PR #206). A thorough pass over validation, parsers, route handlers, the DB layer, MCP wiring, version handling, and the admin import/export paths found **no new code-level safe wins** — the remaining open backlog entries are all legitimately `Accepted` / `Deferred` with sound reasoning, or large refactors / excluded items (#57/#58, physics, module extractions). Dependabot untouched.

## Backlog cleanup

None required: the prior round (2026-05-29) already pruned all obsolete entries, and the two fixes here corrected stale docs rather than tracked open findings. Re-verified open entries (#21, #110, …) still match current code — no obsolete entries to archive, no completed entries to move.

## Verification

- `npm ci` — ok
- `npx tsc --noEmit` — clean
- `npm run build` — success
- `npx vitest run` — 117/117 pass
- `npx eslint .` — not configured in this repo (CLAUDE.md), non-blocking

Closes #207


---
_Generated by [Claude Code](https://claude.ai/code/session_01GFyEWCYYZFUqwALQ3oiXeP)_