### PR TITLE
feat: comfort sweep (Next.js)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,14 @@ import type {
   StashListItem,
   ViewMode,
   LayoutMode,
+  SortMode,
   SettingsSection,
   AdminSessionInfo,
   TagInfo,
 } from './types';
 import { api, setAuthToken } from './api';
 import { loadFavoriteIds, saveFavoriteIds, toggleFavorite } from './utils/favorites';
+import { loadSortMode, saveSortMode } from './utils/sort';
 import { SEARCH_DEBOUNCE_MS } from './utils/constants';
 import Sidebar from './components/Sidebar';
 import Dashboard from './components/Dashboard';
@@ -88,6 +90,7 @@ export default function App() {
   const [layout, setLayout] = useState<LayoutMode>(() =>
     getStoredPreference('clawstash_layout', 'grid'),
   );
+  const [sortMode, setSortMode] = useState<SortMode>(loadSortMode);
   const [selectedStash, setSelectedStash] = useState<Stash | null>(null);
   const [search, setSearch] = useState('');
   const [filterTag, setFilterTag] = useState('');
@@ -573,6 +576,11 @@ export default function App() {
     localStorage.setItem('clawstash_layout', mode);
   };
 
+  const handleSortChange = (mode: SortMode) => {
+    setSortMode(mode);
+    saveSortMode(mode);
+  };
+
   // Show login screen if auth is required and user is not authenticated
   if (adminSession === null) {
     // Still loading session info
@@ -667,6 +675,7 @@ export default function App() {
               stashes={stashes}
               total={total}
               layout={layout}
+              sortMode={sortMode}
               loading={loading}
               filterTag={filterTag}
               showArchived={showArchived}
@@ -674,6 +683,7 @@ export default function App() {
               onToggleFavorite={handleToggleFavorite}
               onToggleShowArchived={() => setShowArchived((prev) => !prev)}
               onLayoutChange={handleLayoutChange}
+              onSortChange={handleSortChange}
               onSelectStash={handleSelectStash}
               onNewStash={handleNewStash}
               onFilterTag={handleFilterTag}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -140,6 +140,19 @@ export default function App() {
       if (e.key === '?') {
         e.preventDefault();
         setShortcutsHelpOpen((prev) => !prev);
+      } else if (e.key === '/') {
+        // Focus the sidebar stash-search field. On mobile the sidebar is a
+        // collapsible drawer, so open it first, then focus on the next frame
+        // once it has mounted/animated into view.
+        e.preventDefault();
+        setSidebarOpen(true);
+        requestAnimationFrame(() => {
+          const input = document.getElementById('sidebar-stash-search');
+          if (input instanceof HTMLInputElement) {
+            input.focus();
+            input.select();
+          }
+        });
       } else if (e.key === 'e') {
         // Edit the currently viewed stash (only when in view mode with a stash open)
         setView((currentView) => {

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
-import type { StashListItem, LayoutMode } from '../types';
+import type { StashListItem, LayoutMode, SortMode } from '../types';
 import { sortStashesWithFavorites } from '../utils/favorites';
+import { sortStashes, SORT_OPTIONS } from '../utils/sort';
 import StashCard from './StashCard';
 import Spinner from './shared/Spinner';
 
@@ -8,12 +9,14 @@ interface Props {
   stashes: StashListItem[];
   total: number;
   layout: LayoutMode;
+  sortMode: SortMode;
   loading: boolean;
   filterTag: string;
   showArchived: boolean;
   favoriteIds: ReadonlySet<string>;
   onToggleShowArchived: () => void;
   onLayoutChange: (mode: LayoutMode) => void;
+  onSortChange: (mode: SortMode) => void;
   onSelectStash: (id: string) => void;
   onNewStash: () => void;
   onFilterTag: (tag: string) => void;
@@ -24,22 +27,24 @@ export default function Dashboard({
   stashes,
   total,
   layout,
+  sortMode,
   loading,
   filterTag,
   showArchived,
   favoriteIds,
   onToggleShowArchived,
   onLayoutChange,
+  onSortChange,
   onSelectStash,
   onNewStash,
   onFilterTag,
   onToggleFavorite,
 }: Props) {
-  // Favorites pinned to the top, while preserving the server-provided order
-  // (updated_at DESC) within each group.
+  // First apply the user-chosen sort order, then pin favorites to the top
+  // (favorites preserve the sorted order within each group).
   const orderedStashes = useMemo(
-    () => sortStashesWithFavorites(stashes, favoriteIds),
-    [stashes, favoriteIds],
+    () => sortStashesWithFavorites(sortStashes(stashes, sortMode), favoriteIds),
+    [stashes, sortMode, favoriteIds],
   );
 
   return (
@@ -93,6 +98,31 @@ export default function Dashboard({
               </button>
             </span>
           )}
+          <label className="sort-control" title="Change how stashes are ordered">
+            <span className="sr-only">Sort stashes by</span>
+            <svg
+              className="sort-control-icon"
+              width="14"
+              height="14"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M11.5 15a.75.75 0 0 1-.53-.22l-2.75-2.75a.75.75 0 1 1 1.06-1.06l1.47 1.47V2.75a.75.75 0 0 1 1.5 0v9.69l1.47-1.47a.75.75 0 1 1 1.06 1.06l-2.75 2.75a.75.75 0 0 1-.53.22ZM1.75 4a.75.75 0 0 1 0-1.5h4.5a.75.75 0 0 1 0 1.5h-4.5Zm0 4a.75.75 0 0 1 0-1.5h3a.75.75 0 0 1 0 1.5h-3Zm0 4a.75.75 0 0 1 0-1.5h1.5a.75.75 0 0 1 0 1.5h-1.5Z" />
+            </svg>
+            <select
+              className="sort-select"
+              value={sortMode}
+              onChange={(e) => onSortChange(e.target.value as SortMode)}
+              aria-label="Sort stashes by"
+            >
+              {SORT_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
           <div className="layout-toggle">
             <button
               className={`layout-btn ${layout === 'grid' ? 'active' : ''}`}

--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -22,7 +22,10 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
   },
   {
     label: 'Search',
-    shortcuts: [{ keys: ['Alt', 'K'], description: 'Open quick search' }],
+    shortcuts: [
+      { keys: ['Alt', 'K'], description: 'Open quick search' },
+      { keys: ['/'], description: 'Focus sidebar search' },
+    ],
   },
   {
     label: 'Stash Viewer tabs',

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -239,6 +239,7 @@ export default function Sidebar({
           <div className="sidebar-search">
             <div className="search-input-wrapper">
               <input
+                id="sidebar-stash-search"
                 type="text"
                 placeholder="Search stashes..."
                 value={search}
@@ -254,7 +255,7 @@ export default function Sidebar({
                   }
                 }}
                 className="search-input"
-                title="Search by name, filename, or content — Esc to clear, Alt+K for quick search"
+                title="Search by name, filename, or content — / to focus, Esc to clear, Alt+K for quick search"
                 aria-label="Search stashes"
               />
               {search ? (

--- a/src/components/StashCard.tsx
+++ b/src/components/StashCard.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import type { StashListItem, LayoutMode } from '../types';
 import { renderDescriptionMarkdown } from '../utils/markdown';
+import { formatBytes } from '../utils/format';
 import RelativeTime from './shared/RelativeTime';
 
 interface Props {
@@ -30,6 +31,8 @@ export default function StashCard({
 }: Props) {
   const languages = getUniqueLanguages(stash);
   const title = stash.name || stash.files[0]?.filename || 'Untitled';
+  const fileCount = stash.files.length;
+  const sizeLabel = formatBytes(stash.total_size);
   // Memoize the rendered markdown — `renderDescriptionMarkdown` runs a DOMParser
   // sanitization pass on every call, which adds up across a 50-card dashboard.
   const descriptionHtml = useMemo(
@@ -150,7 +153,15 @@ export default function StashCard({
             </span>
           ))}
         </div>
-        <RelativeTime dateStr={stash.updated_at} className="stash-card-date" />
+        <div className="stash-card-meta">
+          <span
+            className="stash-card-stat"
+            title={`${fileCount} file${fileCount === 1 ? '' : 's'}, ${sizeLabel} total`}
+          >
+            {fileCount} {fileCount === 1 ? 'file' : 'files'} · {sizeLabel}
+          </span>
+          <RelativeTime dateStr={stash.updated_at} className="stash-card-date" />
+        </div>
       </div>
     </div>
   );

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1287,6 +1287,42 @@ body {
   color: var(--accent-orange);
 }
 
+.sort-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 6px 0 10px;
+  height: 32px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+}
+
+.sort-control:focus-within {
+  border-color: var(--accent-blue);
+}
+
+.sort-control-icon {
+  flex-shrink: 0;
+}
+
+.sort-select {
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 0 2px;
+  outline: none;
+}
+
+.sort-select option {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
 .layout-toggle {
   display: flex;
   border: 1px solid var(--border-color);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1550,6 +1550,19 @@ body {
   align-items: center;
 }
 
+.stash-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.stash-card-stat {
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
 .stash-card-date {
   font-size: 12px;
   color: var(--text-muted);

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,7 @@ export interface FileInput {
 
 export type ViewMode = 'home' | 'view' | 'edit' | 'new' | 'settings' | 'graph';
 export type LayoutMode = 'grid' | 'list';
+export type SortMode = 'updated' | 'created' | 'name' | 'size';
 export type SettingsSection = 'welcome' | 'general' | 'api' | 'storage' | 'about';
 export type ApiTab = 'tokens' | 'rest' | 'mcp';
 export type TokenScope = 'read' | 'write' | 'admin' | 'mcp';

--- a/src/utils/__tests__/format.test.ts
+++ b/src/utils/__tests__/format.test.ts
@@ -1,5 +1,37 @@
 import { describe, it, expect } from 'vitest';
-import { formatBuildVersion, formatDate, formatDateTime, formatRelativeTime } from '../format';
+import {
+  formatBuildVersion,
+  formatBytes,
+  formatDate,
+  formatDateTime,
+  formatRelativeTime,
+} from '../format';
+
+describe('formatBytes', () => {
+  it('renders bytes with no decimals', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(1)).toBe('1 B');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(1023)).toBe('1023 B');
+  });
+
+  it('switches to KB at 1024 and shows one decimal when not whole', () => {
+    expect(formatBytes(1024)).toBe('1 KB');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+  });
+
+  it('scales to MB / GB', () => {
+    expect(formatBytes(1024 * 1024)).toBe('1 MB');
+    expect(formatBytes(Math.round(3.2 * 1024 * 1024))).toBe('3.2 MB');
+    expect(formatBytes(1024 * 1024 * 1024)).toBe('1 GB');
+  });
+
+  it('clamps invalid / negative input to "0 B"', () => {
+    expect(formatBytes(-5)).toBe('0 B');
+    expect(formatBytes(NaN)).toBe('0 B');
+    expect(formatBytes(Infinity)).toBe('0 B');
+  });
+});
 
 describe('formatBuildVersion', () => {
   it('formats a valid ISO date as vYYYYMMDD-HHMM in UTC', () => {

--- a/src/utils/__tests__/sort.test.ts
+++ b/src/utils/__tests__/sort.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadSortMode, saveSortMode, sortStashes, SORT_OPTIONS } from '../sort';
+import type { StashListItem } from '../../types';
+
+const STORAGE_KEY = 'clawstash_sort';
+
+function installLocalStorageStub() {
+  const store = new Map<string, string>();
+  const stub = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+  };
+  vi.stubGlobal('localStorage', stub);
+  // load/saveSortMode also guard on `window`; provide a minimal stub.
+  vi.stubGlobal('window', { localStorage: stub });
+  return store;
+}
+
+function makeStash(overrides: Partial<StashListItem>): StashListItem {
+  return {
+    id: 'id',
+    name: '',
+    description: '',
+    tags: [],
+    version: 1,
+    archived: false,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    total_size: 0,
+    files: [],
+    ...overrides,
+  };
+}
+
+describe('loadSortMode', () => {
+  beforeEach(() => installLocalStorageStub());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('defaults to "updated" when nothing is stored', () => {
+    expect(loadSortMode()).toBe('updated');
+  });
+
+  it('returns a previously saved valid mode', () => {
+    localStorage.setItem(STORAGE_KEY, 'name');
+    expect(loadSortMode()).toBe('name');
+  });
+
+  it('falls back to "updated" on an invalid/hand-edited value', () => {
+    localStorage.setItem(STORAGE_KEY, 'bogus');
+    expect(loadSortMode()).toBe('updated');
+  });
+});
+
+describe('saveSortMode', () => {
+  beforeEach(() => installLocalStorageStub());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('persists and round-trips through loadSortMode', () => {
+    saveSortMode('size');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('size');
+    expect(loadSortMode()).toBe('size');
+  });
+});
+
+describe('sortStashes', () => {
+  const a = makeStash({
+    id: 'a',
+    name: 'Banana',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-03-01T00:00:00.000Z',
+    total_size: 100,
+  });
+  const b = makeStash({
+    id: 'b',
+    name: 'apple',
+    created_at: '2026-02-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    total_size: 300,
+  });
+  const c = makeStash({
+    id: 'c',
+    name: 'cherry',
+    created_at: '2026-03-01T00:00:00.000Z',
+    updated_at: '2026-02-01T00:00:00.000Z',
+    total_size: 200,
+  });
+  const list = [a, b, c];
+
+  it('does not mutate the input array', () => {
+    const input = [a, b, c];
+    sortStashes(input, 'name');
+    expect(input).toEqual([a, b, c]);
+  });
+
+  it('orders by updated_at descending (newest first)', () => {
+    expect(sortStashes(list, 'updated').map((s) => s.id)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('orders by created_at descending (newest first)', () => {
+    expect(sortStashes(list, 'created').map((s) => s.id)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('orders by name case-insensitively A–Z', () => {
+    expect(sortStashes(list, 'name').map((s) => s.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('orders by total_size descending (largest first)', () => {
+    expect(sortStashes(list, 'size').map((s) => s.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('uses first filename as the name fallback when name is empty', () => {
+    const noName = makeStash({
+      id: 'z',
+      name: '',
+      files: [{ filename: 'aaa.txt', language: 'text', size: 1 }],
+    });
+    const withName = makeStash({ id: 'y', name: 'zzz' });
+    expect(sortStashes([withName, noName], 'name').map((s) => s.id)).toEqual(['z', 'y']);
+  });
+
+  it('breaks ties deterministically by id', () => {
+    const t1 = makeStash({ id: 'x2', total_size: 50 });
+    const t2 = makeStash({ id: 'x1', total_size: 50 });
+    expect(sortStashes([t1, t2], 'size').map((s) => s.id)).toEqual(['x1', 'x2']);
+  });
+
+  it('treats unparseable dates as oldest for date sorts', () => {
+    const bad = makeStash({ id: 'bad', updated_at: 'not-a-date' });
+    const good = makeStash({ id: 'good', updated_at: '2026-05-01T00:00:00.000Z' });
+    expect(sortStashes([bad, good], 'updated').map((s) => s.id)).toEqual(['good', 'bad']);
+  });
+});
+
+describe('SORT_OPTIONS', () => {
+  it('exposes a label for every sort mode', () => {
+    expect(SORT_OPTIONS.map((o) => o.value)).toEqual(['updated', 'created', 'name', 'size']);
+    for (const o of SORT_OPTIONS) expect(o.label.length).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,4 +1,25 @@
 /**
+ * Format a byte count as a compact human-readable size ("0 B", "512 B",
+ * "1.5 KB", "3.2 MB", ...). Uses 1024-based units. Bytes show no decimals;
+ * larger units show one decimal unless the value is a whole number. Negative
+ * or NaN inputs are clamped to "0 B".
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  // Bytes are always whole; higher units get one decimal unless already whole.
+  const rounded = unit === 0 ? Math.round(value) : Math.round(value * 10) / 10;
+  const text = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+  return `${text} ${units[unit]}`;
+}
+
+/**
  * Format a date string as "MM/DD/YYYY, HH:MM" (used in token lists, etc.)
  */
 export function formatDateTime(dateStr: string): string {

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -1,0 +1,93 @@
+// Dashboard sort-order state + pure sort helper.
+//
+// Persistence mirrors the `clawstash_layout` pattern in App.tsx: a single
+// string value under a stable localStorage key. The sort itself is a pure,
+// React-free function so it can be unit-tested directly and reused.
+//
+// Sort runs BEFORE the favorites partition (`sortStashesWithFavorites`), so
+// pinned stashes stay on top while the rest follow the chosen order.
+
+import type { SortMode, StashListItem } from '../types';
+
+const STORAGE_KEY = 'clawstash_sort';
+
+/** All valid sort modes paired with a human label, for rendering the picker. */
+export const SORT_OPTIONS: { value: SortMode; label: string }[] = [
+  { value: 'updated', label: 'Recently updated' },
+  { value: 'created', label: 'Recently created' },
+  { value: 'name', label: 'Name (A–Z)' },
+  { value: 'size', label: 'Largest first' },
+];
+
+const VALID_MODES: ReadonlySet<string> = new Set(SORT_OPTIONS.map((o) => o.value));
+
+function isSortMode(value: unknown): value is SortMode {
+  return typeof value === 'string' && VALID_MODES.has(value);
+}
+
+/**
+ * Read the persisted sort mode from localStorage. Safe during SSR and on a
+ * missing / corrupted / hand-edited value (falls back to `'updated'`, which
+ * matches the server's default `updated_at DESC` order).
+ */
+export function loadSortMode(): SortMode {
+  if (typeof window === 'undefined' || typeof localStorage === 'undefined') {
+    return 'updated';
+  }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return isSortMode(raw) ? raw : 'updated';
+  } catch {
+    return 'updated';
+  }
+}
+
+/** Persist the sort mode to localStorage. No-op during SSR / on quota errors. */
+export function saveSortMode(mode: SortMode): void {
+  if (typeof window === 'undefined' || typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, mode);
+  } catch {
+    // Quota exceeded / private mode — sort stays in memory only.
+  }
+}
+
+// Parse an ISO date to epoch millis; unparseable dates sort to the bottom for
+// date-based orders (NaN-safe: treated as 0 / oldest).
+function timeOf(dateStr: string): number {
+  const t = new Date(dateStr).getTime();
+  return Number.isNaN(t) ? 0 : t;
+}
+
+/**
+ * Return a NEW array of stashes ordered by `mode`. The input is never mutated.
+ *
+ * - `updated` / `created`: newest first (descending timestamp)
+ * - `name`: case-insensitive A–Z; falls back to the first filename, then ''
+ * - `size`: largest `total_size` first
+ *
+ * Comparisons are stable-friendly: ties fall back to `id` so the order is
+ * deterministic across renders (Array.prototype.sort is stable in modern
+ * engines, but the id tiebreak keeps results identical regardless of input
+ * order — important since the server order can shift between fetches).
+ */
+export function sortStashes(stashes: readonly StashListItem[], mode: SortMode): StashListItem[] {
+  const byId = (a: StashListItem, b: StashListItem) => a.id.localeCompare(b.id);
+  const copy = stashes.slice();
+
+  switch (mode) {
+    case 'created':
+      return copy.sort((a, b) => timeOf(b.created_at) - timeOf(a.created_at) || byId(a, b));
+    case 'name':
+      return copy.sort((a, b) => {
+        const an = (a.name || a.files[0]?.filename || '').toLowerCase();
+        const bn = (b.name || b.files[0]?.filename || '').toLowerCase();
+        return an.localeCompare(bn) || byId(a, b);
+      });
+    case 'size':
+      return copy.sort((a, b) => b.total_size - a.total_size || byId(a, b));
+    case 'updated':
+    default:
+      return copy.sort((a, b) => timeOf(b.updated_at) - timeOf(a.updated_at) || byId(a, b));
+  }
+}


### PR DESCRIPTION
Autonomous feature-comfort sweep of the ClawStash web GUI. Three small UX/quality features, each in its own commit, all client-side (no server / DB / dependency changes).

## Stack

Next.js 16 (App Router), React 19, TypeScript (strict), better-sqlite3, vitest. Global CSS with custom properties (no CSS-in-JS), BEM-like class naming.

## Features

| # | Bereich/Datei | Kategorie | Feature | Nutzen für User | Aufwand | Empfehlung | Status |
|---|---|---|---|---|---|---|---|
| 1 | `src/utils/sort.ts`, `Dashboard.tsx`, `App.tsx`, `types.ts` | Komfort | Persisted dashboard **sort control** (Recently updated / Recently created / Name A–Z / Largest first) | Order the stash grid the way you want; choice persists across sessions (localStorage, like the layout pref). Sort runs before the favorites pin so pinned stashes stay on top within the chosen order. | M | auto-fix | done |
| 2 | `src/utils/format.ts`, `StashCard.tsx` | Polish | **File count + total size** badge on each stash card ("N files · X.X KB") | See per-stash size/file count at a glance without opening the viewer. New unit-tested `formatBytes` helper. | S | auto-fix | done |
| 3 | `App.tsx`, `Sidebar.tsx`, `KeyboardShortcutsHelp.tsx` | Komfort | **`/` hotkey** to focus the sidebar stash-search field (opens mobile drawer first, focuses + selects) | Standard power-user / agent shortcut for fast search; documented in the shortcuts dialog and the field tooltip. | S | auto-fix | done |

## Weitere Feature-Ideen

- Total storage size in the Settings → Storage overview (needs server `getStats` + DB query → out of client-only scope, deferred).
- Per-card "open in new tab" / copy-link affordance.

## Deferred

- None from this sweep.

## Out of Scope

- Refactors, dependency bumps, dependabot.
- Server / DB / API changes (all three features are client-only).
- Existing open issues (#52 already implemented; #108 large feature; #213 / #209 / #242 are refactor/security sweeps).

## Verifikation

`npm ci` → `npm run format:check` (clean) → `npx tsc --noEmit` (clean) → `npm test` (**134/134 pass, 12 files**; +17 new tests) → `npm run build` (green). No ESLint configured in repo.

Closes #255

---
_Generated by [Claude Code](https://claude.ai/code/session_017qEKJWSa8QRWKksWkEDDiR)_