### PR TITLE
fix(docker): repair bind-mount data dir ownership, fail fast on readonly DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- Docker bind mounts (`./data:/app/data`) no longer break with `SQLITE_READONLY` / failing admin login: the container now starts as root, fixes data-directory ownership, and drops privileges to `node` (uid 1000) via `setpriv` before launching the server. Databases created by older root-running image versions are repaired automatically. Additionally, `ClawStashDB` fails fast with an actionable error when the database path is not writable, instead of letting SQLite silently fall back to read-only mode
 - Multiple security and atomicity hardening rounds (#97 R1, #99 R2, #105 R3): metadata-array rejection, token-validate rate limit, FTS sentinel collision, transactional archive+update, useClickOutside touch on iOS Safari, popstate cancellation, mermaid hydration race, build-info NaN fallback, and many more — see #96 for the rolling list
 
 ## [1.0.0] - 2026-02-11

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,7 @@ npx gitnexus analyze --skip-agents-md
 - MCP is available as Streamable HTTP at `/mcp` (Next.js route handler) and as stdio via `npm run mcp`
 - Docker uses multi-stage build with Node 26-slim; requires python3/make/g++ for better-sqlite3 native addon compilation
 - Docker volume maps to `/app/data` for database persistence
+- Docker entrypoint (`docker-entrypoint.sh`) starts as root, chowns the data dir (fixes root-owned bind mounts), then drops to `node` (uid 1000) via `setpriv` — no `USER` directive in the Dockerfile; `ClawStashDB` additionally fail-fasts on unwritable DB paths (`db-access-check.ts`)
 - CI/CD pipeline: type-check -> (optional lint) -> (optional test) -> build -> Docker push to GHCR
 
 ## Refactoring Notes

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,9 @@ FROM node:26-slim
 
 WORKDIR /app
 
-# Run as non-root user for defense-in-depth. The node:26-slim image ships
-# with a `node` user (uid 1000). Pre-create the data directory so the
-# volume mount inherits the correct ownership on first run.
+# The app runs as the unprivileged `node` user (uid 1000) for
+# defense-in-depth. Pre-create the data directory so named volumes inherit
+# the correct ownership on first run.
 RUN mkdir -p /app/data && chown -R node:node /app /app/data
 
 # Copy standalone Next.js output (includes node_modules + server)
@@ -34,6 +34,13 @@ COPY --from=builder --chown=node:node /app/.next/standalone ./
 COPY --from=builder --chown=node:node /app/.next/static ./.next/static
 COPY --from=builder --chown=node:node /app/public ./public
 COPY --from=builder --chown=node:node /app/build-info.json ./build-info.json
+
+# Entrypoint starts as root, fixes bind-mount ownership of the data dir
+# (Docker creates ./data root-owned on Linux hosts), then drops privileges
+# to `node` via setpriv before exec'ing CMD. `command -v setpriv` asserts
+# at build time that the base image ships the privilege-drop tool.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh && command -v setpriv
 
 ENV NODE_ENV=production
 ENV PORT=3000
@@ -43,6 +50,7 @@ EXPOSE 3000
 
 VOLUME ["/app/data"]
 
-USER node
-
+# No USER directive: docker-entrypoint.sh needs root for the one-time chown
+# and immediately drops to `node` (uid 1000) for the server process.
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -8,6 +8,7 @@ Session-spanning project knowledge. **Read at session start, update during work.
 
 ## Gotchas & Pitfalls
 
+- **Docker bind mounts vs. non-root image (2026-06-12)** — since #200 the image runs the server as `node` (uid 1000). Linux Docker auto-creates bind-mount sources (`./data`) root-owned, and DBs created by pre-#200 root images stay root-owned → SQLite opens them read-only (documented READWRITE fallback, no error at open) and the first write fails with `SQLITE_READONLY` — symptom: server looks healthy but admin login breaks. Fixed via root entrypoint (`docker-entrypoint.sh`: chown data dir, then `setpriv` drop to `node`) + fail-fast writability check in `ClawStashDB` (`db-access-check.ts`). Don't reintroduce a `USER node` directive in the Dockerfile — it would bypass the entrypoint's chown.
 - **GitNexus skill files vs. Prettier (2026-06-12)** — GitNexus (re)writes `.claude/skills/gitnexus/*/SKILL.md` with its own Markdown table layout that fails `prettier --check`, causing recurring `format:check` failures in CI (a PostToolUse hook re-runs `analyze` after commits, so `--write` fixes never stick). Fix: `.claude/` is excluded in `.prettierignore` — do not remove that entry or re-format those files.
 
 ## Working Context

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ docker compose up -d
 Open http://localhost:3000 — done. Database persists in `./data/`.
 
 > Change port mapping (e.g. `"8080:3000"`) for a different port. Uncomment `ADMIN_PASSWORD` to protect the instance.
+> If login fails and the logs show `SQLITE_READONLY` (data directory created by an older version), run `sudo chown -R 1000:1000 ./data` once and restart — details in [Deployment → Bind mounts & file permissions](docs/deployment.md#bind-mounts--file-permissions).
 
 After starting, point your AI agent at the onboarding endpoint to self-configure:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - '${PORT:-3000}:3000'
     volumes:
       - clawstash-data:/app/data
+      # Bind mount alternative (entrypoint fixes ownership automatically):
+      # - ./data:/app/data
     environment:
       - NODE_ENV=production
       - PORT=3000

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+# ClawStash container entrypoint.
+#
+# The image starts as root so this script can repair the ownership of the
+# data directory before any application code runs, then drops privileges
+# to the unprivileged `node` user (uid 1000) — the same pattern the
+# official postgres/redis images use.
+#
+# Why: on Linux hosts Docker auto-creates bind-mount sources (e.g.
+# `./data:/app/data`) owned by root:root. Without the chown below the
+# `node` user cannot create or write the SQLite database, and every write
+# fails with SQLITE_READONLY / SQLITE_CANTOPEN (login breaks while the
+# server otherwise appears healthy). Databases created by image versions
+# that still ran as root are repaired by the same chown.
+
+DATA_DIR="$(dirname "${DATABASE_PATH:-/app/data/clawstash.db}")"
+
+if [ "$(id -u)" = '0' ]; then
+  # Best effort: a failing chown (read-only mount, NFS root_squash, ...)
+  # must not abort startup — the app prints an actionable error if the
+  # directory is truly unwritable.
+  chown -R node:node "$DATA_DIR" 2>/dev/null || true
+  exec setpriv --reuid node --regid node --init-groups "$@"
+fi
+
+# Container was started with an explicit non-root `user:` override —
+# run unchanged; the operator owns mount permissions in that case.
+exec "$@"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -55,6 +55,39 @@ docker run -p 3000:3000 \
   ghcr.io/fo0/clawstash:latest
 ```
 
+## Bind mounts & file permissions
+
+The server process inside the container runs as the unprivileged `node` user (**uid 1000**), not as root. The container _starts_ as root only so the entrypoint can fix ownership of the data directory, then immediately drops privileges before launching the app.
+
+- **Named volume** (`clawstash-data:/app/data`, the default in `docker-compose.yml`): works out of the box — Docker seeds the volume with the image's ownership.
+- **Bind mount** (`./data:/app/data`): on Linux hosts Docker creates `./data` owned by `root:root`. The entrypoint chowns the data directory to `node` on every start, so this also works out of the box.
+
+You only need to intervene in these cases:
+
+| Case                                                                      | Fix                                                                            |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Running an **older image** (which started directly as `node`)             | One-time on the host: `sudo chown -R 1000:1000 ./data`, then restart           |
+| Compose file sets a custom **`user:`** (entrypoint then can't chown)      | Make the mounted directory writable for that uid: `sudo chown -R <uid> ./data` |
+| Mount where chown is impossible (NFS `root_squash`, read-only mount, ...) | Ensure uid 1000 can write the directory by other means, or use a named volume  |
+
+### Symptom: login fails / `SQLITE_READONLY`
+
+If the data directory or database file is not writable by uid 1000, the logs show one of:
+
+```
+SqliteError: attempt to write a readonly database  (code: 'SQLITE_READONLY')
+SqliteError: unable to open database file           (code: 'SQLITE_CANTOPEN')
+ClawStash cannot start: the database directory '/app/data' is not writable ...
+```
+
+Typical effect: the server starts and pages load, but **admin login fails** (creating a session is the first database write). Fix the ownership as above and restart the container:
+
+```bash
+docker compose down
+sudo chown -R 1000:1000 ./data
+docker compose up -d
+```
+
 ## Node.js (without Docker)
 
 **Prerequisites:** Node.js 26+ (project pins Node 26 in Docker; `better-sqlite3` 12.x requires ≥ 20)

--- a/src/server/__tests__/db-access.test.ts
+++ b/src/server/__tests__/db-access.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { assertDatabaseWritable } from '../db-access-check';
+import { ClawStashDB } from '../db';
+
+/**
+ * Fail-fast writability check (Docker bind-mount permissions, refs the
+ * SQLITE_READONLY login failure): SQLite silently opens write-protected
+ * files read-only, so the constructor must reject them with an actionable
+ * error instead of letting later writes fail cryptically.
+ */
+
+// root (and Windows) bypass POSIX permission bits, so the negative cases
+// only run as an unprivileged user — which is what CI uses.
+const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+
+describe.skipIf(isRoot || process.platform === 'win32')('assertDatabaseWritable', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'clawstash-access-'));
+  });
+
+  afterEach(() => {
+    fs.chmodSync(tmp, 0o755);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('throws an actionable error when the directory is not writable', () => {
+    fs.chmodSync(tmp, 0o555);
+    expect(() => assertDatabaseWritable(tmp, path.join(tmp, 'db.sqlite'))).toThrow(
+      /directory '.*' is not writable[\s\S]*chown -R/,
+    );
+  });
+
+  it('throws when the database file itself is read-only', () => {
+    const dbPath = path.join(tmp, 'db.sqlite');
+    fs.writeFileSync(dbPath, '');
+    fs.chmodSync(dbPath, 0o444);
+    expect(() => assertDatabaseWritable(tmp, dbPath)).toThrow(
+      /file '.*db\.sqlite' is not writable/,
+    );
+  });
+
+  it('throws when a stale WAL sidecar file is read-only', () => {
+    const dbPath = path.join(tmp, 'db.sqlite');
+    fs.writeFileSync(dbPath, '');
+    fs.writeFileSync(`${dbPath}-wal`, '');
+    fs.chmodSync(`${dbPath}-wal`, 0o444);
+    expect(() => assertDatabaseWritable(tmp, dbPath)).toThrow(/db\.sqlite-wal' is not writable/);
+  });
+
+  it('passes for a writable directory without a database file', () => {
+    expect(() => assertDatabaseWritable(tmp, path.join(tmp, 'db.sqlite'))).not.toThrow();
+  });
+
+  it('surfaces the error from the ClawStashDB constructor', () => {
+    fs.chmodSync(tmp, 0o555);
+    expect(() => new ClawStashDB(path.join(tmp, 'db.sqlite'))).toThrow(/ClawStash cannot start/);
+  });
+});
+
+it('in-memory databases skip the writability check', () => {
+  // The rest of the suite relies on ClawStashDB(':memory:') staying exempt.
+  const db = new ClawStashDB(':memory:');
+  db.close();
+});

--- a/src/server/db-access-check.ts
+++ b/src/server/db-access-check.ts
@@ -1,0 +1,59 @@
+import fs from 'fs';
+
+/**
+ * Fail fast with an actionable message when the SQLite database cannot be
+ * written. SQLite's documented READWRITE fallback silently opens
+ * write-protected files in read-only mode, so without this check the first
+ * symptom is a cryptic `SQLITE_READONLY: attempt to write a readonly
+ * database` thrown by an unrelated write much later (e.g. session cleanup
+ * or admin login) while the server otherwise starts up fine.
+ *
+ * The classic trigger is a Docker bind mount: on Linux hosts Docker creates
+ * the mount source (e.g. `./data`) owned by root:root, while the container
+ * process runs as the unprivileged `node` user (uid 1000). The container
+ * entrypoint repairs ownership automatically when it starts as root, but a
+ * custom `user:` override, an old root-created database file, or a
+ * read-only mount can still produce an unwritable database — this check
+ * turns all of those into one clear startup error.
+ */
+export function assertDatabaseWritable(dir: string, dbPath: string): void {
+  let problem: string | null = null;
+
+  try {
+    // W_OK: create the database + WAL/SHM journal files; X_OK: traverse.
+    fs.accessSync(dir, fs.constants.W_OK | fs.constants.X_OK);
+  } catch {
+    problem = `the database directory '${dir}' is not writable`;
+  }
+
+  if (!problem) {
+    // A stale root-owned -wal/-shm next to a writable main file breaks
+    // writes just the same, so probe the sidecar files too.
+    for (const file of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+      if (!fs.existsSync(file)) continue;
+      try {
+        fs.accessSync(file, fs.constants.W_OK);
+      } catch {
+        problem = `the database file '${file}' is not writable`;
+        break;
+      }
+    }
+  }
+
+  if (!problem) return;
+
+  const uid = typeof process.getuid === 'function' ? process.getuid() : undefined;
+  const gid = typeof process.getgid === 'function' ? process.getgid() : undefined;
+  const who = uid !== undefined ? `this process (uid ${uid})` : 'this process';
+  const owner = uid !== undefined ? `${uid}:${gid ?? uid}` : '1000:1000';
+  throw new Error(
+    [
+      `ClawStash cannot start: ${problem} by ${who}.`,
+      'SQLite needs write access to the database file AND its directory (WAL journal files).',
+      'If you run ClawStash in Docker with a bind mount (e.g. ./data:/app/data), make the',
+      'mounted host directory writable for the container user:',
+      `  sudo chown -R ${owner} ./data   # host directory mounted to ${dir}`,
+      'then restart the container. Details: docs/deployment.md ("Bind mounts & file permissions").',
+    ].join('\n'),
+  );
+}

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 import path from 'path';
 import fs from 'fs';
 import { detectLanguage } from './detect-language';
