### PR TITLE
refine: ux sweep (Next.js)

### DIFF
--- a/src/components/StashBackupControls.tsx
+++ b/src/components/StashBackupControls.tsx
@@ -140,6 +140,16 @@ export default function StashBackupControls({ stash, onStashUpdated }: Props) {
           {message.text}
         </span>
       )}
+      {/* Persistent visually-hidden live region so the backup result is
+          announced to screen readers. Kept always-mounted (empty when idle):
+          injecting text into an existing aria-live node announces more
+          reliably than mounting a fresh node with text already in it, and
+          .sr-only is position:absolute so it adds no flex gap. The visible
+          message above carries no aria-live, so sighted behaviour is
+          unchanged. */}
+      <span className="sr-only" role="status" aria-live="polite">
+        {message?.text ?? ''}
+      </span>
     </div>
   );
 }

--- a/src/components/VersionHistory.tsx
+++ b/src/components/VersionHistory.tsx
@@ -5,6 +5,8 @@ import { formatRelativeTime } from '../utils/format';
 import VersionDiff from './VersionDiff';
 import { highlightCode, resolvePrismLanguage } from '../languages';
 import { DELETE_CONFIRM_TIMEOUT_MS } from '../utils/constants';
+import { useClipboardWithKey } from '../hooks/useClipboard';
+import { CopyIcon, CheckIcon, XIcon } from './shared/icons';
 import Spinner from './shared/Spinner';
 
 interface Props {
@@ -31,6 +33,11 @@ export default function VersionHistory({ stashId, currentVersion, onRestore }: P
   const [compareTo, setCompareTo] = useState<number | null>(null);
   const [diffData, setDiffData] = useState<{ v1: StashVersion; v2: StashVersion } | null>(null);
   const [diffLoading, setDiffLoading] = useState(false);
+
+  // Per-file copy feedback for the version-detail view, mirroring the copy
+  // affordance the main StashViewer offers — keyed by filename so each file
+  // button tracks its own "Copied!" state.
+  const fileClipboard = useClipboardWithKey();
 
   useEffect(() => {
     let cancelled = false;
@@ -238,6 +245,32 @@ export default function VersionHistory({ stashId, currentVersion, onRestore }: P
                 <div className="file-header">
                   <span className="file-name">{file.filename}</span>
                   {file.language && <span className="lang-tag">{file.language}</span>}
+                  <button
+                    className="btn btn-sm btn-ghost version-file-copy-btn"
+                    onClick={() => fileClipboard.copy(file.filename, file.content)}
+                    title={
+                      fileClipboard.isCopied(file.filename)
+                        ? 'Copied!'
+                        : fileClipboard.isFailed(file.filename)
+                          ? 'Copy failed'
+                          : 'Copy file content to clipboard'
+                    }
+                    aria-label={`Copy content of ${file.filename}`}
+                  >
+                    {fileClipboard.isCopied(file.filename) ? (
+                      <>
+                        <CheckIcon size={12} /> Copied!
+                      </>
+                    ) : fileClipboard.isFailed(file.filename) ? (
+                      <>
+                        <XIcon size={12} /> Failed
+                      </>
+                    ) : (
+                      <>
+                        <CopyIcon size={12} /> Copy
+                      </>
+                    )}
+                  </button>
                 </div>
                 <pre className="file-content">
                   <code dangerouslySetInnerHTML={{ __html: highlightCode(file.content, lang) }} />

--- a/src/components/VersionHistory.tsx
+++ b/src/components/VersionHistory.tsx
@@ -398,6 +398,7 @@ export default function VersionHistory({ stashId, currentVersion, onRestore }: P
                       checked={compareFrom === v.version}
                       onChange={() => handleFromChange(v.version)}
                       disabled={isNewest || (compareTo !== null && v.version >= compareTo)}
+                      aria-label={`Compare from version ${v.version}`}
                     />
                   </label>
                   {/* "To" radio — disabled for the oldest version (nothing older to compare from) */}
@@ -408,6 +409,7 @@ export default function VersionHistory({ stashId, currentVersion, onRestore }: P
                       checked={compareTo === v.version}
                       onChange={() => handleToChange(v.version)}
                       disabled={isOldest || (compareFrom !== null && v.version <= compareFrom)}
+                      aria-label={`Compare to version ${v.version}`}
                     />
                   </label>
                 </div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1913,6 +1913,14 @@ body {
   gap: 8px;
 }
 
+/* Copy button in the VersionHistory file detail header. The header is a
+   flex row (filename + optional lang-tag + this button); margin-left:auto
+   keeps the filename/lang-tag grouped left and pins the button to the
+   right, matching the StashViewer file-header affordance. */
+.version-file-copy-btn {
+  margin-left: auto;
+}
+
 /* Collapsible file headers (stash viewer only — VersionHistory reuses
    .file-header without collapse behavior). The empty header surface is a
    click target; the filename stays selectable and the actions area neutral. */


### PR DESCRIPTION
Small, additive UX/comfort refinements to existing user-facing features. No new endpoints/MCP tools, no dependency bumps, no architecture changes. The codebase is already heavily UX-polished, so this only fills genuinely-missing comfort/A11y gaps.

## Refinements
| # | Bestehendes Feature | Bereich/Datei | Kategorie | UX-Lücke | Verbesserung | Aufwand |
|---|---|---|---|---|---|---|
| 1 | Version history (View detail) | `src/components/VersionHistory.tsx`, `src/styles/app.css` | Komfort | Old-version file content was read-only with no copy affordance, unlike the main StashViewer | Per-file Copy button in the version-detail header (reuses `useClipboardWithKey` + shared copy/check/x icons), timed Copied!/Failed feedback + aria-label | M |
| 2 | GitHub backup controls | `src/components/StashBackupControls.tsx` | A11y/Feedback | "Back up now" / "Exclude" result text had no live region — screen-reader users got no feedback | Persistent visually-hidden `aria-live="polite"` status region mirroring the message text; visible message unchanged (no layout/behaviour change, no flex gap when idle) | S |
| 3 | Version compare radios | `src/components/VersionHistory.tsx` | A11y | From/To radios carried context only on the wrapping label's `title`; screen readers announced a bare "radio button" | `aria-label` on each radio ("Compare from version N" / "Compare to version N") | S |

## Verification
`npm run format:check && npx tsc --noEmit && npm test && npm run build` — all green (242 tests passed, 5 skipped; build OK).

## Patterns reused (no reinvention)
- `useClipboardWithKey` hook + `CopyIcon`/`CheckIcon`/`XIcon` from `shared/icons` (same as StashViewer's file copy)
- Existing `.sr-only` class (position:absolute → no flex gap) for the live region
- Global CSS custom properties + BEM-like classes, no CSS-in-JS

Closes #299

---
_Generated by [Claude Code](https://claude.ai/code/session_011XS1RuiP7io49gb8SMZbFX)_