### PR TITLE
feat: comfort sweep (Next.js)

### DIFF
--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -1056,7 +1056,30 @@ export default function StashViewer({
 
           {Object.keys(stash.metadata).length > 0 && (
             <div className="metadata-section">
-              <h3>AI Metadata</h3>
+              <div className="metadata-section-header">
+                <h3>AI Metadata</h3>
+                <button
+                  className="btn btn-sm btn-ghost copy-btn-inline"
+                  onClick={() =>
+                    apiClipboard.copy('meta-all-json', JSON.stringify(stash.metadata, null, 2))
+                  }
+                  title={
+                    apiClipboard.isCopied('meta-all-json')
+                      ? 'Copied!'
+                      : apiClipboard.isFailed('meta-all-json')
+                        ? 'Copy failed'
+                        : 'Copy all metadata as JSON'
+                  }
+                  aria-label="Copy all metadata as JSON"
+                >
+                  <CopyButtonContent
+                    copied={apiClipboard.isCopied('meta-all-json')}
+                    failed={apiClipboard.isFailed('meta-all-json')}
+                    size={12}
+                    labelCopy="Copy JSON"
+                  />
+                </button>
+              </div>
               <table className="metadata-table">
                 <tbody>
                   {Object.entries(stash.metadata).map(([key, value]) => {

--- a/src/components/api/TokensTab.tsx
+++ b/src/components/api/TokensTab.tsx
@@ -217,6 +217,14 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec }: Props) {
               id="token-label"
               value={label}
               onChange={(e) => setLabel(e.target.value)}
+              onKeyDown={(e) => {
+                // Enter in the label field creates the token, matching the
+                // submit-on-Enter behaviour users expect from a form.
+                if (e.key === 'Enter' && !creating) {
+                  e.preventDefault();
+                  handleCreateToken();
+                }
+              }}
               placeholder="e.g. Monitoring, Claude Desktop, etc."
               className="form-input"
             />

--- a/src/components/api/TokensTab.tsx
+++ b/src/components/api/TokensTab.tsx
@@ -15,6 +15,7 @@ import {
   CheckIcon,
 } from './icons';
 import { useCopyToast, useExpandableSpecs } from './useCopyToast';
+import { DELETE_CONFIRM_TIMEOUT_MS } from '../../utils/constants';
 
 interface Props {
   baseUrl: string;
@@ -33,10 +34,17 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec }: Props) {
   const { copyNotice, handleCopy } = useCopyToast();
   const { expandedSpecs, toggleSpecPreview } = useExpandableSpecs();
   const mountedRef = useRef(true);
+  // Two-click delete confirm: first click arms a per-token confirm window,
+  // second click within DELETE_CONFIRM_TIMEOUT_MS actually deletes. Mirrors
+  // the StashViewer delete pattern so token deletion is no longer a single
+  // irreversible click.
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const confirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     return () => {
       mountedRef.current = false;
+      if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
     };
   }, []);
 
@@ -86,6 +94,19 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec }: Props) {
 
   const handleDeleteToken = useCallback(
     async (id: string) => {
+      // First click on a token's delete button just arms the confirm state
+      // (and auto-disarms after the timeout). Only a second click while this
+      // token is armed proceeds to the irreversible delete.
+      if (confirmDeleteId !== id) {
+        setConfirmDeleteId(id);
+        if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
+        confirmTimerRef.current = setTimeout(() => {
+          if (mountedRef.current) setConfirmDeleteId(null);
+        }, DELETE_CONFIRM_TIMEOUT_MS);
+        return;
+      }
+      if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
+      setConfirmDeleteId(null);
       try {
         await api.deleteToken(id);
         if (mountedRef.current) {
@@ -99,7 +120,7 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec }: Props) {
         }
       }
     },
-    [loadTokens, newlyCreated],
+    [loadTokens, newlyCreated, confirmDeleteId],
   );
 
   const toggleScope = useCallback((scope: TokenScope) => {
@@ -308,11 +329,24 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec }: Props) {
                     </button>
                   </div>
                   <button
-                    className="btn btn-ghost btn-sm api-delete-btn"
+                    className={`btn btn-sm api-delete-btn${
+                      confirmDeleteId === token.id
+                        ? ' btn-danger api-delete-btn-confirm'
+                        : ' btn-ghost'
+                    }`}
                     onClick={() => handleDeleteToken(token.id)}
-                    title="Delete token"
+                    title={
+                      confirmDeleteId === token.id
+                        ? 'Click again to permanently delete this token'
+                        : 'Delete token'
+                    }
+                    aria-label={
+                      confirmDeleteId === token.id
+                        ? `Confirm delete token ${token.label || 'Unnamed Token'}`
+                        : `Delete token ${token.label || 'Unnamed Token'}`
+                    }
                   >
-                    <TrashIcon />
+                    {confirmDeleteId === token.id ? 'Delete?' : <TrashIcon />}
                   </button>
                 </div>
               </div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2170,6 +2170,19 @@ body {
   color: var(--text-primary);
 }
 
+/* Heading + inline action (e.g. "Copy JSON") on one row. */
+.metadata-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.metadata-section-header h3 {
+  margin-bottom: 0;
+}
+
 .metadata-table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
End-user comfort sweep — 3 small, low-risk improvements. All reuse existing patterns; no new dependencies, no schema/architecture changes.

## Merged features

| # | Area/File | Category | Feature | User benefit | Effort | Status |
|---|-----------|----------|---------|--------------|--------|--------|
| 1 | `src/components/api/TokensTab.tsx` | comfort / safety | Two-click confirm before deleting an API token | Was a single irreversible click; first click arms a per-token confirm (auto-disarms after `DELETE_CONFIRM_TIMEOUT_MS`), second click deletes — mirrors the StashViewer delete pattern | S | Done |
| 2 | `src/components/StashViewer.tsx`, `src/styles/app.css` | copy-to-clipboard | "Copy JSON" button in the AI Metadata section header | Copy the whole metadata object as pretty-printed JSON in one click | S | Done |
| 3 | `src/components/api/TokensTab.tsx` | keyboard / comfort | Submit token creation on Enter in the label field | Enter in the label input creates the token (no-op while creating) | S | Done |

## Verification

`npm ci` → `npm run format:check` (clean) → `npx tsc --noEmit` (clean) → `npm test` (24 files, 242 passed / 5 skipped) → `npm run build` (compiled successfully). All green.

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4B1zYUguPZb1fhRFtz52m

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4B1zYUguPZb1fhRFtz52m)_