### PR TITLE
refine: ux sweep (Next.js)

### DIFF
--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -186,7 +186,11 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
             ref={listRef}
             role="listbox"
             id="search-overlay-results"
+            aria-label={`${results.length} result${results.length !== 1 ? 's' : ''}`}
           >
+            <div className="search-overlay-results-count" aria-live="polite" role="status">
+              {results.length} result{results.length !== 1 ? 's' : ''}
+            </div>
             {results.map((stash, idx) => (
               <button
                 type="button"

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -628,7 +628,7 @@ export default function StashViewer({
             {stash.archived ? 'Unarchive' : 'Archive'}
           </button>
           <button
-            className={`btn ${showDeleteConfirm ? 'btn-danger' : 'btn-ghost'}`}
+            className={`btn ${showDeleteConfirm ? 'btn-danger btn-confirm-timeout' : 'btn-ghost'}`}
             onClick={handleDelete}
             title={
               showDeleteConfirm

--- a/src/components/editor/StashEditor.tsx
+++ b/src/components/editor/StashEditor.tsx
@@ -243,6 +243,7 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
             onChange={(e) => handleNameChange(e.target.value)}
             placeholder="e.g. Docker Compose Setup, API Keys, Prompt Template..."
             className="form-input"
+            autoFocus={!stash}
           />
         </div>
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1121,6 +1121,23 @@ body {
   border-color: var(--accent-red);
 }
 
+/* Confirm-timeout ring: animated outline shrinks over DELETE_CONFIRM_TIMEOUT_MS (3s)
+   to visually signal the confirm window is expiring. */
+@keyframes confirm-timeout-ring {
+  from {
+    outline: 2px solid rgba(218, 54, 51, 0.8);
+    outline-offset: 2px;
+  }
+  to {
+    outline: 2px solid rgba(218, 54, 51, 0);
+    outline-offset: 6px;
+  }
+}
+
+.btn-confirm-timeout {
+  animation: confirm-timeout-ring 3s linear forwards;
+}
+
 .btn-warning {
   background: var(--accent-orange);
   color: #000;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -823,6 +823,14 @@ body {
   padding: 4px 0;
 }
 
+.search-overlay-results-count {
+  padding: 4px 16px 2px;
+  font-size: 11px;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 2px;
+}
+
 .search-overlay-item {
   display: block;
   width: 100%;


### PR DESCRIPTION
Closes #236

UX refine sweep — 3 existing features sharpened (comfort/UX). All changes additive + local, verified green (Prettier `format:check`, `tsc --noEmit`, 117/117 vitest, Next.js build).

| # | Feature | UX gap | Improvement | Effort | Recommendation |
|---|---|---|---|---|---|
| 1 | Stash Editor — New Stash | User must click the Name field before typing when creating a new stash | `autoFocus={!stash}` on Name input — focus lands there immediately | S | auto-refine |
| 2 | Search Overlay | Results list shows items with no total count | "N result(s)" count label at top of results list with `aria-live` | S | auto-refine |
| 3 | Stash Viewer — Delete Confirm | "Confirm Delete?" resets after 3 s with no visual indication of the expiring window | CSS `@keyframes` animated outline ring that fades out over 3 s via `.btn-confirm-timeout` | S | auto-refine |

<!-- screenshot: optional -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01VUsKKUXwYL7HuEAmiPVe2T)_