+import { assertDatabaseWritable } from './db-access-check';
 import { INITIAL_SCHEMA_SQL } from './db-schema';
 import { applyPendingMigrations } from './db-migrations';
 import { TokenStore } from './stores/token-store';
@@ -77,6 +78,11 @@ export class ClawStashDB {
     const dir = path.dirname(resolvedPath);
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
+    }
+    if (resolvedPath !== ':memory:') {
+      // SQLite silently falls back to read-only on write-protected files;
+      // fail fast with an actionable error instead (Docker bind mounts).
+      assertDatabaseWritable(dir, resolvedPath);
     }
     this.db = new Database(resolvedPath);
     this.db.pragma('journal_mode = WAL');


### PR DESCRIPTION
# Summary

Fixes broken admin login (`SqliteError: attempt to write a readonly database`, `SQLITE_READONLY`) for Docker deployments that use a bind mount like `./data:/app/data`.

## Root cause

Since #200 the image runs the server as the unprivileged `node` user (uid 1000). Two situations then produce an unwritable database:

- Docker auto-creates the bind-mount source (`./data`) owned by `root:root` on Linux hosts.
- Databases created by older, root-running image versions stay owned by root after pulling the new image.

SQLite's documented `READWRITE` fallback silently opens write-protected files **read-only**, so the server starts up looking healthy — and the first write (session cleanup, then the login session INSERT) fails with a cryptic `SQLITE_READONLY`. The README quick start uses exactly this bind-mount setup, so fresh installs were affected too.

