### PR TITLE
feat: comfort sweep (Next.js)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import type {
 import { api, setAuthToken } from './api';
 import { loadFavoriteIds, saveFavoriteIds, toggleFavorite } from './utils/favorites';
 import { loadSortMode, saveSortMode } from './utils/sort';
+import { loadShowArchived, saveShowArchived } from './utils/archived';
 import { SEARCH_DEBOUNCE_MS } from './utils/constants';
 import Sidebar from './components/Sidebar';
 import Dashboard from './components/Dashboard';
@@ -103,7 +104,7 @@ export default function App() {
   const [searchOpen, setSearchOpen] = useState(false);
   const [shortcutsHelpOpen, setShortcutsHelpOpen] = useState(false);
   const [analyzeStashId, setAnalyzeStashId] = useState<string | null>(null);
-  const [showArchived, setShowArchived] = useState(false);
+  const [showArchived, setShowArchived] = useState<boolean>(loadShowArchived);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   // Favorite stash ids — persisted to localStorage (key `clawstash_favorite_stashes`).
   // Held as Set<string> for O(1) lookups during sort + per-card render.
@@ -594,6 +595,16 @@ export default function App() {
     saveSortMode(mode);
   };
 
+  // Toggle the "show archived" filter and persist it so the choice survives a
+  // reload (mirrors the layout/sort preference handlers above).
+  const handleToggleShowArchived = () => {
+    setShowArchived((prev) => {
+      const next = !prev;
+      saveShowArchived(next);
+      return next;
+    });
+  };
+
   // Show login screen if auth is required and user is not authenticated
   if (adminSession === null) {
     // Still loading session info
@@ -617,7 +628,7 @@ export default function App() {
         tags={tags}
         recentTags={recentTags}
         showArchived={showArchived}
-        onToggleShowArchived={() => setShowArchived((prev) => !prev)}
+        onToggleShowArchived={handleToggleShowArchived}
         onSelectStash={handleSelectStash}
         onNewStash={handleNewStash}
         onGoHome={handleGoHome}
@@ -694,7 +705,7 @@ export default function App() {
               showArchived={showArchived}
               favoriteIds={favoriteIds}
               onToggleFavorite={handleToggleFavorite}
-              onToggleShowArchived={() => setShowArchived((prev) => !prev)}
+              onToggleShowArchived={handleToggleShowArchived}
               onLayoutChange={handleLayoutChange}
               onSortChange={handleSortChange}
               onSelectStash={handleSelectStash}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -174,6 +174,15 @@ export default function App() {
         setView('new');
         pushUrl('/new');
         setSidebarOpen(false);
+      } else if (e.key === 'a') {
+        // Toggle the "show archived" dashboard filter and persist it (mirrors
+        // the click handler). Functional setState keeps the effect dependency-free.
+        e.preventDefault();
+        setShowArchived((prev) => {
+          const next = !prev;
+          saveShowArchived(next);
+          return next;
+        });
       } else if (e.key === 'Escape') {
         setView((currentView) => {
           if (currentView === 'view' || currentView === 'edit' || currentView === 'graph') {

--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -16,6 +16,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
     shortcuts: [
       { keys: ['n'], description: 'New stash' },
       { keys: ['e'], description: 'Edit current stash (in viewer)' },
+      { keys: ['a'], description: 'Toggle archived stashes on the dashboard' },
       { keys: ['Esc'], description: 'Back to dashboard / close overlay' },
       { keys: ['?'], description: 'Show / hide keyboard shortcuts' },
     ],

--- a/src/utils/__tests__/archived.test.ts
+++ b/src/utils/__tests__/archived.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadShowArchived, saveShowArchived } from '../archived';
+
+const STORAGE_KEY = 'clawstash_archived';
+
+function installLocalStorageStub() {
+  const store = new Map<string, string>();
+  const stub = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+  };
+  vi.stubGlobal('localStorage', stub);
+  // load/saveShowArchived also guard on `window`; provide a minimal stub.
+  vi.stubGlobal('window', { localStorage: stub });
+  return store;
+}
+
+describe('loadShowArchived', () => {
+  beforeEach(() => installLocalStorageStub());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('defaults to false when nothing is stored', () => {
+    expect(loadShowArchived()).toBe(false);
+  });
+
+  it('returns true only for the exact "1" marker', () => {
+    localStorage.setItem(STORAGE_KEY, '1');
+    expect(loadShowArchived()).toBe(true);
+  });
+
+  it('returns false for "0"', () => {
+    localStorage.setItem(STORAGE_KEY, '0');
+    expect(loadShowArchived()).toBe(false);
+  });
+
+  it('falls back to false on an unexpected/hand-edited value', () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    expect(loadShowArchived()).toBe(false);
+  });
+});
+
+describe('saveShowArchived', () => {
+  beforeEach(() => installLocalStorageStub());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('persists true as "1" and round-trips through loadShowArchived', () => {
+    saveShowArchived(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('1');
+    expect(loadShowArchived()).toBe(true);
+  });
+
+  it('persists false as "0" and round-trips through loadShowArchived', () => {
+    saveShowArchived(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('0');
+    expect(loadShowArchived()).toBe(false);
+  });
+});

--- a/src/utils/archived.ts
+++ b/src/utils/archived.ts
@@ -1,0 +1,37 @@
+// Persistence for the dashboard "show archived stashes" toggle.
+//
+// Mirrors the `clawstash_layout` / `clawstash_sort` pattern: a single string
+// value ('1' | '0') under a stable localStorage key, with SSR- and
+// quota-safe getters/setters. Keeping it here (React-free) lets it be
+// unit-tested directly and reused without dragging in component state.
+//
+// Default is `false` (hide archived) to match the server default and the
+// prior in-memory behaviour, so an unset / corrupted value is harmless.
+
+const STORAGE_KEY = 'clawstash_archived';
+
+/**
+ * Read the persisted "show archived" preference from localStorage. Safe during
+ * SSR and on a missing / corrupted value (falls back to `false`, i.e. hide
+ * archived — the server default).
+ */
+export function loadShowArchived(): boolean {
+  if (typeof window === 'undefined' || typeof localStorage === 'undefined') {
+    return false;
+  }
+  try {
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/** Persist the "show archived" preference. No-op during SSR / on quota errors. */
+export function saveShowArchived(show: boolean): void {
+  if (typeof window === 'undefined' || typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, show ? '1' : '0');
+  } catch {
+    // Quota exceeded / private mode — preference stays in memory only.
+  }
+}


### PR DESCRIPTION
Autonomous comfort sweep — two small dashboard quality-of-life wins, both reusing the existing localStorage-preference pattern. Verified green (`tsc --noEmit` + 232 vitest tests + build).

| # | Bereich/Datei | Kategorie | Feature | Nutzen | Aufwand |
|---|---------------|-----------|---------|--------|---------|
| 1 | `utils/archived.ts` + `App.tsx` | Komfort | Persist "show archived" toggle across reloads | Dashboard keeps the archived filter on reload (mirrors layout/sort persistence); SSR/quota-safe + unit-tested | S |
| 2 | `App.tsx` + `KeyboardShortcutsHelp.tsx` | Komfort | `a` hotkey toggles archived (documented in shortcuts help) | Toggle from anywhere; joins existing `n`/`e` hotkeys | S |

No deps added. Note: #52 (description Markdown) is already implemented (`renderDescriptionMarkdown`) and was not rebuilt.

Closes #290

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCKbRrKvKfRNnrJy6myQnA)_