### PR TITLE
feat(backup): add pre-filled GitHub creation links for OAuth app and PAT

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -17,10 +17,10 @@ Uses the GitHub OAuth **device flow**: no client secret, no callback URL, works 
 
 One-time setup:
 
-1. On GitHub: **Settings → Developer settings → OAuth Apps → New OAuth App**.
+1. On GitHub: **Settings → Developer settings → OAuth Apps → New OAuth App** — or click **create a GitHub OAuth app** in ClawStash's connect card, which opens the form pre-filled.
    - Name: anything (e.g. `ClawStash Backup`), Homepage: anything.
-   - Authorization callback URL: any placeholder (not used by the device flow).
-2. After creating the app, **enable "Device Flow"** in the app settings and copy the **Client ID**.
+   - Authorization callback URL: any placeholder (not used by the device flow; the pre-filled form uses `http://localhost`).
+2. Tick **"Enable Device Flow"** (on the creation form, or later in the app settings) and copy the **Client ID**.
 3. In ClawStash: paste the Client ID, click **Sign in with GitHub**, open the shown link, and enter the one-time code.
 
 The resulting token has the `repo` scope (GitHub OAuth apps have no narrower repo-level scope). If you want tighter scoping, use a fine-grained PAT instead.
@@ -29,8 +29,8 @@ The resulting token has the `repo` scope (GitHub OAuth apps have no narrower rep
 
 Best minimal-scope option and ideal for headless setups:
 
-1. On GitHub: **Settings → Developer settings → Fine-grained tokens → Generate new token**.
-2. Repository access: **Only select repositories** → your backup repo.
+1. On GitHub: **Settings → Developer settings → Fine-grained tokens → Generate new token** — or click **create one on GitHub** in ClawStash's connect card, which opens the form pre-filled with name, description, and the `Contents` permission.
+2. Repository access: **Only select repositories** → your backup repo (cannot be pre-filled — always set this manually).
 3. Permissions: **Contents → Read and write**. Nothing else (GitHub automatically adds the mandatory **Metadata → Read**).
 4. Paste the token into **connect with a personal access token** in ClawStash.
 

--- a/src/components/settings/BackupConnectCard.tsx
+++ b/src/components/settings/BackupConnectCard.tsx
@@ -25,6 +25,26 @@ const DEVICE_POLL_MIN_INTERVAL_SEC = 5;
 const DEVICE_POLL_MAX_CONSECUTIVE_FAILURES = 3;
 
 /**
+ * Pre-filled GitHub creation forms. GitHub ignores unknown query params, so
+ * if the pre-fill contract ever drifts these degrade to the empty form
+ * instead of breaking.
+ */
+const OAUTH_APP_CREATE_URL = `https://github.com/settings/applications/new?${new URLSearchParams({
+  'oauth_application[name]': 'ClawStash Backup',
+  'oauth_application[url]': 'https://github.com/fo0/clawstash',
+  // Required by the form but never called by the device flow.
+  'oauth_application[callback_url]': 'http://localhost',
+})}`;
+
+const PAT_CREATE_URL = `https://github.com/settings/personal-access-tokens/new?${new URLSearchParams(
+  {
+    name: 'ClawStash Backup',
+    description: 'Mirrors ClawStash stashes into the backup repository.',
+    contents: 'write',
+  },
+)}`;
+
+/**
  * GitHub connection card: "Sign in with GitHub" via OAuth device flow
  * (user code + github.com/login/device) with a PAT field as the headless
  * fallback. The token never reaches this component — the server stores it
@@ -183,9 +203,12 @@ export default function BackupConnectCard({ response, onUpdated }: Props) {
       ) : (
         <>
           <p className="api-hint">
-            Sign in with GitHub (recommended): create a GitHub OAuth app once (Settings → Developer
-            settings → OAuth Apps, enable <em>Device Flow</em>) and paste its client ID here — no
-            client secret, no callback URL needed.
+            Sign in with GitHub (recommended):{' '}
+            <a href={OAUTH_APP_CREATE_URL} target="_blank" rel="noopener noreferrer">
+              create a GitHub OAuth app
+            </a>{' '}
+            once — the form opens pre-filled, just tick <em>Enable Device Flow</em> — and paste its
+            client ID here. No client secret needed; the callback URL is an unused placeholder.
           </p>
           <div className="backup-form-row">
             <input
@@ -208,7 +231,11 @@ export default function BackupConnectCard({ response, onUpdated }: Props) {
             <button className="backup-link-btn" onClick={() => setShowPat((v) => !v)}>
               connect with a personal access token
             </button>{' '}
-            (fine-grained, “Contents: Read and write” on the target repository).
+            (fine-grained, “Contents: Read and write” on the target repository —{' '}
+            <a href={PAT_CREATE_URL} target="_blank" rel="noopener noreferrer">
+              create one on GitHub
+            </a>
+            ).
           </p>
           {showPat && (
             <div className="backup-form-row">


### PR DESCRIPTION
## Summary

The GitHub Backup connect card (Settings → GitHub Backup) now links directly to GitHub's creation forms for both connection paths, pre-filled via URL query parameters:

- **OAuth app** ("create a GitHub OAuth app"): opens `github.com/settings/applications/new` pre-filled with app name (`ClawStash Backup`), homepage, and a placeholder callback URL (`http://localhost`, never called by the device flow). The user only ticks *Enable Device Flow* and copies the Client ID.
- **Fine-grained PAT** ("create one on GitHub"): opens `github.com/settings/personal-access-tokens/new` pre-filled with token name, description, and the `Contents: Read and write` permission. Repository selection cannot be pre-filled, so the hint text and docs still tell the user to restrict it to the backup repo.

GitHub ignores unknown query parameters, so if the pre-fill contract ever drifts the links degrade gracefully to the empty form instead of breaking.

`docs/backup.md` (Path A / Path B setup steps) updated accordingly.

Refs #108.

## Test plan

- [x] `npm run format` / `format:check`
- [x] `npx tsc --noEmit`
- [x] `npm test` — 206 passed, 5 skipped
- [x] `npm run build`
- Manual: open Settings → GitHub Backup while disconnected; both links open the respective GitHub form in a new tab with fields pre-filled.

https://claude.ai/code/session_01NxCVZVaQmSf39BvbnUTz9o

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxCVZVaQmSf39BvbnUTz9o)_