### PR TITLE
refactor: best-practice sweep (Next.js)

### DIFF
--- a/src/app/api/_helpers.ts
+++ b/src/app/api/_helpers.ts
@@ -70,7 +70,7 @@ export function getBaseUrl(req: NextRequest): string {
  */
 export function parsePositiveInt(value: string | null): number | undefined {
   if (!value) return undefined;
-  const num = parseInt(value, 10);
+  const num = Number.parseInt(value, 10);
   return Number.isInteger(num) && num > 0 ? num : undefined;
 }
 
@@ -87,7 +87,7 @@ export function parsePositiveInt(value: string | null): number | undefined {
  */
 export function parseNonNegativeInt(value: string | null): number | undefined {
   if (value === null || value === '') return undefined;
-  const num = parseInt(value, 10);
+  const num = Number.parseInt(value, 10);
   return Number.isInteger(num) && num >= 0 ? num : undefined;
 }
 

--- a/src/app/api/admin/import/route.ts
+++ b/src/app/api/admin/import/route.ts
@@ -40,7 +40,7 @@ export async function POST(req: NextRequest) {
         { status: 411 },
       );
     }
-    const contentLength = parseInt(contentLengthHeader, 10);
+    const contentLength = Number.parseInt(contentLengthHeader, 10);
     if (!Number.isFinite(contentLength) || contentLength < 0) {
       return NextResponse.json({ error: 'Invalid Content-Length header' }, { status: 400 });
     }

--- a/src/components/GraphViewer.tsx
+++ b/src/components/GraphViewer.tsx
@@ -68,9 +68,9 @@ const CLUSTER_COLORS = [
 function getClusterColor(cluster: number, alpha = 1): string {
   const hex = CLUSTER_COLORS[cluster % CLUSTER_COLORS.length];
   if (alpha === 1) return hex;
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
+  const r = Number.parseInt(hex.slice(1, 3), 16);
+  const g = Number.parseInt(hex.slice(3, 5), 16);
+  const b = Number.parseInt(hex.slice(5, 7), 16);
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
@@ -624,9 +624,9 @@ export default function GraphViewer({
           node.radius * 2.2,
         );
         const glowColor = isFocusNode ? '#58a6ff' : baseColor;
-        const gr = parseInt(glowColor.slice(1, 3), 16);
-        const gg = parseInt(glowColor.slice(3, 5), 16);
-        const gb = parseInt(glowColor.slice(5, 7), 16);
+        const gr = Number.parseInt(glowColor.slice(1, 3), 16);
+        const gg = Number.parseInt(glowColor.slice(3, 5), 16);
+        const gb = Number.parseInt(glowColor.slice(5, 7), 16);
         gradient.addColorStop(0, `rgba(${gr}, ${gg}, ${gb}, 0.3)`);
         gradient.addColorStop(1, `rgba(${gr}, ${gg}, ${gb}, 0)`);
         ctx.beginPath();

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -35,7 +35,7 @@ function loadStoredScale(key: string | undefined): number | null {
   try {
     const raw = window.localStorage.getItem(STORAGE_PREFIX + key);
     if (!raw) return null;
-    const n = parseFloat(raw);
+    const n = Number.parseFloat(raw);
     return Number.isFinite(n) && n >= MIN_SCALE && n <= MAX_SCALE ? n : null;
   } catch {
     return null;

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -248,7 +248,7 @@ function extractHeadings(html: string): TocHeading[] {
       // Explicit radix 10 — leading-zero strings are spec-compliantly base 10
       // in modern JS, but the linter (when added) flags missing radix as a
       // code-smell, and being explicit removes any historical ambiguity.
-      headings.push({ id: el.id, text, depth: parseInt(el.tagName[1], 10) });
+      headings.push({ id: el.id, text, depth: Number.parseInt(el.tagName[1], 10) });
     }
   });
   return headings;

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -26,7 +26,7 @@ const ADMIN_PASSWORD = () => process.env.ADMIN_PASSWORD || '';
 const ADMIN_SESSION_HOURS = () => {
   const val = process.env.ADMIN_SESSION_HOURS;
   if (val === undefined || val === '') return 24;
-  const num = parseFloat(val);
+  const num = Number.parseFloat(val);
   // 0 means "unlimited" (documented). Treat NaN, negatives, and infinities as
   // misconfiguration and fall back to the safe 24h default rather than
   // silently granting a never-expiring session. Without this guard,

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -28,7 +28,7 @@ export function formatDate(dateStr: string): string {
  */
 export function formatRelativeTime(dateStr: string): string {
   const d = new Date(dateStr);
-  if (isNaN(d.getTime())) return dateStr;
+  if (Number.isNaN(d.getTime())) return dateStr;
   const now = new Date();
   const diffMs = now.getTime() - d.getTime();
   if (diffMs < 0) return 'just now'; // future date (clock skew)


### PR DESCRIPTION
Best-practice sweep: migrate the remaining global `parseInt` / `parseFloat` calls to the `Number.*` namespace already used throughout the codebase (`Number.isNaN` / `Number.isFinite` / `Number.isInteger`). `Number.parseInt` / `Number.parseFloat` are spec-identical function references — behaviourally equivalent, no behaviour change.

## Findings (merged)
| # | Datei | Kategorie | Befund | Fix | Aufwand | Status |
|---|-------|-----------|--------|-----|---------|--------|
| 1 | `src/server/auth.ts`, `src/components/MermaidDiagram.tsx` | Konsistenz | Global `parseFloat` neben `Number.isFinite`-Guard | `Number.parseFloat` | S | done |
| 2 | `src/app/api/_helpers.ts` | Konsistenz | `parsePositiveInt`/`parseNonNegativeInt`: global `parseInt` + `Number.isInteger`-Guard | `Number.parseInt` | S | done |
| 3 | `src/components/GraphViewer.tsx` | Konsistenz | 6x global `parseInt(hex, 16)` (RGBA-Konversion) | `Number.parseInt` | S | done |
| 4 | `src/components/StashViewer.tsx`, `src/app/api/admin/import/route.ts` | Konsistenz | Global `parseInt(.., 10)` (Heading-Depth / Content-Length) | `Number.parseInt` | S | done |

## Verifikation
- `npm ci` — gruen
- `npx tsc --noEmit` — gruen
- `npm run build` — gruen
- Prettier `format:check` — angefasste Dateien gruen (3 pre-existing Warnungen in nicht angefassten Dateien, bestehen bereits auf `main`)
- Lint: kein ESLint konfiguriert (per CLAUDE.md) — nicht anwendbar

Closes #222

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkSj6MnrAPDZxs3uMquBGV)_