### PR TITLE
refactor(server): replace uuid dependency with native crypto.randomUUID

### DIFF
--- a/src/server/db-migrations.ts
+++ b/src/server/db-migrations.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3';
-import { v4 as uuidv4 } from 'uuid';
+import crypto from 'crypto';
 
 // Versioned schema migrations for ClawStashDB. Extracted from db.ts
 // (Round 1/3 — refs #129) so each migration is independently
@@ -112,7 +112,13 @@ export const MIGRATIONS: Migration[] = [
           const shared = parsed[i].tags.filter((t) => parsed[j].tags.includes(t));
           if (shared.length > 0) {
             const [src, tgt] = [parsed[i].id, parsed[j].id].sort();
-            insert.run(uuidv4(), src, tgt, shared.length, JSON.stringify({ shared_tags: shared }));
+            insert.run(
+              crypto.randomUUID(),
+              src,
+              tgt,
+              shared.length,
+              JSON.stringify({ shared_tags: shared }),
+            );
           }
         }
       }
@@ -155,7 +161,7 @@ export const MIGRATIONS: Migration[] = [
       `);
 
       for (const s of stashes) {
-        const versionId = uuidv4();
+        const versionId = crypto.randomUUID();
         insertVersion.run(versionId, s.id, s.name, s.description, s.tags, s.metadata, s.created_at);
 
         const files = db
@@ -170,7 +176,7 @@ export const MIGRATIONS: Migration[] = [
         }[];
         for (const f of files) {
           insertVersionFile.run(
-            uuidv4(),
+            crypto.randomUUID(),
             versionId,
             f.filename,
             f.content,

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3';
-import { v4 as uuidv4 } from 'uuid';
+import crypto from 'crypto';
 import path from 'path';
 import fs from 'fs';
 import { detectLanguage } from './detect-language';
@@ -163,7 +163,7 @@ export class ClawStashDB {
     ip?: string,
     userAgent?: string,
   ): void {
-    const id = uuidv4();
+    const id = crypto.randomUUID();
     const now = new Date().toISOString();
     this.db
       .prepare(
@@ -182,7 +182,7 @@ export class ClawStashDB {
   }
 
   createStash(input: CreateStashInput): Stash {
-    const id = uuidv4();
+    const id = crypto.randomUUID();
     const now = new Date().toISOString();
 
     const insertStash = this.db.prepare(`
@@ -206,7 +206,7 @@ export class ClawStashDB {
       const files: StashFile[] = [];
       for (let i = 0; i < input.files.length; i++) {
         const file = input.files[i];
-        const fileId = uuidv4();
+        const fileId = crypto.randomUUID();
         const language = file.language || detectLanguage(file.filename);
         insertFile.run(fileId, id, file.filename, file.content, language, i);
         files.push({
@@ -469,7 +469,7 @@ export class ClawStashDB {
         for (let i = 0; i < input.files.length; i++) {
           const file = input.files[i];
           const language = file.language || detectLanguage(file.filename);
-          insertFile.run(uuidv4(), id, file.filename, file.content, language, i);
+          insertFile.run(crypto.randomUUID(), id, file.filename, file.content, language, i);
         }
       }
 
@@ -680,7 +680,13 @@ export class ClawStashDB {
       const shared = otherTags.filter((t) => tagSet.has(t));
       if (shared.length > 0) {
         const [src, tgt] = [stashId, row.id].sort();
-        insert.run(uuidv4(), src, tgt, shared.length, JSON.stringify({ shared_tags: shared }));
+        insert.run(
+          crypto.randomUUID(),
+          src,
+          tgt,
+          shared.length,
+          JSON.stringify({ shared_tags: shared }),
+        );
       }
     }
   }
@@ -714,7 +720,13 @@ export class ClawStashDB {
           const shared = parsed[i].tags.filter((t) => parsed[j].tags.includes(t));
           if (shared.length > 0) {
             const [src, tgt] = [parsed[i].id, parsed[j].id].sort();
-            insert.run(uuidv4(), src, tgt, shared.length, JSON.stringify({ shared_tags: shared }));
+            insert.run(
+              crypto.randomUUID(),
+              src,
+              tgt,
+              shared.length,
+              JSON.stringify({ shared_tags: shared }),
+            );
           }
         }
       }

--- a/src/server/stores/session-store.ts
+++ b/src/server/stores/session-store.ts
@@ -1,5 +1,4 @@
 import type Database from 'better-sqlite3';
-import { v4 as uuidv4 } from 'uuid';
 import crypto from 'crypto';
 import { hashToken } from './_token-hash';
 
@@ -23,7 +22,7 @@ export class SessionStore {
   constructor(private readonly db: Database.Database) {}
 
   createAdminSession(hours: number): { token: string; expiresAt: string | null } {
-    const id = uuidv4();
+    const id = crypto.randomUUID();
     const now = new Date();
     const rawToken = `csa_${crypto.randomBytes(24).toString('hex')}`;
     const tokenHash = hashToken(rawToken);

--- a/src/server/stores/token-store.ts
+++ b/src/server/stores/token-store.ts
@@ -1,5 +1,4 @@
 import type Database from 'better-sqlite3';
-import { v4 as uuidv4 } from 'uuid';
 import crypto from 'crypto';
 import type { TokenScope, ApiTokenListItem } from '../db-types';
 import { hashToken } from './_token-hash';
@@ -46,7 +45,7 @@ export class TokenStore {
     label: string,
     scopes: TokenScope[],
   ): { id: string; token: string; label: string; scopes: TokenScope[] } {
-    const id = uuidv4();
+    const id = crypto.randomUUID();
     const now = new Date().toISOString();
     const rawToken = `cs_${crypto.randomBytes(24).toString('hex')}`;
     const tokenHash = hashToken(rawToken);

--- a/src/server/stores/version-store.ts
+++ b/src/server/stores/version-store.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3';
-import { v4 as uuidv4 } from 'uuid';
+import crypto from 'crypto';
 import type {
   Stash,
   StashVersion,
@@ -171,7 +171,7 @@ export class VersionStore {
     changeSummaryJson: string;
     files: { filename: string; content: string; language: string; sort_order: number }[];
   }): string {
-    const versionId = uuidv4();
+    const versionId = crypto.randomUUID();
     this.db
       .prepare(
         `
@@ -198,7 +198,7 @@ export class VersionStore {
     `);
     for (const file of args.files) {
       insertVersionFile.run(
-        uuidv4(),
+        crypto.randomUUID(),
         versionId,
         file.filename,
         file.content,


### PR DESCRIPTION
Closes #230

## Summary

- Replace all `uuidv4()` calls (5 server files, 17 call sites) with `crypto.randomUUID()` from Node's built-in `crypto` module
- Add `import crypto from 'crypto'` to `db.ts`, `db-migrations.ts`, and `stores/version-store.ts` (already present in session-store and token-store)
- Remove the `import { v4 as uuidv4 } from 'uuid'` import from all five files
- `package.json` intentionally unchanged per sweep rules (no lockfile/dependency modifications)

> **Note:** This branch contains 10 pre-existing commits (prior work, intentional) that are not part of this sweep. The table below covers only the single sweep finding fixed here.

## Sweep Findings

| # | File | Category | Finding | Fix | Effort | Status |
|---|------|----------|---------|-----|--------|--------|
| 1 | 5 server files | Maintainability | `uuid` v14 runtime dep used only for UUIDv4 — replaceable with native `crypto.randomUUID()` (Node 14.17+) | Replace calls + imports | M | Fixed ✅ |

## Verification

- Prettier: all 5 changed files pass `prettier --check`
- Tests/build: skipped (node_modules not installed in sweep environment) — Build übersprungen (Toolchain/Netz)
- Behavioural equivalence: `crypto.randomUUID()` and `uuid.v4()` both produce RFC 4122 v4 UUIDs with identical string format

https://claude.ai/code/session_01BXxYrHvhHdf4A1wbGskSTh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXxYrHvhHdf4A1wbGskSTh)_