### PR TITLE
ux: tag combobox arrow nav, cancel dirty-check, metadata copy buttons (#259)

### DIFF
--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -999,8 +999,7 @@ export default function StashViewer({
               <table className="metadata-table">
                 <tbody>
                   {Object.entries(stash.metadata).map(([key, value]) => {
-                    const display =
-                      typeof value === 'string' ? value : JSON.stringify(value);
+                    const display = typeof value === 'string' ? value : JSON.stringify(value);
                     const copyKey = `meta-${key}`;
                     return (
                       <tr key={key}>

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -998,14 +998,30 @@ export default function StashViewer({
               <h3>AI Metadata</h3>
               <table className="metadata-table">
                 <tbody>
-                  {Object.entries(stash.metadata).map(([key, value]) => (
-                    <tr key={key}>
-                      <td>{key}</td>
-                      <td>
-                        <code>{typeof value === 'string' ? value : JSON.stringify(value)}</code>
-                      </td>
-                    </tr>
-                  ))}
+                  {Object.entries(stash.metadata).map(([key, value]) => {
+                    const display =
+                      typeof value === 'string' ? value : JSON.stringify(value);
+                    const copyKey = `meta-${key}`;
+                    return (
+                      <tr key={key}>
+                        <td>{key}</td>
+                        <td className="metadata-value-cell">
+                          <code>{display}</code>
+                          <button
+                            className="btn btn-sm btn-ghost copy-btn-inline"
+                            onClick={() => apiClipboard.copy(copyKey, display)}
+                            title={`Copy value of "${key}"`}
+                            aria-label={`Copy value of "${key}"`}
+                          >
+                            <CopyButtonContent
+                              copied={apiClipboard.isCopied(copyKey)}
+                              failed={apiClipboard.isFailed(copyKey)}
+                            />
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>

--- a/src/components/editor/StashEditor.tsx
+++ b/src/components/editor/StashEditor.tsx
@@ -36,6 +36,7 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
   );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const [confirmCancel, setConfirmCancel] = useState(false);
   const [availableTags, setAvailableTags] = useState<TagInfo[]>([]);
   const [availableMetaKeys, setAvailableMetaKeys] = useState<string[]>([]);
   const [firstFileManuallyEdited, setFirstFileManuallyEdited] = useState(!!stash);
@@ -205,12 +206,42 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
       <div className="editor-header">
         <h2>{stash ? 'Edit Stash' : 'New Stash'}</h2>
         <div className="editor-header-actions">
-          <button className="btn btn-ghost" onClick={onCancel} title="Discard changes and go back">
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-              <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
-            </svg>
-            Cancel
-          </button>
+          {confirmCancel ? (
+            <span className="cancel-confirm-inline">
+              Discard changes?
+              <button
+                className="btn btn-danger btn-sm"
+                onClick={onCancel}
+                title="Discard all unsaved changes"
+              >
+                Discard
+              </button>
+              <button
+                className="btn btn-ghost btn-sm"
+                onClick={() => setConfirmCancel(false)}
+                title="Keep editing"
+              >
+                Keep editing
+              </button>
+            </span>
+          ) : (
+            <button
+              className="btn btn-ghost"
+              onClick={() => {
+                if (dirtyRef.current) {
+                  setConfirmCancel(true);
+                } else {
+                  onCancel();
+                }
+              }}
+              title="Discard changes and go back"
+            >
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+              </svg>
+              Cancel
+            </button>
+          )}
           <button
             className="btn btn-primary"
             onClick={handleSave}

--- a/src/components/editor/TagCombobox.tsx
+++ b/src/components/editor/TagCombobox.tsx
@@ -12,12 +12,19 @@ interface Props {
 export default function TagCombobox({ tags, onChange, availableTags, inputLabelledBy }: Props) {
   const [input, setInput] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   const filtered = availableTags
     .filter((t) => !tags.includes(t.tag))
     .filter((t) => !input || t.tag.toLowerCase().includes(input.toLowerCase()));
+
+  // Build the full option list: filtered suggestions + optional "Create" entry
+  const showCreate =
+    !!input.trim() && !availableTags.some((t) => t.tag === input.trim().toLowerCase());
+  const visibleOptions = filtered.slice(0, 10);
+  const totalOptions = visibleOptions.length + (showCreate ? 1 : 0);
 
   const addTag = (tag: string) => {
     const trimmed = tag.trim().toLowerCase();
@@ -26,6 +33,7 @@ export default function TagCombobox({ tags, onChange, availableTags, inputLabell
     }
     setInput('');
     setShowDropdown(false);
+    setActiveIndex(-1);
     inputRef.current?.focus();
   };
 
@@ -34,18 +42,45 @@ export default function TagCombobox({ tags, onChange, availableTags, inputLabell
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ',') {
+    if (e.key === 'ArrowDown') {
       e.preventDefault();
-      if (input.trim()) addTag(input);
+      setShowDropdown(true);
+      setActiveIndex((prev) => (totalOptions === 0 ? -1 : Math.min(prev + 1, totalOptions - 1)));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setShowDropdown(true);
+      setActiveIndex((prev) => Math.max(prev - 1, -1));
+    } else if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      if (showDropdown && activeIndex >= 0 && totalOptions > 0) {
+        // Select the highlighted option
+        if (activeIndex < visibleOptions.length) {
+          addTag(visibleOptions[activeIndex]!.tag);
+        } else {
+          // "Create" option
+          addTag(input);
+        }
+      } else if (input.trim()) {
+        addTag(input);
+      }
     } else if (e.key === 'Backspace' && !input && tags.length > 0) {
-      removeTag(tags[tags.length - 1]);
+      removeTag(tags[tags.length - 1]!);
     } else if (e.key === 'Escape') {
       setShowDropdown(false);
+      setActiveIndex(-1);
     }
   };
 
-  const closeDropdown = useCallback(() => setShowDropdown(false), []);
+  const closeDropdown = useCallback(() => {
+    setShowDropdown(false);
+    setActiveIndex(-1);
+  }, []);
   useClickOutside(wrapperRef, closeDropdown);
+
+  const activeOptionId =
+    showDropdown && activeIndex >= 0 ? `tag-combobox-option-${activeIndex}` : undefined;
+
+  const dropdownVisible = showDropdown && totalOptions > 0;
 
   return (
     <div className="tag-combobox" ref={wrapperRef}>
@@ -57,6 +92,7 @@ export default function TagCombobox({ tags, onChange, availableTags, inputLabell
           onChange={(e) => {
             setInput(e.target.value);
             setShowDropdown(true);
+            setActiveIndex(-1);
           }}
           onFocus={() => setShowDropdown(true)}
           onKeyDown={handleKeyDown}
@@ -64,49 +100,40 @@ export default function TagCombobox({ tags, onChange, availableTags, inputLabell
           className="tag-combobox-input"
           autoComplete="off"
           role="combobox"
-          aria-expanded={showDropdown && (filtered.length > 0 || !!input.trim())}
+          aria-expanded={dropdownVisible}
           aria-haspopup="listbox"
           aria-autocomplete="list"
           aria-controls="tag-combobox-listbox"
           aria-labelledby={inputLabelledBy}
+          aria-activedescendant={activeOptionId}
         />
       </div>
-      {showDropdown && filtered.length > 0 && (
+      {dropdownVisible && (
         <div id="tag-combobox-listbox" className="tag-combobox-dropdown" role="listbox">
-          {filtered.slice(0, 10).map((t) => (
+          {visibleOptions.map((t, i) => (
             <button
               key={t.tag}
-              className="tag-combobox-option"
+              id={`tag-combobox-option-${i}`}
+              className={`tag-combobox-option${activeIndex === i ? ' active' : ''}`}
               onClick={() => addTag(t.tag)}
               role="option"
-              aria-selected={false}
+              aria-selected={activeIndex === i}
             >
               <span>{t.tag}</span>
               <span className="tag-combobox-count">{t.count}</span>
             </button>
           ))}
-          {input.trim() && !availableTags.some((t) => t.tag === input.trim().toLowerCase()) && (
+          {showCreate && (
             <button
-              className="tag-combobox-option tag-combobox-create"
+              id={`tag-combobox-option-${visibleOptions.length}`}
+              className={`tag-combobox-option tag-combobox-create${activeIndex === visibleOptions.length ? ' active' : ''}`}
               onClick={() => addTag(input)}
               role="option"
-              aria-selected={false}
+              aria-selected={activeIndex === visibleOptions.length}
             >
               Create &quot;{input.trim()}&quot;
             </button>
           )}
-        </div>
-      )}
-      {showDropdown && filtered.length === 0 && input.trim() && (
-        <div id="tag-combobox-listbox" className="tag-combobox-dropdown" role="listbox">
-          <button
-            className="tag-combobox-option tag-combobox-create"
-            onClick={() => addTag(input)}
-            role="option"
-            aria-selected={false}
-          >
-            Create &quot;{input.trim()}&quot;
-          </button>
         </div>
       )}
       {tags.length > 0 && (

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2153,6 +2153,23 @@ body {
   gap: 6px;
 }
 
+.metadata-value-cell {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.copy-btn-inline {
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.metadata-table tr:hover .copy-btn-inline,
+.copy-btn-inline:focus-visible {
+  opacity: 1;
+}
+
 .stash-id-copy-btn {
   flex-shrink: 0;
   padding: 2px 6px;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5374,7 +5374,8 @@ body {
   text-align: left;
 }
 
-.tag-combobox-option:hover {
+.tag-combobox-option:hover,
+.tag-combobox-option.active {
   background: var(--bg-hover, #1c2128);
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2216,6 +2216,15 @@ body {
 .editor-header-actions {
   display: flex;
   gap: 8px;
+  align-items: center;
+}
+
+.cancel-confirm-inline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary, #8b949e);
 }
 
 .error-banner {


### PR DESCRIPTION
Closes #259

## Changes

Three small UX/comfort refinements to existing features. No new dependencies, no new API surface.

### 1. TagCombobox — Arrow Up/Down keyboard navigation

`role="combobox"` without arrow key navigation violates the ARIA combobox pattern. `aria-selected` was always `false`; `aria-activedescendant` was missing.

- Add `activeIndex` state; handle `ArrowDown` / `ArrowUp` with bounds clamping
- `Enter` with an active option selects it instead of adding typed text
- Per-option `id` attributes + `aria-activedescendant` on the input
- `aria-selected={activeIndex === i}` (was always `false`)
- `.active` CSS class on highlighted option (shares `:hover` style)

### 2. StashEditor — Confirm before discarding unsaved changes

The Cancel button called `onCancel()` directly, bypassing the existing `dirtyRef` dirty-state tracking. One misclick silently discarded all edits.

- If `dirtyRef.current`, show inline "Discard changes? [Discard] [Keep editing]" instead of navigating away
- If form is clean, Cancel navigates immediately (no extra click)

### 3. StashViewer — Copy buttons on metadata value cells

`useClipboardWithKey` and `CopyButtonContent` were already in the file for stash-id/API rows but unused for metadata values.

- Each metadata value `<td>` gets a `btn btn-sm btn-ghost` copy button
- Button hidden by default, shown on row hover or `focus-visible`
- Copy key scoped as `meta-{fieldKey}`

## Files

| File | LoC delta |
|---|---|
| `src/components/editor/TagCombobox.tsx` | +28 |
| `src/components/editor/StashEditor.tsx` | +25 |
| `src/components/StashViewer.tsx` | +15 |
| `src/styles/app.css` | +31 |

## Verification

```
npm ci              ✅
npm run format      ✅
npm run format:check ✅
npx tsc --noEmit    ✅
npm test            ✅  134/134 passed
npm run build       ✅
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01McmvxrjvMVdM8WFEhB6Xvd)_