### PR TITLE
chore(deps): remove unused uuid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "react-simple-code-editor": "^0.14.1",
         "react-zoom-pan-pinch": "^4.0.3",
         "tsx": "^4.22.3",
-        "uuid": "^14.0.0",
         "zod": "^3.24.0",
         "zod-to-json-schema": "^3.25.2"
       },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "react-simple-code-editor": "^0.14.1",
     "react-zoom-pan-pinch": "^4.0.3",
     "tsx": "^4.22.3",
-    "uuid": "^14.0.0",
     "zod": "^3.24.0",
     "zod-to-json-schema": "^3.25.2"
   },


### PR DESCRIPTION
## Housekeeping Sweep — 2026-06-07

**Keine Version-Bumps enthalten.** Nur Entfernung einer ungenutzten Dependency.

### Findings

| # | Pass | Befund | Fix | Aufwand | Empfehlung | Status |
|---|------|--------|-----|---------|------------|--------|
| 1 | D Unused deps | `uuid@^14.0.0` — nirgends importiert, nur als Format-String in OpenAPI | `npm uninstall uuid` | S | auto-fix | gemerged |

### Tooling-Status

| Tool | Aktiv | Status |
|------|-------|--------|
| Formatter (Prettier) | ✅ | ✅ grün |
| Linter (ESLint) | ❌ | — |
| Tests (Vitest) | ✅ | ✅ grün (117/117) |
| TypeScript | ✅ | ✅ grün |

### Verifikation
- `npx prettier --check .` ✅
- `npx tsc --noEmit` ✅  
- `npm test` ✅ (117 tests, 11 files)

Closes #253

---
_Generated by [Claude Code](https://claude.ai/code/session_013pihupduX4RNpYJgFbG8Em)_