### PR TITLE
security: hardening sweep (Next.js)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -32,11 +32,36 @@ const CORS_HEADERS: Record<string, string> = {
 // header (rather than CSP `frame-ancestors`) because it is universally
 // honored by older browsers and is sufficient here — ClawStash never
 // needs to be embedded.
+//
+// The Content-Security-Policy below is intentionally MINIMAL and ADDITIVE.
+// It omits `script-src` / `style-src` / `default-src` on purpose so the
+// Next.js inline runtime, React hydration, PrismJS highlighting, and the
+// inline-SVG/style Mermaid rendering keep working WITHOUT a per-request
+// nonce pipeline (a full script-restricting CSP needs nonces and is a
+// larger, separately-tracked hardening task). The directives set here are
+// pure defense-in-depth that cannot break current functionality:
+//   - `base-uri 'self'`        blocks `<base>` href hijacking (reinforces the
+//                              markdown sanitiser, which already strips <base>)
+//   - `object-src 'none'`      blocks legacy plugin / <object>/<embed> vectors
+//                              (the app never renders them)
+//   - `frame-ancestors 'none'` modern clickjacking defense, complementing the
+//                              legacy `X-Frame-Options: DENY` on browsers that
+//                              prefer CSP over the legacy header
+//   - `form-action 'self'`     stops an injected <form> from exfiltrating to a
+//                              third-party origin
+const CONTENT_SECURITY_POLICY = [
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+].join('; ');
+
 const SECURITY_HEADERS: Record<string, string> = {
   'X-Content-Type-Options': 'nosniff',
   'Referrer-Policy': 'strict-origin-when-cross-origin',
   'X-DNS-Prefetch-Control': 'off',
   'X-Frame-Options': 'DENY',
+  'Content-Security-Policy': CONTENT_SECURITY_POLICY,
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Autonomous security-hardening sweep of the externally reachable web layer (Next.js App Router). Scope was the web-only surface; Electron is not present (pure web app), so nothing was excluded on that axis.

This PR contains **one safe, additive, verified-non-breaking fix**. Items requiring human judgement (full nonce-CSP, conditional HSTS, a transitive dependency CVE) are **not** in this PR — they are tracked as flags in #209.

## Fixed in this PR

| # | Category | Severity | File | Fix | Fix-class |
|---|----------|----------|------|-----|-----------|
| 1 | E — Misconfig / missing security header | Medium | `src/middleware.ts` | Add a **minimal additive** `Content-Security-Policy`: `base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'`. Deliberately omits `script-src`/`style-src`/`default-src` so the Next.js inline runtime, React hydration, PrismJS, and inline-SVG/style Mermaid rendering keep working **without** a nonce pipeline. Pure defense-in-depth (blocks `<base>` hijacking, legacy plugin embeds, clickjacking, injected-form exfiltration) that cannot break current functionality. | safe / S |

## Why only one change

The web layer is already strongly hardened (timing-safe password compare, hashed tokens at rest, per-IP auth rate limiting, `TRUST_PROXY`-gated forwarded headers, path-traversal-safe filenames, scheme-stripping markdown sanitiser, `sandbox=""` HTML-preview iframe, `nosniff`). No Critical/High issues and no other mechanically-safe fixes were found. CSRF is N/A (Bearer-only auth, no cookies); IDOR/tenant-bypass is N/A (single-tenant shared store by design); SQL is fully parameterized; no SSRF / command-injection / hardcoded-secret surface.

## Not included (see #209)
- **Full script-restricting CSP** — needs per-request nonces wired through Next.js rendering (architectural).
- **HSTS** — would break the documented plain-HTTP LAN deployment unless emitted only for genuine HTTPS requests.
- **`postcss <8.5.10`** (transitive via `next`, GHSA-qx2v-qp2m-jg93) — `npm audit` fix forces a major `next` downgrade; flag-only per policy.

## Verification
`npm ci` → `npx tsc --noEmit` (clean) → Prettier check on changed file (clean) → `vitest run` → **117/117 tests pass (11 files)**. No ESLint configured in repo. Build: green.

Review-ready — not auto-merged (human merges).

Refs #209

---
_Generated by [Claude Code](https://claude.ai/code/session_015a2ER3YXz8FQYC1yGspRQo)_