### PR TITLE
refactor: best-practice sweep (Next.js)

### DIFF
--- a/src/components/api/SwaggerViewer.tsx
+++ b/src/components/api/SwaggerViewer.tsx
@@ -30,11 +30,21 @@ export default function SwaggerViewer() {
   useEffect(() => {
     if (initializedRef.current || !containerRef.current) return;
 
+    // Pinned to 5.32.6 so SRI hashes remain stable. Bump both constants
+    // together and regenerate hashes when upgrading swagger-ui-dist.
+    const SWAGGER_BASE = 'https://unpkg.com/swagger-ui-dist@5.32.6';
+    const SWAGGER_CSS_SRI =
+      'sha384-VtRGWKd5DZlNwdyTFUVdweEFnkqOXqI0AJyGjrU6HMCsFe3ZpyT90bRXqtGBq67o';
+    const SWAGGER_JS_SRI =
+      'sha384-vbnE7TPM+ZTC5QAF6LmD1Rp4ULi7Sm2q3XDLjsjUhOtmwvCY8L9W6VM2wgqL+hYv';
+
     // Load CSS
     if (!document.querySelector('link[href*="swagger-ui.css"]')) {
       const link = document.createElement('link');
       link.rel = 'stylesheet';
-      link.href = 'https://unpkg.com/swagger-ui-dist@5/swagger-ui.css';
+      link.href = `${SWAGGER_BASE}/swagger-ui.css`;
+      link.integrity = SWAGGER_CSS_SRI;
+      link.crossOrigin = 'anonymous';
       link.onerror = () => {
         if (mountedRef.current) setHasError(true);
       };
@@ -91,7 +101,9 @@ export default function SwaggerViewer() {
       attachedScript = existingScript;
     } else {
       const script = document.createElement('script');
-      script.src = 'https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js';
+      script.src = `${SWAGGER_BASE}/swagger-ui-bundle.js`;
+      script.integrity = SWAGGER_JS_SRI;
+      script.crossOrigin = 'anonymous';
       script.onload = initSwagger;
       script.onerror = () => {
         if (mountedRef.current) {


### PR DESCRIPTION
## Summary
- Pins Swagger UI CDN assets from floating `@5` tag to exact version `5.32.6`
- Adds `integrity` (sha384) + `crossOrigin="anonymous"` to both the injected `<script>` and `<link>` in `SwaggerViewer.tsx`, blocking supply-chain substitution attacks via the unpkg CDN

## Changes
| File | Change |
|------|--------|
| `src/components/api/SwaggerViewer.tsx` | Version-pin + SRI hashes for swagger-ui-bundle.js and swagger-ui.css |

## Verification
- `npx tsc --noEmit` — clean
- `npm run format:check` — clean
- `npm test` — 117/117 passed
- `npm run build` — clean (standalone output)

Closes #213


---
_Generated by [Claude Code](https://claude.ai/code/session_01DzmmxRGWJJ1P8JEjHrGf2j)_