### PR TITLE
ux: best-practice sweep (Next.js)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -631,7 +631,14 @@ export default function App() {
               <line x1="3" y1="18" x2="21" y2="18" />
             </svg>
           </button>
-          <span className="mobile-header-title" onClick={handleGoHome}>
+          <span
+            className="mobile-header-title"
+            onClick={handleGoHome}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && handleGoHome()}
+            aria-label="Go to dashboard"
+          >
             ClawStash
           </span>
           <button

--- a/src/components/GraphViewer.tsx
+++ b/src/components/GraphViewer.tsx
@@ -1401,6 +1401,7 @@ export default function GraphViewer({
                 type="text"
                 className="graph-search-input"
                 placeholder="Search tags..."
+                aria-label="Search tags"
                 value={searchQuery}
                 onChange={(e) => {
                   setSearchQuery(e.target.value);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -207,6 +207,7 @@ export default function Sidebar({
           className="sidebar-graph-btn"
           onClick={onGraphView}
           title="Tag Graph — visualize tag connections"
+          aria-label="Tag Graph — visualize tag connections"
         >
           <svg
             width="16"
@@ -526,6 +527,7 @@ export default function Sidebar({
             className="sidebar-footer-settings-btn"
             onClick={onSettingsView}
             title="Settings, API tokens, and administration"
+            aria-label="Settings, API tokens, and administration"
           >
             <svg
               width="16"
@@ -543,7 +545,7 @@ export default function Sidebar({
             Settings
           </button>
           {onLogout && (
-            <button className="sidebar-footer-logout-btn" onClick={onLogout} title="Sign out">
+            <button className="sidebar-footer-logout-btn" onClick={onLogout} title="Sign out" aria-label="Sign out">
               <svg
                 width="16"
                 height="16"

--- a/src/components/editor/MetadataEditor.tsx
+++ b/src/components/editor/MetadataEditor.tsx
@@ -166,6 +166,7 @@ export default function MetadataEditor({ entries, onChange, availableKeys }: Pro
           onKeyDown={handleKeyInputKeyDown}
           placeholder="Add key..."
           className="form-input metadata-add-input"
+          aria-label="Add metadata key"
           autoComplete="off"
         />
         <button

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1065,6 +1065,11 @@ body {
   line-height: 1.4;
 }
 
+.btn:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+
 .btn-primary {
   background: var(--accent-green);
   color: #fff;


### PR DESCRIPTION
Automated UX best-practice sweep — all 5 findings are accessibility fixes with zero functional changes.

## Changes

| # | File | Finding | Fix |
|---|------|---------|-----|
| 1 | `src/styles/app.css` | `.btn` had no `:focus-visible` style — keyboard Tab navigation produced no visible focus ring | Added `.btn:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }` |
| 2 | `src/components/Sidebar.tsx` | Icon-only sidebar buttons (graph, settings, logout) had `title` but no `aria-label` | Added `aria-label` matching the `title` on all three buttons |
| 3 | `src/components/GraphViewer.tsx` | Graph tag search input had no `aria-label` (placeholder only) | Added `aria-label="Search tags"` |
| 4 | `src/components/editor/MetadataEditor.tsx` | "Add key..." input had no `aria-label` | Added `aria-label="Add metadata key"` |
| 5 | `src/App.tsx` | Mobile header title `<span>` had `onClick` but no `role`/`tabIndex`/keyboard handler | Added `role="button"`, `tabIndex={0}`, `onKeyDown` (Enter/Space), `aria-label` |

## Verification
- `npm ci` — ✅ clean install
- `npx tsc --noEmit` — ✅ no type errors
- All changes are additive attributes only; no logic altered.

Closes #232

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsfjxvAcwC26MygzN1BXeZ)_