### PR TITLE
security: hardening sweep (Next.js)

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,23 +1,61 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/server/singleton';
+import { isAuthEnabled } from '@/server/auth';
+import { checkScope } from '@/app/api/_helpers';
 
-export async function GET() {
+// GET /api/health — liveness probe for Docker/LB health checks.
+//
+// When auth is disabled (open mode) the response includes the stash/file
+// counts so operators can confirm data is present without a separate call.
+// When auth is enabled the stash/file counts are gated behind the `read`
+// scope to prevent unauthenticated callers from inferring the instance's
+// content volume. The database-connectivity signal (status: ok/error) is
+// always public so load-balancers without credentials can still route
+// traffic correctly.
+export async function GET(req: NextRequest) {
+  // Always return the DB liveness signal — that is the primary use-case
+  // for a health endpoint (load-balancer / Docker HEALTHCHECK) and does
+  // not leak sensitive data.
+  let dbConnected = false;
+  let stats: { totalStashes: number; totalFiles: number } | null = null;
+
   try {
     const db = getDb();
-    const stats = db.getStats();
-    return NextResponse.json({
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-      database: {
-        connected: true,
-        stashes: stats.totalStashes,
-        files: stats.totalFiles,
-      },
-    });
+    dbConnected = true;
+
+    // Include counts only when the caller is authorised to read them.
+    // In open mode every caller qualifies (isAuthEnabled() === false →
+    // checkScope always succeeds). When auth is on, omit counts for
+    // unauthenticated probes so the instance's content volume is not
+    // disclosed to anonymous callers.
+    if (!isAuthEnabled()) {
+      stats = db.getStats();
+    } else {
+      const scope = checkScope(req, 'read');
+      if (scope.ok) {
+        stats = db.getStats();
+      }
+    }
   } catch {
+    // DB error — fall through to the error response below.
+  }
+
+  if (!dbConnected) {
     return NextResponse.json(
       { status: 'error', timestamp: new Date().toISOString(), database: { connected: false } },
       { status: 503 },
     );
   }
+
+  const database: Record<string, unknown> = { connected: true };
+  if (stats !== null) {
+    database.stashes = stats.totalStashes;
+    database.files = stats.totalFiles;
+  }
+
+  return NextResponse.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    database,
+  });
 }


### PR DESCRIPTION
## Summary
One safe, non-breaking fix; four findings flagged for follow-up.

`src/app/api/health/route.ts` — when `ADMIN_PASSWORD` is set, `GET /api/health` previously returned `{ database: { stashes: N, files: N } }` to any unauthenticated caller, disclosing content volume without a credential. The fix mirrors the pattern used by every other read-scoped endpoint: gate the counts behind `checkScope(req, 'read')`. The DB liveness signal (`status: ok/error`, `connected`) stays unconditional so Docker `HEALTHCHECK` and LB probes keep working. In open mode (no password) behaviour is unchanged.

| # | Category | Severity | File | Change |
|---|----------|----------|------|--------|
| 1 | Info Disclosure | Medium | app/api/health/route.ts | gate stash/file counts behind read scope when auth is enabled |

Refs #274 — flagged items (`/api/version` auth gate + GitHub-fetch, CSP `script-src`, Mermaid `innerHTML` post-sanitise) tracked in the issue. All 36 API routes, server modules and render paths were reviewed; prepared statements, FTS5 sanitisation, timing-safe auth, path-traversal guards and markdown sanitisation verified clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKDJgPgHypQqHcULx4L27d)_