### PR TITLE
ux: best-practice sweep (Next.js + React)

### DIFF
--- a/src/components/LoginScreen.tsx
+++ b/src/components/LoginScreen.tsx
@@ -32,7 +32,7 @@ export default function LoginScreen({ onLogin }: Props) {
         </div>
         <p className="login-hint">Enter your password to continue.</p>
         {error && (
-          <div className="login-error" role="alert">
+          <div id="login-error-msg" className="login-error" role="alert">
             {error}
           </div>
         )}

--- a/src/components/VersionHistory.tsx
+++ b/src/components/VersionHistory.tsx
@@ -278,6 +278,7 @@ export default function VersionHistory({ stashId, currentVersion, onRestore }: P
       {error && (
         <div
           className="version-error"
+          role="alert"
           style={{
             color: 'var(--text-danger, #f85149)',
             padding: '8px 12px',

--- a/src/components/settings/BackupConnectCard.tsx
+++ b/src/components/settings/BackupConnectCard.tsx
@@ -228,7 +228,12 @@ export default function BackupConnectCard({ response, onUpdated }: Props) {
           </div>
           <p className="api-hint">
             Alternatively,{' '}
-            <button className="backup-link-btn" onClick={() => setShowPat((v) => !v)}>
+            <button
+              className="backup-link-btn"
+              onClick={() => setShowPat((v) => !v)}
+              aria-expanded={showPat}
+              aria-controls="backup-pat-form"
+            >
               connect with a personal access token
             </button>{' '}
             (fine-grained, “Contents: Read and write” on the target repository —{' '}
@@ -238,7 +243,7 @@ export default function BackupConnectCard({ response, onUpdated }: Props) {
             ).
           </p>
           {showPat && (
-            <div className="backup-form-row">
+            <div className="backup-form-row" id="backup-pat-form">
               <input
                 className="form-input"
                 type="password"


### PR DESCRIPTION
## Gemergte Findings
| # | Datei | Kategorie | Aufwand | Empfehlung |
|---|-------|-----------|---------|------------|
| 1 | src/components/LoginScreen.tsx | a11y | S | auto-fix |
| 2 | src/components/VersionHistory.tsx | a11y | S | auto-fix |
| 3 | src/components/settings/BackupConnectCard.tsx | a11y | S | auto-fix |

Additive a11y only: dangling `aria-describedby` am Login-Fehler behoben (`id` ergänzt); `role="alert"` am Version-History-Fehlerbanner; `aria-expanded`/`aria-controls` am PAT-Disclosure-Toggle.

**Betroffene Screens:** Login, Version-History (Vergleich), Settings → Backup-Connect. Keine visuelle Änderung.
**Verifikation:** `npm ci && tsc --noEmit && npm test (232) && npm run build` grün.

Closes #294

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcBFniNKuQecPBxm5UYrFx)_