### PR TITLE
refactor: best-practice sweep (Next.js 16)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from 'next';
+import type { ReactNode } from 'react';
 import '../styles/app.css';
 
 // Do NOT set `maximumScale` or `userScalable: false` — disabling pinch-zoom
@@ -17,7 +18,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>{children}</body>

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -778,8 +778,8 @@ export default function StashViewer({
                   </a>
                   {entry.headings.length > 0 && (
                     <ul className="toc-headings">
-                      {entry.headings.map((h, hi) => (
-                        <li key={hi} className={`toc-heading toc-h${h.depth}`}>
+                      {entry.headings.map((h) => (
+                        <li key={h.id} className={`toc-heading toc-h${h.depth}`}>
                           <a href={`#${h.id}`} onClick={(e) => scrollToId(e, h.id)}>
                             {h.text}
                           </a>

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import type { NextRequest } from 'next/server';
 import type { ClawStashDB, TokenScope } from './db';
 
 /**

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1162,5 +1162,3 @@ export class ClawStashDB {
     this.db.close();
   }
 }
-
-export default ClawStashDB;

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,17 +38,6 @@ export interface StashListResponse {
   total: number;
 }
 
-export interface SearchStashItem extends StashListItem {
-  relevance: number;
-  snippets?: Record<string, string>;
-}
-
-export interface SearchStashesResponse {
-  stashes: SearchStashItem[];
-  total: number;
-  query: string;
-}
-
 export interface CreateStashInput {
   name?: string;
   description?: string;


### PR DESCRIPTION
## Summary

- Replace `React.ReactNode` namespace type in `layout.tsx` with explicit `import type { ReactNode }` (new JSX transform does not put `React` in scope)
- Change `import { NextRequest }` to `import type { NextRequest }` in `auth.ts` — type-only usage, consistent with `auth-rate-limit.ts`
- Remove dead `export default ClawStashDB` from `db.ts` — all consumers use the named export; default was never referenced
- Remove dead `SearchStashItem` + `SearchStashesResponse` type exports from `types.ts` — never imported anywhere in the frontend
- Use stable `key={h.id}` instead of array index `key={hi}` for TOC headings in `StashViewer.tsx`

## Test plan

- [x] `npx tsc --noEmit` — clean (0 errors)
- [x] `npm run test:run` — 117/117 passed
- [x] `npx next build` — build succeeded
- [x] `npm run format:check` — pre-existing Prettier warning in `RelativeTime.tsx` only (not caused by this PR)

Closes #217

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhprVN9LWS5zkTpUftmnL4)_