### PR TITLE
chore: quality &amp; housekeeping sweep (Node/TS)

### DIFF
--- a/agent_docs/ci_formatting_guard.md
+++ b/agent_docs/ci_formatting_guard.md
@@ -59,7 +59,7 @@ npx prettier --check .
 - **husky >= 9.1 is mandatory.** `prepare: "husky"` runs on every `npm ci` — including the Docker `deps` stage that `COPY package*.json` then `RUN npm ci` **without `.git`** (ClawStash's Dockerfile is multi-stage, Node 26-slim). husky >= 9.1 only prints a warning and **exits 0** when `.git` is missing; older husky versions abort with an error and break the Docker build. Verify: run `node node_modules/husky/bin.js` in a non-git directory → expect exit 0.
 - **`.husky/pre-commit` must use LF**, not CRLF (it runs on Linux/CI). Generate it via `printf`, not an editor that writes CRLF.
 - **Only commit `.husky/pre-commit`.** husky writes `.husky/_/.gitignore` (`*`), which ignores the wrapper directory. In husky v9 the hook file needs no `+x` and no shebang.
-- **`prettier --check .` silently skips files without a parser in directory mode** (shell hook scripts, `.gitignore`, etc.), so the hook scripts never break the check. (Errors occur only for *explicitly named* unknown files — CI passes a directory, so this is harmless.)
+- **`prettier --check .` silently skips files without a parser in directory mode** (shell hook scripts, `.gitignore`, etc.), so the hook scripts never break the check. (Errors occur only for _explicitly named_ unknown files — CI passes a directory, so this is harmless.)
 - **Never bypass with `git commit --no-verify`.**
 - The guard auto-corrects on **commit**. If commits via external GUIs are a concern, add a `pre-push` mirror that runs `npm run format:check` as a hard gate.
 


### PR DESCRIPTION
Automated quality & housekeeping sweep for `clawstash` (2026-06-14).

## Findings (merged)
| # | Pass | Datei | Befund | Fix | Aufwand |
| --- | --- | --- | --- | --- | --- |
| 1 | A — Formatting | `agent_docs/ci_formatting_guard.md` | Markdown emphasis not Prettier-normalized (`*x*` → `_x_`); CI `prettier --check .` gate failed on this file | `npm run format` (1-line, equivalence-preserving) | S |

## Tooling-Status
- **Formatter (Prettier):** configured — green after fix (`prettier --check .` exit 0).
- **Linter (ESLint):** intentionally absent (documented in CLAUDE.md). Not added.
- **Tests (vitest):** green — 211 passed, 5 skipped, 0 failed.
- **Typecheck (`tsc --noEmit`):** green.
- **Build (`next build`):** green.

## Verification
`npm install` → `prettier --check .` ✅ → `tsc --noEmit` ✅ → `vitest run` ✅ → `next build` ✅ — all green.

## Notes
- **Keine Version-Bumps enthalten.** Dependency version bumps and bot PRs are out of scope (dependency routine).
- No unused dependency removed (`react-dom` kept as the required Next.js render peer; all other deps used).
- No dead code / no TODO-FIXME markers found; docs verified accurate against the codebase (MCP tool list, REST endpoints, Node version, env vars, internal links).
- Only 1 file changed; no lockfile / `package.json` drift.

Closes #282

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbeb5exrTCuyth2SaqWFBV)_