### PR TITLE
ux: best-practice sweep (Next.js / React 19)

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -308,8 +308,9 @@ function GeneralSection({ layout, onLayoutChange }: GeneralSectionProps) {
           <button
             className={`settings-option-btn ${layout === 'grid' ? 'active' : ''}`}
             onClick={() => onLayoutChange('grid')}
+            aria-pressed={layout === 'grid'}
           >
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
               <path d="M1 2.5A1.5 1.5 0 0 1 2.5 1h3A1.5 1.5 0 0 1 7 2.5v3A1.5 1.5 0 0 1 5.5 7h-3A1.5 1.5 0 0 1 1 5.5v-3zm8 0A1.5 1.5 0 0 1 10.5 1h3A1.5 1.5 0 0 1 15 2.5v3A1.5 1.5 0 0 1 13.5 7h-3A1.5 1.5 0 0 1 9 5.5v-3zm-8 8A1.5 1.5 0 0 1 2.5 9h3A1.5 1.5 0 0 1 7 10.5v3A1.5 1.5 0 0 1 5.5 15h-3A1.5 1.5 0 0 1 1 13.5v-3zm8 0A1.5 1.5 0 0 1 10.5 9h3a1.5 1.5 0 0 1 1.5 1.5v3a1.5 1.5 0 0 1-1.5 1.5h-3A1.5 1.5 0 0 1 9 13.5v-3z" />
             </svg>
             Grid
@@ -317,8 +318,9 @@ function GeneralSection({ layout, onLayoutChange }: GeneralSectionProps) {
           <button
             className={`settings-option-btn ${layout === 'list' ? 'active' : ''}`}
             onClick={() => onLayoutChange('list')}
+            aria-pressed={layout === 'list'}
           >
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
               <path d="M2 4a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3.75-1.5a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5h-8.5zm0 5a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5h-8.5zm0 5a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5h-8.5zM3 8a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-1 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2z" />
             </svg>
             List

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -675,8 +675,10 @@ export default function StashViewer({
         </div>
       )}
 
-      <div className="viewer-tabs">
+      <div className="viewer-tabs" role="tablist" aria-label="Stash view tabs">
         <button
+          role="tab"
+          aria-selected={activeTab === 'content'}
           className={`tab ${activeTab === 'content' ? 'active' : ''}`}
           onClick={() => switchTab('content')}
           title="View file contents (key: 1)"
@@ -687,6 +689,7 @@ export default function StashViewer({
             viewBox="0 0 16 16"
             fill="currentColor"
             style={{ marginRight: 6, verticalAlign: -2 }}
+            aria-hidden="true"
           >
             <path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z" />
           </svg>
@@ -694,6 +697,8 @@ export default function StashViewer({
           <kbd className="tab-kbd">1</kbd>
         </button>
         <button
+          role="tab"
+          aria-selected={activeTab === 'metadata'}
           className={`tab ${activeTab === 'metadata' ? 'active' : ''}`}
           onClick={() => switchTab('metadata')}
           title="View stash details, metadata, and API endpoints (key: 2)"
@@ -704,6 +709,7 @@ export default function StashViewer({
             viewBox="0 0 16 16"
             fill="currentColor"
             style={{ marginRight: 6, verticalAlign: -2 }}
+            aria-hidden="true"
           >
             <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.92 6.085h.001a.749.749 0 1 1-1.342-.67c.169-.339.516-.552.974-.552.97 0 1.447.67 1.447 1.181 0 .43-.245.756-.462.97l-.044.042c-.21.196-.383.375-.383.632v.22a.75.75 0 0 1-1.5 0v-.22c0-.67.406-1.05.634-1.26l.044-.043c.16-.147.228-.228.228-.356 0-.098-.06-.233-.447-.233-.218 0-.316.1-.361.183ZM8 10.5a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z" />
           </svg>
@@ -711,6 +717,8 @@ export default function StashViewer({
           <kbd className="tab-kbd">2</kbd>
         </button>
         <button
+          role="tab"
+          aria-selected={activeTab === 'access-log'}
           className={`tab ${activeTab === 'access-log' ? 'active' : ''}`}
           onClick={() => switchTab('access-log')}
           title="View when and how this stash was accessed (API, MCP, UI) (key: 3)"
@@ -721,6 +729,7 @@ export default function StashViewer({
             viewBox="0 0 16 16"
             fill="currentColor"
             style={{ marginRight: 6, verticalAlign: -2 }}
+            aria-hidden="true"
           >
             <path d="M1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0ZM8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0Zm.5 4.75a.75.75 0 0 0-1.5 0v3.5a.75.75 0 0 0 .37.65l2.5 1.5a.75.75 0 1 0 .77-1.29L8.5 7.94Z" />
           </svg>
@@ -728,6 +737,8 @@ export default function StashViewer({
           <kbd className="tab-kbd">3</kbd>
         </button>
         <button
+          role="tab"
+          aria-selected={activeTab === 'history'}
           className={`tab ${activeTab === 'history' ? 'active' : ''}`}
           onClick={() => switchTab('history')}
           title="View version history and compare changes (key: 4)"
@@ -738,6 +749,7 @@ export default function StashViewer({
             viewBox="0 0 16 16"
             fill="currentColor"
             style={{ marginRight: 6, verticalAlign: -2 }}
+            aria-hidden="true"
           >
             <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
           </svg>
@@ -756,6 +768,7 @@ export default function StashViewer({
             viewBox="0 0 16 16"
             fill="currentColor"
             style={{ marginRight: 6, verticalAlign: -2 }}
+            aria-hidden="true"
           >
             <path d="M8 2a6 6 0 1 0 0 12A6 6 0 0 0 8 2Zm0 1.5a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Zm0 2a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z" />
           </svg>

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -778,8 +778,13 @@ export default function StashViewer({
 
       {activeTab === 'content' && tocEntries.length > 0 && renderPreview && (
         <div className="viewer-toc">
-          <button className="viewer-toc-toggle" onClick={() => setTocExpanded(!tocExpanded)}>
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+          <button
+            className="viewer-toc-toggle"
+            onClick={() => setTocExpanded(!tocExpanded)}
+            aria-expanded={tocExpanded}
+            aria-controls="viewer-toc-nav"
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
               <path d="M2 4a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm3.75-1.5a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5Zm0 5a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5Zm0 5a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5ZM3 8a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm-1 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" />
             </svg>
             Table of Contents
@@ -794,7 +799,7 @@ export default function StashViewer({
             </svg>
           </button>
           {tocExpanded && (
-            <nav className="viewer-toc-nav" aria-label="Table of contents">
+            <nav id="viewer-toc-nav" className="viewer-toc-nav" aria-label="Table of contents">
               {tocEntries.map((entry) => (
                 <div key={entry.fileIndex} className="toc-file-group">
                   <a

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1685,6 +1685,11 @@ body {
   color: var(--text-primary);
 }
 
+.tab:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: -2px;
+}
+
 .tab.active {
   color: var(--text-primary);
   border-bottom-color: var(--accent-green);
@@ -1738,6 +1743,11 @@ body {
 
 .viewer-toc-toggle:hover {
   background: var(--bg-tertiary);
+}
+
+.viewer-toc-toggle:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: -2px;
 }
 
 .toc-chevron {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -233,8 +233,8 @@ body {
 }
 
 .search-input-clear:focus-visible {
-  outline: none;
-  border-color: var(--accent-blue);
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 1px;
   color: var(--text-primary);
 }
 


### PR DESCRIPTION
## Stack
Next.js 16 (App Router) · React 19 · TypeScript 6 · Global CSS (BEM-like, dark theme) · No ESLint (Prettier only)

## Findings

| # | File | Category | Issue | Fix | Impact | Effort | Recommendation | Status |
|---|------|----------|-------|-----|--------|--------|----------------|--------|
| 1 | `src/components/StashViewer.tsx` | a11y | `.viewer-tabs` container and its 4 tab buttons lack `role="tablist"` / `role="tab"` / `aria-selected` — screen readers announce them as plain buttons with no state | Added `role="tablist"` on container; `role="tab"` + `aria-selected={activeTab === ...}` on each tab button; `aria-hidden="true"` on decorative SVGs | Screen readers can now navigate tabs correctly and hear selection state | M | auto-fix | ✅ done |
| 2 | `src/styles/app.css` | a11y | `.tab` and `.viewer-toc-toggle` buttons have no `:focus-visible` rule — keyboard users see no focus ring when tabbing to them | Added `.tab:focus-visible` and `.viewer-toc-toggle:focus-visible` rules (`outline: 2px solid var(--accent-blue); outline-offset: -2px`) consistent with `.btn:focus-visible` | Keyboard navigation now shows a visible focus indicator on tab buttons and the TOC toggle | S | auto-fix | ✅ done |
| 3 | `src/styles/app.css` | a11y | `.search-input-clear:focus-visible` sets `outline: none` with only `border-color` as replacement — the clear button is a small icon with no visible border normally, so keyboard focus is invisible | Replaced `outline: none` + `border-color` with `outline: 2px solid var(--accent-blue); outline-offset: 1px` | Focus is now visible on the sidebar search clear button for keyboard users | S | auto-fix | ✅ done |
| 4 | `src/components/StashViewer.tsx` | a11y | TOC toggle `<button>` missing `aria-expanded` and `aria-controls` — screen readers cannot announce collapsed/expanded state or associate the button with its controlled region | Added `aria-expanded={tocExpanded}` and `aria-controls="viewer-toc-nav"` to toggle button; `id="viewer-toc-nav"` to the `<nav>` | Screen readers now announce "expanded/collapsed" and link button to its controlled nav | S | auto-fix | ✅ done |
| 5 | `src/components/Settings.tsx` | a11y | Layout-toggle buttons ("Grid" / "List") in the Appearance section missing `aria-pressed` — screen readers cannot convey which layout is currently active | Added `aria-pressed={layout === 'grid'}` and `aria-pressed={layout === 'list'}` to the respective buttons | Screen readers now announce the active layout selection | S | auto-fix | ✅ done |

## Further findings (not touched — dropped by tie-breaker)
| File | Category | Issue | Effort | Recommendation |
|------|----------|-------|--------|----------------|
| `src/components/StashViewer.tsx` | a11y | Copy-all button (`copyAllFiles`) uses only `title` — no `aria-label`; label changes on copy state but is not live-announced | S | add `aria-label` mirroring title text + `aria-live="polite"` region |
| `src/components/VersionHistory.tsx` | a11y | Restore-version button lacks confirmation dialog — double-click risk for destructive operation (mirrors the delete pattern in StashViewer) | M | defer backlog |

## Deferred (too large / equivalence unclear)
| File | Issue | Effort | Recommendation | Reason |
|------|-------|--------|----------------|--------|
| `src/components/StashViewer.tsx` | Full ARIA tabpanel pattern: add `role="tabpanel"` + `aria-labelledby` to each conditional content section | L | implement full tabpanel pattern | >3 files / >50 LoC touching multiple conditionally-rendered sections |

## Out of scope
- Server-side API / MCP routes (no UI surface)
- `StashGraphCanvas.tsx` / `GraphViewer.tsx` canvas rendering (no DOM a11y applicable to canvas)
- Mermaid inline HTML injection (third-party renderer)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeezvWdcwBLC6U1X4irHqT)_