### PR TITLE
feat(backup): split settings page into tabs

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -4,7 +4,7 @@ Temporary working context. **Clean up aggressively -- delete when resolved.**
 
 ## Current Work
 
-- Sweep-issue triage (2026-06-12): #213 closed (SRI fix already on main via PR #221). Remaining actionables from #209/#242 shipped on `claude/peaceful-albattani-5rmwla`: conditional HSTS (middleware) + control-char stripping in admin import/export audit logs; nonce-CSP and next-bundled-postcss CVE moved to BACKLOG #118/#119. PR closes #209 + #242 on merge.
+- Backup settings UI tabs (2026-06-12): Settings → GitHub Backup split into 4 tabs (Connection / Target & Schedule / Activity / Sync Log) on `claude/awesome-davinci-o46cv8`, PR #272. Panels stay mounted (hidden) so device-flow polling + unsaved form edits survive tab switches; review done (a11y fix for the unhealthy tab dot).
 
 ## Open Questions
 

--- a/agent_docs/project-structure.md
+++ b/agent_docs/project-structure.md
@@ -136,7 +136,14 @@ clawstash/
 │   │   ├── Settings.tsx        # Settings/admin area (general, API, storage, about)
 │   │   ├── shared/
 │   │   │   ├── icons.tsx       # Shared Octicon-style icons
+│   │   │   ├── CommitLink.tsx  # Short-SHA link to a backup commit on GitHub
 │   │   │   └── Spinner.tsx     # Loading spinner animation
+│   │   ├── settings/           # Settings sub-components (GitHub backup)
+│   │   │   ├── BackupSection.tsx # Settings → GitHub Backup: tab container (Connection / Target & Schedule / Activity / Sync Log)
+│   │   │   ├── BackupConnectCard.tsx # GitHub connection (OAuth device flow + PAT fallback)
+│   │   │   ├── BackupTargetCard.tsx # Target repo/branch, schedule, delete mode, commit author form
+│   │   │   ├── BackupActivityCard.tsx # Health summary, "Back up all now", per-stash sync states
+│   │   │   └── BackupLogCard.tsx # Recent sync log table
 │   │   ├── api/                # API management sub-components
 │   │   │   ├── ApiManager.tsx  # Tab container: Tokens/REST/MCP tabs
 │   │   │   ├── TokensTab.tsx   # Token CRUD + Quick Access spec copy

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -6,10 +6,12 @@ ClawStash can mirror all stashes into a GitHub repository — on a schedule, sho
 
 ## Quick start
 
+The settings page is split into four tabs — **Connection**, **Target & Schedule**, **Activity**, and **Sync Log** — and opens on the first step that still needs attention.
+
 1. Open **Settings → GitHub Backup** (admin login required when `ADMIN_PASSWORD` is set).
-2. Connect a GitHub account — pick one of the two paths below.
-3. Choose the target repository and branch, set a sync interval, click **Save settings**.
-4. Click **Back up all now** for the first full mirror.
+2. **Connection** tab: connect a GitHub account — pick one of the two paths below.
+3. **Target & Schedule** tab: choose the target repository and branch, set a sync interval, click **Save settings**.
+4. **Activity** tab: click **Back up all now** for the first full mirror.
 
 ### Path A — Sign in with GitHub (recommended)
 
@@ -73,9 +75,9 @@ Change detection is a SHA-256 content hash per stash — a sync with no changes 
 
 ## Observability
 
-- Per-stash status (idle / pending / syncing / error, last sync time, last commit SHA) in **Settings → GitHub Backup** and as a status bar in the stash viewer.
-- A bounded sync log (last 500 entries) records every run — including skipped no-change runs — with trigger, result, and commit SHA: `GET /api/backup/log`.
-- A health indicator marks the backup unhealthy after 3 consecutive failed runs.
+- Per-stash status (idle / pending / syncing / error, last sync time, last commit SHA) in the **Activity** tab of **Settings → GitHub Backup** and as a status bar in the stash viewer.
+- A bounded sync log (last 500 entries) records every run — including skipped no-change runs — with trigger, result, and commit SHA: the **Sync Log** tab, or `GET /api/backup/log`.
+- A health indicator marks the backup unhealthy after 3 consecutive failed runs and as a red dot on the **Activity** tab.
 
 ## Security
 

--- a/src/components/settings/BackupActivityCard.tsx
+++ b/src/components/settings/BackupActivityCard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import type { BackupLogEntry, BackupStatusResponse, BackupSyncState } from '../../types';
+import type { BackupStatusResponse, BackupSyncState } from '../../types';
 import { api } from '../../api';
 import { formatDateTime } from '../../utils/format';
 import Spinner from '../shared/Spinner';
@@ -12,13 +12,17 @@ const STATE_LABELS: Record<BackupSyncState, string> = {
   error: 'Error',
 };
 
