### PR TITLE
fix(ci): exclude .claude/ from Prettier checks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,6 @@ data
 *.tsbuildinfo
 build-info.json
 .gitnexus
+# Tool-managed Claude Code config/skills (GitNexus rewrites skill files
+# non-Prettier-formatted on analyze, breaking format:check in CI)
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ Try/catch in async route handlers; UI components keep error state in React. Vali
 
 - **Language**: All UI text and documentation in English
 - **Module System**: ESM (`"type": "module"` in package.json)
-- **Formatting**: 2-space indentation, single quotes in TS
+- **Formatting**: 2-space indentation, single quotes in TS. `.claude/` is excluded via `.prettierignore` (tool-managed files; GitNexus rewrites its skill files non-Prettier-formatted) -- keep that exclusion.
 - **Imports**: Named imports, `@/*` path aliases for server-side imports in route handlers
 - **Components**: Functional React components with TypeScript interfaces for props
 - **Component Organization**: Complex features split into sub-directories (`api/`, `editor/`) with focused, single-responsibility files. Shared components in `shared/`, utilities in `utils/`.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -8,7 +8,7 @@ Session-spanning project knowledge. **Read at session start, update during work.
 
 ## Gotchas & Pitfalls
 
-_(No entries yet)_
+- **GitNexus skill files vs. Prettier (2026-06-12)** — GitNexus (re)writes `.claude/skills/gitnexus/*/SKILL.md` with its own Markdown table layout that fails `prettier --check`, causing recurring `format:check` failures in CI (a PostToolUse hook re-runs `analyze` after commits, so `--write` fixes never stick). Fix: `.claude/` is excluded in `.prettierignore` — do not remove that entry or re-format those files.
 
 ## Working Context
 


### PR DESCRIPTION
## Problem

CI (`npm run format:check`) keeps failing with:

```
[warn] .claude/skills/gitnexus/gitnexus-cli/SKILL.md
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
```

Root cause: GitNexus generates and rewrites `.claude/skills/gitnexus/*/SKILL.md` with its own Markdown table layout, which doesn't match Prettier's formatting. Since a PostToolUse hook re-runs `gitnexus analyze` after commits, running `prettier --write` never sticks — the files get rewritten unformatted again, so the failure recurs.

## Fix

- Add `.claude/` to `.prettierignore` — the directory is tool-managed (GitNexus skills, Claude Code config) and not part of the built product, so Prettier checks there only cause CI friction.
- Document the gotcha in `MEMORY.md` and the exclusion in `CLAUDE.md` (Coding Conventions) so the entry doesn't get removed later.

## Verification

`npm run format:check` passes locally with the unformatted GitNexus skill file untouched:

```
Checking formatting...
All matched files use Prettier code style!
```

https://claude.ai/code/session_01PzrKGYbFM8k3qrwfKJKAVb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzrKGYbFM8k3qrwfKJKAVb)_