## Changes

- **`docker-entrypoint.sh` (new):** container starts as root, chowns the data directory (derived from `DATABASE_PATH`), then drops privileges to `node` via `setpriv` before exec'ing the server — the same pattern the official postgres/redis images use. Explicit non-root `user:` overrides run unchanged. chown is best-effort (read-only mounts, NFS `root_squash`) — the app check below is authoritative.
- **`Dockerfile`:** `USER node` replaced by the entrypoint; `command -v setpriv` asserts at build time that the base image ships the privilege-drop tool.
- **`src/server/db-access-check.ts` (new):** `ClawStashDB` now fails fast with an actionable error (which path is unwritable, current uid, exact `chown` command, docs pointer) when the DB directory, file, or stale WAL sidecars are not writable. `:memory:` databases are exempt.
- **Docs:** new "Bind mounts & file permissions" + troubleshooting section in `docs/deployment.md`, README quick-start note, commented bind-mount example in `docker-compose.yml`, CHANGELOG entry.

## Testing

- `npm run format` / `npx tsc --noEmit` / `npm test` (139 passed) / `npm run build` all green.
- New `db-access.test.ts` covers readonly dir, readonly DB file, readonly WAL sidecar, happy path, constructor surfacing, and the `:memory:` exemption (permission-bit cases skip under root/Windows; CI runs non-root).
- Negative paths additionally verified end-to-end by running the compiled check as `nobody` (uid 65534) against root-owned readonly dir/file — both produce the actionable error; the `setpriv --reuid node --regid node --init-groups` invocation used by the entrypoint was validated the same way.

## Operator note (existing deployments)

Until this image is published, affected hosts can fix it manually:

```bash
docker compose down
sudo chown -R 1000:1000 ./data
docker compose up -d
```

https://claude.ai/code/session_01RWnwNExZcWuu7pLn6wzec6

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWnwNExZcWuu7pLn6wzec6)_