### PR TITLE
refactor: best-practice sweep (Next.js)

### DIFF
--- a/src/app/api/admin/logout/route.ts
+++ b/src/app/api/admin/logout/route.ts
@@ -39,11 +39,12 @@ export async function POST(req: NextRequest) {
   // by guessing or replaying captured admin tokens — even if they are not
   // themselves authenticated. (API tokens reaching this path are also rejected,
   // so accidentally hitting /api/admin/logout with a `cs_…` token does nothing.)
-  const auth = validateAuth(getDb(), token);
+  const db = getDb();
+  const auth = validateAuth(db, token);
   if (!auth.authenticated || auth.source !== 'admin_session') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  getDb().deleteAdminSession(token);
+  db.deleteAdminSession(token);
   // Standard admin POST response shape: { success: true, message }. `message`
   // is preserved for backwards compatibility with existing callers that read it.
   return NextResponse.json({ success: true, message: 'Logged out' });

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -656,12 +656,17 @@ export class ClawStashDB {
     }
   }
 
+  private tableExists(name: string): boolean {
+    const row = this.db
+      .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?")
+      .get(name);
+    return !!row;
+  }
+
   private rebuildStashRelations(): void {
     const rebuild = this.db.transaction(() => {
-      try {
+      if (this.tableExists('stash_relations')) {
         this.db.exec("DELETE FROM stash_relations WHERE relation_type = 'shared_tags'");
-      } catch (_) {
-        /* table may not exist */
       }
 
       const stashes = this.db.prepare('SELECT id, tags FROM stashes').all() as {
@@ -1040,15 +1045,11 @@ export class ClawStashDB {
       this.db.exec('DELETE FROM stashes');
 
       // Also clear stash_relations and FTS index
-      try {
+      if (this.tableExists('stash_relations')) {
         this.db.exec('DELETE FROM stash_relations');
-      } catch (_) {
-        /* table may not exist */
       }
-      try {
+      if (this.tableExists('stashes_fts')) {
         this.db.exec('DELETE FROM stashes_fts');
-      } catch (_) {
-        /* table may not exist */
       }
 
       let stashCount = 0;

--- a/src/server/stores/search-store.ts
+++ b/src/server/stores/search-store.ts
@@ -183,6 +183,19 @@ export class SearchStore {
       return { stashes: [], total: 0, query };
     }
 
+    // Build the shared WHERE clauses (tag + archived) that are appended
+    // identically to both the COUNT and the row-fetch queries. Extracting
+    // them once prevents count/rows from diverging when filters are added.
+    const filterSuffix = { sql: '', params: [] as unknown[] };
+    if (tag) {
+      filterSuffix.sql += ` AND s.tags LIKE ? ESCAPE '\\'`;
+      filterSuffix.params.push(`%"${tag.replace(/[\\%_]/g, '\\$&')}"%`);
+    }
+    if (archived !== undefined) {
+      filterSuffix.sql += ' AND s.archived = ?';
+      filterSuffix.params.push(archived ? 1 : 0);
+    }
+
     // Run FTS5 query — may throw on syntax errors despite sanitization
     let countRow: { count: number };
     let rows: {
@@ -196,33 +209,22 @@ export class SearchStore {
     }[];
 
     try {
-      let countSql = `
+      const countSql = `
         SELECT COUNT(*) as count
         FROM stashes_fts f
         JOIN stashes s ON s.id = f.stash_id
-        WHERE stashes_fts MATCH ?
+        WHERE stashes_fts MATCH ?${filterSuffix.sql}
       `;
-      const countParams: unknown[] = [ftsQuery];
-
-      if (tag) {
-        countSql += ` AND s.tags LIKE ? ESCAPE '\\'`;
-        const escapedTag = tag.replace(/[\\%_]/g, '\\$&');
-        countParams.push(`%"${escapedTag}"%`);
-      }
-
-      if (archived !== undefined) {
-        countSql += ' AND s.archived = ?';
-        countParams.push(archived ? 1 : 0);
-      }
-
-      countRow = this.db.prepare(countSql).get(...countParams) as { count: number };
+      countRow = this.db
+        .prepare(countSql)
+        .get(ftsQuery, ...filterSuffix.params) as { count: number };
 
       // Use private-use Unicode markers (U+E000 / U+E001) so we can detect
       // a real FTS hit without confusing it with literal "**" the user wrote
       // (markdown bold, `**kwargs`, etc.). Replaced with "**" before return.
       const O = FTS_SNIPPET_OPEN;
       const C = FTS_SNIPPET_CLOSE;
-      let sql = `
+      const sql = `
         SELECT f.stash_id, f.rank,
           snippet(stashes_fts, 1, '${O}', '${C}', '…', 32) as name_snippet,
           snippet(stashes_fts, 2, '${O}', '${C}', '…', 64) as desc_snippet,
@@ -231,25 +233,12 @@ export class SearchStore {
           snippet(stashes_fts, 5, '${O}', '${C}', '…', 64) as content_snippet
         FROM stashes_fts f
         JOIN stashes s ON s.id = f.stash_id
-        WHERE stashes_fts MATCH ?
+        WHERE stashes_fts MATCH ?${filterSuffix.sql}
+        ORDER BY f.rank LIMIT ? OFFSET ?
       `;
-      const params: unknown[] = [ftsQuery];
-
-      if (tag) {
-        sql += ` AND s.tags LIKE ? ESCAPE '\\'`;
-        const escapedTag = tag.replace(/[\\%_]/g, '\\$&');
-        params.push(`%"${escapedTag}"%`);
-      }
-
-      if (archived !== undefined) {
-        sql += ' AND s.archived = ?';
-        params.push(archived ? 1 : 0);
-      }
-
-      sql += ` ORDER BY f.rank LIMIT ? OFFSET ?`;
-      params.push(limit, offset);
-
-      rows = this.db.prepare(sql).all(...params) as typeof rows;
+      rows = this.db
+        .prepare(sql)
+        .all(ftsQuery, ...filterSuffix.params, limit, offset) as typeof rows;
     } catch (err) {
       // Only fall back to LIKE search for FTS5-specific errors (syntax /
       // malformed MATCH). Other errors (Zod, schema, I/O, etc.) must

--- a/src/server/stores/search-store.ts
+++ b/src/server/stores/search-store.ts
@@ -30,7 +30,7 @@ const FTS_SNIPPET_OPEN = '';
 const FTS_SNIPPET_CLOSE = '';
 
 function formatSnippet(raw: string): string {
-  return raw.split(FTS_SNIPPET_OPEN).join('**').split(FTS_SNIPPET_CLOSE).join('**');
+  return raw.replaceAll(FTS_SNIPPET_OPEN, '**').replaceAll(FTS_SNIPPET_CLOSE, '**');
 }
 
 /**

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -15,12 +15,8 @@ export function isUnsafeUrl(value: string): boolean {
   // Strip ASCII control chars + whitespace (code points 0x00-0x20 and DEL=0x7F)
   // before scheme detection. Browsers ignore those when resolving URLs, so an
   // attacker could otherwise hide a `javascript:` scheme behind them.
-  let cleaned = '';
-  for (let i = 0; i < value.length; i++) {
-    const code = value.charCodeAt(i);
-    if (code > 0x20 && code !== 0x7f) cleaned += value[i];
-  }
-  cleaned = cleaned.toLowerCase();
+  // eslint-disable-next-line no-control-regex
+  const cleaned = value.replace(/[\x00-\x20\x7f]/g, '').toLowerCase();
   // Block all data: URIs, not just data:text/html. data:image/svg+xml can
   // carry embedded scripts that execute in some browser contexts, and no
   // legitimate markdown link or image needs a data: source (user content is


### PR DESCRIPTION
Five focused, behaviour-equivalent refactors across the DB, search, markdown utility, and auth layers.

## Merged Findings

| File | Category | Finding | Fix | Effort | Recommendation |
|---|---|---|---|---|---|
| `src/server/db.ts` | Correctness | `try/catch (_)` in transactions swallowed all DB errors (not just "table missing") | `tableExists()` helper via `sqlite_master`; guard DELETE with explicit check | S | auto-fix |
| `src/server/stores/search-store.ts` | Maintainability | `formatSnippet` used `.split().join()` instead of ES2022 `replaceAll()` | Replace with `replaceAll()` | S | auto-fix |
| `src/utils/markdown.ts` | Performance | `isUnsafeUrl` accumulated `cleaned` char-by-char (O(n²) string allocations) | Single `replace(/[\x00-\x20\x7f]/g, '')` regex | S | auto-fix |
| `src/server/stores/search-store.ts` | Maintainability | COUNT and row-fetch queries built tag/archived filters independently — drift risk | Shared `filterSuffix` object reused by both queries | S | auto-fix |
| `src/app/api/admin/logout/route.ts` | Maintainability | `getDb()` singleton resolved twice in one handler | Single `const db = getDb()` | S | auto-fix |

Closes #219

https://claude.ai/code/session_01ASZre7Tvy6vXwpjAsNz5bd

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASZre7Tvy6vXwpjAsNz5bd)_