+interface Props {
+  /** Called after a manual run so sibling tabs (sync log) can refetch. */
+  onSyncRan?: () => void;
+}
+
 /**
- * Sync activity: health summary, "Back up all now", per-stash states and
- * the recent sync log. Self-refreshing after manual runs.
+ * Sync activity: health summary, "Back up all now" and per-stash states.
+ * Self-refreshing after manual runs.
  */
-export default function BackupActivityCard() {
+export default function BackupActivityCard({ onSyncRan }: Props) {
   const [status, setStatus] = useState<BackupStatusResponse | null>(null);
-  const [log, setLog] = useState<BackupLogEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadFailed, setLoadFailed] = useState(false);
   const [syncing, setSyncing] = useState(false);
@@ -26,12 +30,8 @@ export default function BackupActivityCard() {
 
   const refresh = useCallback(async () => {
     try {
-      const [statusData, logData] = await Promise.all([
-        api.getBackupStatus(),
-        api.getBackupLog({ limit: 50 }),
-      ]);
+      const statusData = await api.getBackupStatus();
       setStatus(statusData);
-      setLog(logData.entries);
       setLoadFailed(false);
     } catch (err) {
       console.error('Failed to load backup status:', err);
@@ -59,6 +59,8 @@ export default function BackupActivityCard() {
     } finally {
       setSyncing(false);
       refresh();
+      // Both success and failure produce log entries.
+      onSyncRan?.();
     }
   };
 
@@ -170,44 +172,6 @@ export default function BackupActivityCard() {
             </tbody>
           </table>
         </div>
-      )}
-
-      {log.length > 0 && (
-        <>
-          <div className="settings-card-header backup-log-header">
-            <h3>Recent Sync Log</h3>
-          </div>
-          <div className="backup-table-wrap">
-            <table className="backup-table">
-              <thead>
-                <tr>
-                  <th>Time</th>
-                  <th>Trigger</th>
-                  <th>Status</th>
-                  <th>Details</th>
-                </tr>
-              </thead>
-              <tbody>
-                {log.map((entry) => (
-                  <tr key={entry.id}>
-                    <td>{formatDateTime(entry.started_at)}</td>
-                    <td>{entry.trigger}</td>
-                    <td>
-                      <span className={`backup-state-badge backup-log-${entry.status}`}>
-                        {entry.status}
-                      </span>
-                    </td>
-                    <td>
-                      {entry.stash_name ? `${entry.action ?? 'sync'} ${entry.stash_name} ` : ''}
-                      {entry.message}{' '}
-                      <CommitLink repoFullName={status.repoFullName} sha={entry.commit_sha} />
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </>
       )}
     </div>
   );

--- a/src/components/settings/BackupLogCard.tsx
+++ b/src/components/settings/BackupLogCard.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { BackupLogEntry } from '../../types';
+import { api } from '../../api';
+import { formatDateTime } from '../../utils/format';
+import Spinner from '../shared/Spinner';
+import CommitLink from '../shared/CommitLink';
+
+interface Props {
+  /** Saved backup target for commit links (null when no repo is configured). */
+  repoFullName: string | null;
+  /** Bumped by the parent after a manual sync so the log refetches. */
+  refreshToken: number;
+}
+
+/**
+ * Recent sync log: every scheduled / mutation / manual run, including
+ * skipped no-change runs, with trigger, result, and commit link.
+ */
+export default function BackupLogCard({ repoFullName, refreshToken }: Props) {
+  const [log, setLog] = useState<BackupLogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await api.getBackupLog({ limit: 50 });
+      setLog(data.entries);
+      setLoadFailed(false);
+    } catch (err) {
+      console.error('Failed to load backup log:', err);
+      setLoadFailed(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh, refreshToken]);
+
+  if (loading) {
+    return (
+      <div className="settings-card">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-card">
+      <div className="settings-card-header">
+        <h3>Recent Sync Log</h3>
+      </div>
+
+      {loadFailed && (
+        <div className="settings-import-error">
+          Could not load the sync log{log.length > 0 ? ' — the entries below may be stale' : ''}.
+        </div>
+      )}
+
+      <div className="settings-option-group">
+        <button className="btn btn-secondary btn-sm" onClick={refresh}>
+          Refresh
+        </button>
+      </div>
+
+      {log.length === 0 && !loadFailed && <p className="api-hint">No sync runs recorded yet.</p>}
+
+      {log.length > 0 && (
+        <div className="backup-table-wrap">
+          <table className="backup-table">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Trigger</th>
+                <th>Status</th>
+                <th>Details</th>
+              </tr>
+            </thead>
+            <tbody>
+              {log.map((entry) => (
+                <tr key={entry.id}>
+                  <td>{formatDateTime(entry.started_at)}</td>
+                  <td>{entry.trigger}</td>
+                  <td>
+                    <span className={`backup-state-badge backup-log-${entry.status}`}>
+                      {entry.status}
+                    </span>
+                  </td>
+                  <td>
+                    {entry.stash_name ? `${entry.action ?? 'sync'} ${entry.stash_name} ` : ''}
+                    {entry.message}{' '}
+                    <CommitLink repoFullName={repoFullName} sha={entry.commit_sha} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/BackupSection.tsx
+++ b/src/components/settings/BackupSection.tsx
@@ -1,24 +1,19 @@
-import { useEffect, useRef, useState } from 'react';
-import type { BackupRepoInfo, BackupSettings, BackupSettingsResponse } from '../../types';
+import { useEffect, useState } from 'react';
+import type { BackupSettingsResponse } from '../../types';
 import { api } from '../../api';
 import Spinner from '../shared/Spinner';
 import BackupConnectCard from './BackupConnectCard';
+import BackupTargetCard from './BackupTargetCard';
 import BackupActivityCard from './BackupActivityCard';
+import BackupLogCard from './BackupLogCard';
 
-/** Display form of the saved repo target ("owner/name", or a lone owner). */
-function formatRepoTarget(settings: { repoOwner: string; repoName: string }): string {
-  return settings.repoOwner && settings.repoName
-    ? `${settings.repoOwner}/${settings.repoName}`
-    : settings.repoOwner;
-}
+type BackupTab = 'connection' | 'target' | 'activity' | 'log';
 
-const INTERVAL_OPTIONS: { value: number; label: string }[] = [
-  { value: 0, label: 'Off (manual / on change only)' },
-  { value: 5, label: 'Every 5 minutes' },
-  { value: 15, label: 'Every 15 minutes' },
-  { value: 60, label: 'Every hour' },
-  { value: 360, label: 'Every 6 hours' },
-  { value: 1440, label: 'Every 24 hours' },
+const TABS: { id: BackupTab; label: string }[] = [
+  { id: 'connection', label: 'Connection' },
+  { id: 'target', label: 'Target & Schedule' },
+  { id: 'activity', label: 'Activity' },
+  { id: 'log', label: 'Sync Log' },
 ];
 
 function CloudIcon() {
@@ -41,48 +36,18 @@ function CloudIcon() {
 }
 
 /**
- * Settings → GitHub Backup. Connect an account (device flow or PAT), pick
- * the target repo/branch, configure the schedule, trigger manual syncs and
- * inspect the sync log. All endpoints are admin-gated server-side; without
- * admin access the API errors are surfaced inline (same pattern as the
- * token manager).
+ * Settings → GitHub Backup, split into tabs: connect an account (device
+ * flow or PAT), pick the target repo/branch and schedule, trigger manual
+ * syncs, and inspect the sync log. All endpoints are admin-gated
+ * server-side; without admin access the API errors are surfaced inline
+ * (same pattern as the token manager).
  */
 export default function BackupSection() {
   const [response, setResponse] = useState<BackupSettingsResponse | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [form, setForm] = useState<BackupSettings | null>(null);
-  // Raw text of the repository input. Kept separately from the derived
-  // repoOwner/repoName so a trailing "/" survives while typing — deriving
-  // the input value from the parsed halves would swallow the slash and make
-  // manual "owner/repo" entry impossible.
-  const [repoInput, setRepoInput] = useState('');
-  const [repos, setRepos] = useState<BackupRepoInfo[]>([]);
-  const [branches, setBranches] = useState<string[]>([]);
-  // Drops out-of-order branch responses (rapid repo switches).
-  const branchRequestGen = useRef(0);
-  const [saving, setSaving] = useState(false);
-  const [saveResult, setSaveResult] = useState<{ ok: boolean; message: string } | null>(null);
-
-  const applyResponse = (data: BackupSettingsResponse) => {
-    setResponse(data);
-    setForm((prev) => ({
-      ...data.settings,
-      // Keep unsaved target/schedule edits when only the connection changed.
-      ...(prev
-        ? {
-            repoOwner: prev.repoOwner,
-            repoName: prev.repoName,
-            branch: prev.branch,
-            pathPrefix: prev.pathPrefix,
-            intervalMinutes: prev.intervalMinutes,
-            deleteMode: prev.deleteMode,
-            commitAuthorName: prev.commitAuthorName,
-            commitAuthorEmail: prev.commitAuthorEmail,
-            enabled: prev.enabled,
-          }
-        : {}),
-    }));
-  };
+  const [activeTab, setActiveTab] = useState<BackupTab>('connection');
+  // Bumped after "Back up all now" so the sync-log tab refetches.
+  const [logRefresh, setLogRefresh] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -91,8 +56,15 @@ export default function BackupSection() {
       .then((data) => {
         if (cancelled) return;
         setResponse(data);
-        setForm(data.settings);
-        setRepoInput(formatRepoTarget(data.settings));
+        // Land where the setup funnel left off: connect → pick a target →
+        // watch activity.
+        setActiveTab(
+          !data.tokenSet
+            ? 'connection'
+            : data.settings.repoOwner && data.settings.repoName
+              ? 'activity'
+              : 'target',
+        );
       })
       .catch((err) => {
         if (cancelled) return;
@@ -110,85 +82,11 @@ export default function BackupSection() {
     };
   }, []);
 
-  // Repo suggestions once connected.
-  const tokenSet = response?.tokenSet ?? false;
-  useEffect(() => {
-    if (!tokenSet) {
-      setRepos([]);
-      return;
-    }
-    let cancelled = false;
-    api
-      .listBackupRepos()
-      .then((data) => {
-        if (!cancelled) setRepos(data.repos);
-      })
-      .catch(() => {
-        /* dropdown stays empty — manual entry still works */
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [tokenSet]);
-
-  const loadBranches = async (owner: string, repo: string) => {
-    if (!owner || !repo) return;
-    const gen = ++branchRequestGen.current;
-    try {
-      const data = await api.listBackupBranches(owner, repo);
-      if (gen !== branchRequestGen.current) return;
-      setBranches(data.branches);
-      setForm((prev) => (prev && !prev.branch ? { ...prev, branch: data.defaultBranch } : prev));
-    } catch {
-      if (gen === branchRequestGen.current) setBranches([]);
-    }
-  };
-
-  const handleRepoInput = (value: string) => {
-    setRepoInput(value);
-    // Any change invalidates the previously loaded branch list.
-    branchRequestGen.current++;
-    setBranches([]);
-    const [owner = '', name = ''] = value.split('/', 2);
-    setForm((prev) => (prev ? { ...prev, repoOwner: owner.trim(), repoName: name.trim() } : prev));
-    const match = repos.find((r) => r.fullName === value);
-    if (match) {
-      setForm((prev) => (prev ? { ...prev, branch: match.defaultBranch } : prev));
-      loadBranches(owner.trim(), name.trim());
-    }
-  };
-
-  const handleSave = async () => {
-    if (!form || !response) return;
-    setSaving(true);
-    setSaveResult(null);
-    try {
-      // The OAuth client ID is owned by the connect card / server — submit
-      // the latest known value so saving cannot clobber it.
-      const saved = await api.saveBackupSettings({
-        ...form,
-        branch: form.branch.trim() || 'main',
-        oauthClientId: response.settings.oauthClientId,
-      });
-      setResponse(saved);
-      setForm(saved.settings);
-      setRepoInput(formatRepoTarget(saved.settings));
-      setSaveResult({
-        ok: true,
-        message:
-          saved.settings.enabled && !saved.tokenSet
-            ? 'Settings saved. Connect a GitHub account to activate the backup.'
-            : 'Settings saved.',
-      });
-    } catch (err) {
-      setSaveResult({
-        ok: false,
-        message: err instanceof Error ? err.message : 'Saving failed.',
-      });
-    } finally {
-      setSaving(false);
-    }
-  };
+  const settings = response?.settings;
+  const repoFullName =
+    settings && settings.repoOwner && settings.repoName
+      ? `${settings.repoOwner}/${settings.repoName}`
+      : null;
 
   return (
     <div className="settings-section-content">
@@ -206,163 +104,54 @@ export default function BackupSection() {
 
       {loadError && <div className="settings-import-error">{loadError}</div>}
 
-      {!loadError && (!response || !form) && (
+      {!loadError && !response && (
         <div className="settings-card">
           <Spinner />
         </div>
       )}
 
-      {!loadError && response && form && (
+      {!loadError && response && (
         <>
-          <BackupConnectCard response={response} onUpdated={applyResponse} />
-
-          <div className="settings-card">
-            <div className="settings-card-header">
-              <h3>Target & Schedule</h3>
-            </div>
-
-            <label className="backup-field-label" htmlFor="backup-repo">
-              Repository
-            </label>
-            <div className="backup-form-row">
-              <input
-                id="backup-repo"
-                className="form-input"
-                placeholder="owner/repository"
-                list="backup-repo-list"
-                value={repoInput}
-                onChange={(e) => handleRepoInput(e.target.value)}
-                // Locked until a connection exists or a target was saved —
-                // without a token the repo cannot be listed or synced anyway.
-                disabled={!tokenSet && repos.length === 0 && !form.repoOwner && !repoInput}
-              />
-              <datalist id="backup-repo-list">
-                {repos.map((r) => (
-                  <option key={r.fullName} value={r.fullName} />
-                ))}
-              </datalist>
-            </div>
-
-            <label className="backup-field-label" htmlFor="backup-branch">
-              Branch
-            </label>
-            <div className="backup-form-row">
-              <input
-                id="backup-branch"
-                className="form-input"
-                placeholder="main"
-                list="backup-branch-list"
-                value={form.branch}
-                onFocus={() => {
-                  if (branches.length === 0) loadBranches(form.repoOwner, form.repoName);
-                }}
-                onChange={(e) => setForm({ ...form, branch: e.target.value })}
-              />
-              <datalist id="backup-branch-list">
-                {branches.map((b) => (
-                  <option key={b} value={b} />
-                ))}
-              </datalist>
-            </div>
-
-            <label className="backup-field-label" htmlFor="backup-prefix">
-              Path prefix in repository
-            </label>
-            <div className="backup-form-row">
-              <input
-                id="backup-prefix"
-                className="form-input"
-                placeholder="stashes"
-                value={form.pathPrefix}
-                onChange={(e) => setForm({ ...form, pathPrefix: e.target.value })}
-              />
-            </div>
-
-            <label className="backup-field-label" htmlFor="backup-interval">
-              Scheduled sync
-            </label>
-            <div className="backup-form-row">
-              <select
-                id="backup-interval"
-                className="form-input"
-                value={form.intervalMinutes}
-                onChange={(e) => setForm({ ...form, intervalMinutes: Number(e.target.value) })}
-              >
-                {INTERVAL_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <p className="api-hint">
-              Changes are additionally pushed ~10 seconds after every create / update / delete.
-            </p>
-
-            <label className="backup-field-label" htmlFor="backup-delete-mode">
-              When a stash is deleted
-            </label>
-            <div className="backup-form-row">
-              <select
-                id="backup-delete-mode"
-                className="form-input"
-                value={form.deleteMode}
-                onChange={(e) =>
-                  setForm({ ...form, deleteMode: e.target.value as 'remove' | 'keep' })
-                }
-              >
-                <option value="remove">Remove its files from the repo (history keeps them)</option>
-                <option value="keep">Keep its files in the repo</option>
-              </select>
-            </div>
-
-            <label className="backup-field-label" htmlFor="backup-author-name">
-              Commit author
-            </label>
-            <div className="backup-form-row">
-              <input
-                id="backup-author-name"
-                className="form-input"
-                placeholder="Name"
-                aria-label="Commit author name"
-                value={form.commitAuthorName}
-                onChange={(e) => setForm({ ...form, commitAuthorName: e.target.value })}
-              />
-              <input
-                className="form-input"
-                placeholder="email@example.com"
-                aria-label="Commit author email"
-                value={form.commitAuthorEmail}
-                onChange={(e) => setForm({ ...form, commitAuthorEmail: e.target.value })}
-              />
-            </div>
-
-            <label className="backup-toggle-row">
-              <input
-                type="checkbox"
-                checked={form.enabled}
-                onChange={(e) => setForm({ ...form, enabled: e.target.checked })}
-              />
-              <span>Enable automatic backups (scheduled + on change)</span>
-            </label>
-
-            <div className="settings-option-group">
+          <div className="api-tabs backup-tabs" role="tablist" aria-label="GitHub backup sections">
+            {TABS.map((tab) => (
               <button
-                className="btn btn-primary"
-                onClick={handleSave}
-                disabled={saving || !form.commitAuthorName.trim() || !form.commitAuthorEmail.trim()}
+                key={tab.id}
+                id={`backup-tab-${tab.id}`}
+                role="tab"
+                aria-selected={activeTab === tab.id}
+                className={`api-tab ${activeTab === tab.id ? 'active' : ''}`}
+                onClick={() => setActiveTab(tab.id)}
               >
-                {saving ? 'Saving…' : 'Save settings'}
+                {tab.label}
+                {tab.id === 'activity' && response.unhealthy && (
+                  <span className="backup-tab-alert" title="The backup has sync failures" />
+                )}
               </button>
-            </div>
-            {saveResult && (
-              <div className={saveResult.ok ? 'settings-import-success' : 'settings-import-error'}>
-                {saveResult.message}
-              </div>
-            )}
+            ))}
           </div>
 
-          <BackupActivityCard />
+          {/* Panels are hidden, not unmounted: a pending device-flow login
+              keeps polling and unsaved form edits survive tab switches. */}
+          <div
+            role="tabpanel"
+            aria-labelledby="backup-tab-connection"
+            hidden={activeTab !== 'connection'}
+          >
+            <BackupConnectCard response={response} onUpdated={setResponse} />
+          </div>
+          <div role="tabpanel" aria-labelledby="backup-tab-target" hidden={activeTab !== 'target'}>
+            <BackupTargetCard response={response} onSaved={setResponse} />
+          </div>
+          <div
+            role="tabpanel"
+            aria-labelledby="backup-tab-activity"
+            hidden={activeTab !== 'activity'}
+          >
+            <BackupActivityCard onSyncRan={() => setLogRefresh((n) => n + 1)} />
+          </div>
+          <div role="tabpanel" aria-labelledby="backup-tab-log" hidden={activeTab !== 'log'}>
+            <BackupLogCard repoFullName={repoFullName} refreshToken={logRefresh} />
+          </div>
         </>
       )}
     </div>

--- a/src/components/settings/BackupSection.tsx
+++ b/src/components/settings/BackupSection.tsx
@@ -113,21 +113,26 @@ export default function BackupSection() {
       {!loadError && response && (
         <>
           <div className="api-tabs backup-tabs" role="tablist" aria-label="GitHub backup sections">
-            {TABS.map((tab) => (
-              <button
-                key={tab.id}
-                id={`backup-tab-${tab.id}`}
-                role="tab"
-                aria-selected={activeTab === tab.id}
-                className={`api-tab ${activeTab === tab.id ? 'active' : ''}`}
-                onClick={() => setActiveTab(tab.id)}
-              >
-                {tab.label}
-                {tab.id === 'activity' && response.unhealthy && (
-                  <span className="backup-tab-alert" title="The backup has sync failures" />
-                )}
-              </button>
-            ))}
+            {TABS.map((tab) => {
+              const showAlert = tab.id === 'activity' && response.unhealthy;
+              return (
+                <button
+                  key={tab.id}
+                  id={`backup-tab-${tab.id}`}
+                  role="tab"
+                  aria-selected={activeTab === tab.id}
+                  // The alert dot is visual-only — mirror it for screen readers.
+                  aria-label={showAlert ? `${tab.label} — has sync failures` : undefined}
+                  className={`api-tab ${activeTab === tab.id ? 'active' : ''}`}
+                  onClick={() => setActiveTab(tab.id)}
+                >
+                  {tab.label}
+                  {showAlert && (
+                    <span className="backup-tab-alert" title="The backup has sync failures" />
+                  )}
+                </button>
+              );
+            })}
           </div>
 
           {/* Panels are hidden, not unmounted: a pending device-flow login

--- a/src/components/settings/BackupTargetCard.tsx
+++ b/src/components/settings/BackupTargetCard.tsx
@@ -1,0 +1,290 @@
+import { useEffect, useRef, useState } from 'react';
+import type { BackupRepoInfo, BackupSettings, BackupSettingsResponse } from '../../types';
+import { api } from '../../api';
+
+interface Props {
+  response: BackupSettingsResponse;
+  onSaved: (response: BackupSettingsResponse) => void;
+}
+
+/** Display form of the saved repo target ("owner/name", or a lone owner). */
+function formatRepoTarget(settings: { repoOwner: string; repoName: string }): string {
+  return settings.repoOwner && settings.repoName
+    ? `${settings.repoOwner}/${settings.repoName}`
+    : settings.repoOwner;
+}
+
+const INTERVAL_OPTIONS: { value: number; label: string }[] = [
+  { value: 0, label: 'Off (manual / on change only)' },
+  { value: 5, label: 'Every 5 minutes' },
+  { value: 15, label: 'Every 15 minutes' },
+  { value: 60, label: 'Every hour' },
+  { value: 360, label: 'Every 6 hours' },
+  { value: 1440, label: 'Every 24 hours' },
+];
+
+/**
+ * Target & Schedule form: repo/branch/path, sync interval, delete mode,
+ * commit author and the enable toggle. Owns the form state so unsaved
+ * edits survive tab switches; saved settings flow back via onSaved.
+ */
+export default function BackupTargetCard({ response, onSaved }: Props) {
+  const [form, setForm] = useState<BackupSettings>(response.settings);
+  // Raw text of the repository input. Kept separately from the derived
+  // repoOwner/repoName so a trailing "/" survives while typing — deriving
+  // the input value from the parsed halves would swallow the slash and make
+  // manual "owner/repo" entry impossible.
+  const [repoInput, setRepoInput] = useState(() => formatRepoTarget(response.settings));
+  const [repos, setRepos] = useState<BackupRepoInfo[]>([]);
+  const [branches, setBranches] = useState<string[]>([]);
+  // Drops out-of-order branch responses (rapid repo switches).
+  const branchRequestGen = useRef(0);
+  const [saving, setSaving] = useState(false);
+  const [saveResult, setSaveResult] = useState<{ ok: boolean; message: string } | null>(null);
+
+  // Adopt server-side settings changes (connect/disconnect on the connection
+  // tab updates the stored oauthClientId) while keeping unsaved target and
+  // schedule edits.
+  const lastResponse = useRef(response);
+  useEffect(() => {
+    if (lastResponse.current === response) return;
+    lastResponse.current = response;
+    setForm((prev) => ({
+      ...response.settings,
+      repoOwner: prev.repoOwner,
+      repoName: prev.repoName,
+      branch: prev.branch,
+      pathPrefix: prev.pathPrefix,
+      intervalMinutes: prev.intervalMinutes,
+      deleteMode: prev.deleteMode,
+      commitAuthorName: prev.commitAuthorName,
+      commitAuthorEmail: prev.commitAuthorEmail,
+      enabled: prev.enabled,
+    }));
+  }, [response]);
+
+  // Repo suggestions once connected.
+  const tokenSet = response.tokenSet;
+  useEffect(() => {
+    if (!tokenSet) {
+      setRepos([]);
+      return;
+    }
+    let cancelled = false;
+    api
+      .listBackupRepos()
+      .then((data) => {
+        if (!cancelled) setRepos(data.repos);
+      })
+      .catch(() => {
+        /* dropdown stays empty — manual entry still works */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [tokenSet]);
+
+  const loadBranches = async (owner: string, repo: string) => {
+    if (!owner || !repo) return;
+    const gen = ++branchRequestGen.current;
+    try {
+      const data = await api.listBackupBranches(owner, repo);
+      if (gen !== branchRequestGen.current) return;
+      setBranches(data.branches);
+      setForm((prev) => (!prev.branch ? { ...prev, branch: data.defaultBranch } : prev));
+    } catch {
+      if (gen === branchRequestGen.current) setBranches([]);
+    }
+  };
+
+  const handleRepoInput = (value: string) => {
+    setRepoInput(value);
+    // Any change invalidates the previously loaded branch list.
+    branchRequestGen.current++;
+    setBranches([]);
+    const [owner = '', name = ''] = value.split('/', 2);
+    setForm((prev) => ({ ...prev, repoOwner: owner.trim(), repoName: name.trim() }));
+    const match = repos.find((r) => r.fullName === value);
+    if (match) {
+      setForm((prev) => ({ ...prev, branch: match.defaultBranch }));
+      loadBranches(owner.trim(), name.trim());
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveResult(null);
+    try {
+      // The OAuth client ID is owned by the connection tab / server — submit
+      // the latest known value so saving cannot clobber it.
+      const saved = await api.saveBackupSettings({
+        ...form,
+        branch: form.branch.trim() || 'main',
+        oauthClientId: response.settings.oauthClientId,
+      });
+      setForm(saved.settings);
+      setRepoInput(formatRepoTarget(saved.settings));
+      onSaved(saved);
+      setSaveResult({
+        ok: true,
+        message:
+          saved.settings.enabled && !saved.tokenSet
+            ? 'Settings saved. Connect a GitHub account to activate the backup.'
+            : 'Settings saved.',
+      });
+    } catch (err) {
+      setSaveResult({
+        ok: false,
+        message: err instanceof Error ? err.message : 'Saving failed.',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="settings-card">
+      <div className="settings-card-header">
+        <h3>Target & Schedule</h3>
+      </div>
+
+      <label className="backup-field-label" htmlFor="backup-repo">
+        Repository
+      </label>
+      <div className="backup-form-row">
+        <input
+          id="backup-repo"
+          className="form-input"
+          placeholder="owner/repository"
+          list="backup-repo-list"
+          value={repoInput}
+          onChange={(e) => handleRepoInput(e.target.value)}
+          // Locked until a connection exists or a target was saved —
+          // without a token the repo cannot be listed or synced anyway.
+          disabled={!tokenSet && repos.length === 0 && !form.repoOwner && !repoInput}
+        />
+        <datalist id="backup-repo-list">
+          {repos.map((r) => (
+            <option key={r.fullName} value={r.fullName} />
+          ))}
+        </datalist>
+      </div>
+
+      <label className="backup-field-label" htmlFor="backup-branch">
+        Branch
+      </label>
+      <div className="backup-form-row">
+        <input
+          id="backup-branch"
+          className="form-input"
+          placeholder="main"
+          list="backup-branch-list"
+          value={form.branch}
+          onFocus={() => {
+            if (branches.length === 0) loadBranches(form.repoOwner, form.repoName);
+          }}
+          onChange={(e) => setForm({ ...form, branch: e.target.value })}
+        />
+        <datalist id="backup-branch-list">
+          {branches.map((b) => (
+            <option key={b} value={b} />
+          ))}
+        </datalist>
+      </div>
+
+      <label className="backup-field-label" htmlFor="backup-prefix">
+        Path prefix in repository
+      </label>
+      <div className="backup-form-row">
+        <input
+          id="backup-prefix"
+          className="form-input"
+          placeholder="stashes"
+          value={form.pathPrefix}
+          onChange={(e) => setForm({ ...form, pathPrefix: e.target.value })}
+        />
+      </div>
+
+      <label className="backup-field-label" htmlFor="backup-interval">
+        Scheduled sync
+      </label>
+      <div className="backup-form-row">
+        <select
+          id="backup-interval"
+          className="form-input"
+          value={form.intervalMinutes}
+          onChange={(e) => setForm({ ...form, intervalMinutes: Number(e.target.value) })}
+        >
+          {INTERVAL_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <p className="api-hint">
+        Changes are additionally pushed ~10 seconds after every create / update / delete.
+      </p>
+
+      <label className="backup-field-label" htmlFor="backup-delete-mode">
+        When a stash is deleted
+      </label>
+      <div className="backup-form-row">
+        <select
+          id="backup-delete-mode"
+          className="form-input"
+          value={form.deleteMode}
+          onChange={(e) => setForm({ ...form, deleteMode: e.target.value as 'remove' | 'keep' })}
+        >
+          <option value="remove">Remove its files from the repo (history keeps them)</option>
+          <option value="keep">Keep its files in the repo</option>
+        </select>
+      </div>
+
+      <label className="backup-field-label" htmlFor="backup-author-name">
+        Commit author
+      </label>
+      <div className="backup-form-row">
+        <input
+          id="backup-author-name"
+          className="form-input"
+          placeholder="Name"
+          aria-label="Commit author name"
+          value={form.commitAuthorName}
+          onChange={(e) => setForm({ ...form, commitAuthorName: e.target.value })}
+        />
+        <input
+          className="form-input"
+          placeholder="email@example.com"
+          aria-label="Commit author email"
+          value={form.commitAuthorEmail}
+          onChange={(e) => setForm({ ...form, commitAuthorEmail: e.target.value })}
+        />
+      </div>
+
+      <label className="backup-toggle-row">
+        <input
+          type="checkbox"
+          checked={form.enabled}
+          onChange={(e) => setForm({ ...form, enabled: e.target.checked })}
+        />
+        <span>Enable automatic backups (scheduled + on change)</span>
+      </label>
+
+      <div className="settings-option-group">
+        <button
+          className="btn btn-primary"
+          onClick={handleSave}
+          disabled={saving || !form.commitAuthorName.trim() || !form.commitAuthorEmail.trim()}
+        >
+          {saving ? 'Saving…' : 'Save settings'}
+        </button>
+      </div>
+      {saveResult && (
+        <div className={saveResult.ok ? 'settings-import-success' : 'settings-import-error'}>
+          {saveResult.message}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6527,6 +6527,23 @@ body {
 
 /* === GitHub Backup (refs #108) === */
 
+/* Section tabs reuse the api-tab look; the settings section's flex gap
+   already provides the spacing below the tab bar. */
+.api-tabs.backup-tabs {
+  margin-bottom: 0;
+}
+
+/* Unhealthy indicator on the Activity tab. */
+.backup-tab-alert {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  margin-left: 6px;
+  border-radius: 50%;
+  background: var(--accent-red);
+  vertical-align: 1px;
+}
+
 .backup-form-row {
   display: flex;
   gap: 8px;
@@ -6663,10 +6680,6 @@ body {
 
 .backup-table code {
   font-size: 12px;
-}
-
-.backup-log-header {
-  margin-top: 20px;
 }
 
 /* Per-stash backup bar in the viewer */


### PR DESCRIPTION
## Summary

The GitHub backup settings page stacked the connection, target/schedule and activity cards into one long scroll. This splits it into four tabs (reusing the existing `api-tab` look from the API settings page):

| Tab | Content |
| --- | --- |
| **Connection** | GitHub account (OAuth device flow / PAT), unchanged `BackupConnectCard` |
| **Target & Schedule** | Repo/branch/path, interval, delete mode, commit author — extracted into new `BackupTargetCard` |
| **Activity** | Health summary, "Back up all now", per-stash sync states (`BackupActivityCard`, log removed) |
| **Sync Log** | Recent sync runs — extracted into new `BackupLogCard` with its own refresh + empty state |

## Behavior details

- **Panels are hidden, not unmounted**: a pending device-flow login keeps polling and unsaved form edits survive tab switches.
- **Smart landing tab**: not connected → Connection; connected without a saved repo → Target & Schedule; fully configured → Activity.
- **Unhealthy indicator**: the Activity tab shows a red dot when the backup has consecutive sync failures, so errors stay visible even though the banner now lives behind a tab.
- After a manual "Back up all now", the Sync Log tab refetches automatically.
- `BackupSection` shrinks from ~370 to ~160 lines; form state moved into `BackupTargetCard`.

Docs (`docs/backup.md`) and `agent_docs/project-structure.md` updated (the latter was missing the `settings/` directory entirely).

Refs #108

## Checks

- `npm run format:check` ✅
- `npx tsc --noEmit` ✅
- `npm test` — 206 passed, 5 skipped ✅
- `npm run build` ✅

https://claude.ai/code/session_01DMD2CWfhtTVvsVwGLK3AJh

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMD2CWfhtTVvsVwGLK3AJh)_