### PR TITLE
refactor: best-practice sweep (Next.js)

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -819,10 +819,19 @@ export class ClawStashDB {
       // Tags are stored as JSON arrays, e.g. '["foo","bar"]'. We match
       // '"<tag>"' anywhere in the JSON string — a cheap and correct check
       // since tag values are validated to contain no double-quotes.
+      //
+      // Escape LIKE wildcards (`% _ \`) in the tag and pair every clause with
+      // `ESCAPE '\\'` — a tag literally containing `%`/`_` (both allowed by
+      // TagsSchema) would otherwise over-match unrelated rows and pull
+      // spurious stashes into the focus-tag BFS. Mirrors the escaping used by
+      // every other tag-LIKE in this file (listStashes / getStashGraph) and
+      // search-store.ts.
       const placeholders = Array.from(frontier)
-        .map(() => `tags LIKE ?`)
+        .map(() => `tags LIKE ? ESCAPE '\\'`)
         .join(' OR ');
-      const params: string[] = Array.from(frontier).map((t) => `%"${t}"%`);
+      const params: string[] = Array.from(frontier).map(
+        (t) => `%"${t.replace(/[\\%_]/g, '\\$&')}"%`,
+      );
 
       const rows = this.db
         .prepare(`SELECT id, tags FROM stashes WHERE ${placeholders}`)

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1125,21 +1125,51 @@ export class ClawStashDB {
 
     // Version nodes & edges
     if (include_versions) {
-      for (const row of stashRows) {
-        const versions = this.db
-          .prepare(
-            `
-          SELECT id, version, created_by, created_at, change_summary
-          FROM stash_versions WHERE stash_id = ? ORDER BY version ASC
-        `,
-          )
-          .all(row.id) as {
+      // Batch-load every stash's versions in a single query grouped by
+      // stash_id (preserving the per-stash `version ASC` order) instead of one
+      // query per row (former N+1 pattern). Bounded by the graph `limit`.
+      // Mirrors getFileInfoByStash / the search-store batch loads.
+      const versionsByStash = new Map<
+        string,
+        {
           id: string;
           version: number;
           created_by: string;
           created_at: string;
           change_summary: string;
+        }[]
+      >();
+      const stashIdList = stashRows.map((r) => r.id);
+      if (stashIdList.length > 0) {
+        const placeholders = stashIdList.map(() => '?').join(', ');
+        const versionRows = this.db
+          .prepare(
+            `
+          SELECT id, stash_id, version, created_by, created_at, change_summary
+          FROM stash_versions WHERE stash_id IN (${placeholders})
+          ORDER BY stash_id, version ASC
+        `,
+          )
+          .all(...stashIdList) as {
+          id: string;
+          stash_id: string;
+          version: number;
+          created_by: string;
+          created_at: string;
+          change_summary: string;
         }[];
+        for (const { stash_id, ...v } of versionRows) {
+          let list = versionsByStash.get(stash_id);
+          if (!list) {
+            list = [];
+            versionsByStash.set(stash_id, list);
+          }
+          list.push(v);
+        }
+      }
+
+      for (const row of stashRows) {
+        const versions = versionsByStash.get(row.id) ?? [];
 
         let prevNodeId = row.id; // current stash is the "head"
         for (let vi = versions.length - 1; vi >= 0; vi--) {

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -11,7 +11,12 @@ import { SessionStore } from './stores/session-store';
 import { VersionStore } from './stores/version-store';
 import { SearchStore } from './stores/search-store';
 import { BackupStore } from './stores/backup-store';
-import { safeParseTags, safeParseMetadata, clampPagination } from './stores/_parsers';
+import {
+  safeParseTags,
+  safeParseMetadata,
+  clampPagination,
+  rowToStashListItem,
+} from './stores/_parsers';
 import type {
   BackupCandidate,
   BackupLogEntry,
@@ -150,20 +155,6 @@ export class ClawStashDB {
       description: (row.description as string) || '',
       tags: safeParseTags(row.tags),
       metadata: safeParseMetadata(row.metadata),
-      version: (row.version as number) || 1,
-      archived: (row.archived as number) === 1,
-      backup_enabled: (row.backup_enabled as number) === 1,
-      created_at: row.created_at as string,
-      updated_at: row.updated_at as string,
-    };
-  }
-
-  private rowToListItem(row: Record<string, unknown>): Omit<StashListItem, 'files' | 'total_size'> {
-    return {
-      id: row.id as string,
-      name: (row.name as string) || '',
-      description: (row.description as string) || '',
-      tags: safeParseTags(row.tags),
       version: (row.version as number) || 1,
       archived: (row.archived as number) === 1,
       backup_enabled: (row.backup_enabled as number) === 1,
@@ -387,7 +378,7 @@ export class ClawStashDB {
       .prepare(`SELECT g.* FROM stashes g ${where} ORDER BY g.updated_at DESC LIMIT ? OFFSET ?`)
       .all(...params, limit, offset) as Record<string, unknown>[];
 
-    const items = rows.map((row) => this.rowToListItem(row));
+    const items = rows.map((row) => rowToStashListItem(row));
 
     // Batch-load files for all listed stashes in a single query instead of one
     // query per row (former N+1 pattern). Bounded by the page limit. Closes

--- a/src/server/stores/_parsers.ts
+++ b/src/server/stores/_parsers.ts
@@ -11,6 +11,31 @@
  * db.ts, version-store.ts, and search-store.ts.
  */
 
+import type { StashListItem } from '../db-types';
+
+/**
+ * Map a raw `stashes` row to the common list-item shape (without `files` /
+ * `total_size`, which the caller fills in after a batch file load).
+ *
+ * Centralised so the identical mapping in ClawStashDB.listStashes and
+ * SearchStore can't drift on field set or coercions when a column is added.
+ */
+export function rowToStashListItem(
+  row: Record<string, unknown>,
+): Omit<StashListItem, 'files' | 'total_size'> {
+  return {
+    id: row.id as string,
+    name: (row.name as string) || '',
+    description: (row.description as string) || '',
+    tags: safeParseTags(row.tags),
+    version: (row.version as number) || 1,
+    archived: (row.archived as number) === 1,
+    backup_enabled: (row.backup_enabled as number) === 1,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  };
+}
+
 export function safeParseTags(raw: unknown): string[] {
   if (typeof raw !== 'string') return [];
   try {

--- a/src/server/stores/search-store.ts
+++ b/src/server/stores/search-store.ts
@@ -6,21 +6,7 @@ import type {
   StashListItem,
   ListStashesOptions,
 } from '../db-types';
-import { safeParseTags, clampPagination } from './_parsers';
-
-function rowToListItem(row: Record<string, unknown>): Omit<StashListItem, 'files' | 'total_size'> {
-  return {
-    id: row.id as string,
-    name: (row.name as string) || '',
-    description: (row.description as string) || '',
-    tags: safeParseTags(row.tags),
-    version: (row.version as number) || 1,
-    archived: (row.archived as number) === 1,
-    backup_enabled: (row.backup_enabled as number) === 1,
-    created_at: row.created_at as string,
-    updated_at: row.updated_at as string,
-  };
-}
+import { safeParseTags, clampPagination, rowToStashListItem } from './_parsers';
 
 // FTS5 snippet markers — Unicode private-use characters that cannot
 // appear in legitimate user content. Used internally so we can detect a
@@ -325,7 +311,7 @@ export class SearchStore {
 
     const stashes: SearchStashItem[] = rows.map((row) => {
       const stashRow = stashRowsById.get(row.stash_id) as Record<string, unknown>;
-      const item = rowToListItem(stashRow);
+      const item = rowToStashListItem(stashRow);
       const files = filesByStash.get(item.id) ?? [];
       const total_size = files.reduce((sum, f) => sum + f.size, 0);
 

--- a/src/server/tool-defs.ts
+++ b/src/server/tool-defs.ts
@@ -8,20 +8,23 @@
  * - /api/mcp-tools        → Frontend tool list endpoint
  */
 import { z } from 'zod';
-import { MAX_METADATA_DEPTH, maxObjectDepth } from './validation';
+import {
+  MAX_DESCRIPTION_LENGTH,
+  MAX_FILE_CONTENT_LENGTH,
+  MAX_FILENAME_LENGTH,
+  MAX_FILES,
+  MAX_METADATA_DEPTH,
+  MAX_METADATA_KEYS,
+  MAX_NAME_LENGTH,
+  MAX_TAG_LENGTH,
+  MAX_TAGS,
+  maxObjectDepth,
+} from './validation';
 
 // ---------------------------------------------------------------------------
-// Shared sub-schemas — limits match REST validation (src/server/validation.ts)
+// Shared sub-schemas — size limits are imported from src/server/validation.ts
+// (single source of truth) so REST and MCP cannot drift on payload limits.
 // ---------------------------------------------------------------------------
-
-const MAX_NAME_LENGTH = 500;
-const MAX_DESCRIPTION_LENGTH = 50_000;
-const MAX_TAGS = 50;
-const MAX_TAG_LENGTH = 100;
-const MAX_METADATA_KEYS = 50;
-const MAX_FILES = 100;
-const MAX_FILENAME_LENGTH = 255;
-const MAX_FILE_CONTENT_LENGTH = 10 * 1024 * 1024; // 10MB per file
 
 export const FileInputSchema = z.object({
   filename: z

--- a/src/server/validation.ts
+++ b/src/server/validation.ts
@@ -7,15 +7,18 @@
 import { z } from 'zod';
 
 // --- Size Limits ---
-const MAX_NAME_LENGTH = 500;
-const MAX_DESCRIPTION_LENGTH = 50_000;
-const MAX_TAGS = 50;
-const MAX_TAG_LENGTH = 100;
-const MAX_METADATA_KEYS = 50;
+// Exported as the single source of truth for both the REST schemas below and
+// the MCP tool schemas (src/server/tool-defs.ts imports these). Keeping one
+// copy prevents the two trust boundaries from drifting on payload limits.
+export const MAX_NAME_LENGTH = 500;
+export const MAX_DESCRIPTION_LENGTH = 50_000;
+export const MAX_TAGS = 50;
+export const MAX_TAG_LENGTH = 100;
+export const MAX_METADATA_KEYS = 50;
 export const MAX_METADATA_DEPTH = 5;
-const MAX_FILES = 100;
-const MAX_FILENAME_LENGTH = 255;
-const MAX_FILE_CONTENT_LENGTH = 10 * 1024 * 1024; // 10MB per file
+export const MAX_FILES = 100;
+export const MAX_FILENAME_LENGTH = 255;
+export const MAX_FILE_CONTENT_LENGTH = 10 * 1024 * 1024; // 10MB per file
 export const MAX_IMPORT_SIZE = 100 * 1024 * 1024; // 100MB for ZIP import
 
 /**


### PR DESCRIPTION
Autonomous best-practice sweep of the server layer. All changes are behavior-preserving and verified locally: `npm ci` + `prettier --check` + `tsc --noEmit` + `vitest` (242 passed / 5 skipped) + `next build`, all green.

## Findings

| # | Datei | Kategorie | Befund | Vorschlag | Impact | Aufwand | Empfehlung | Status |
|---|-------|-----------|--------|-----------|--------|---------|------------|--------|
| 1 | `src/server/db.ts` (`getTagGraphFocusRows`) | Correctness / Security | Focus-tag BFS built `tags LIKE '%"<tag>"%'` without escaping LIKE wildcards or an `ESCAPE` clause — unlike every other tag-LIKE in the codebase. A tag containing `%` or `_` (both allowed by `TagsSchema`) over-matches unrelated rows and skews the focus subgraph. | Escape `% _ \` + add `ESCAPE '\'`, matching `listStashes` / `getStashGraph` / `search-store`. | Correct focus-tag graphs for tags with `%`/`_` | S | auto-fix | ✅ Fixed |
| 2 | `src/server/db.ts` (`getStashGraph`, `include_versions`) | Performance | One `stash_versions` query per stash row (N+1). | Single `WHERE stash_id IN (...) ORDER BY stash_id, version ASC` grouped into a `Map`. | Fewer queries on opt-in version graphs | M | auto-fix | ✅ Fixed |
| 3 | `src/server/validation.ts` + `src/server/tool-defs.ts` | Maintainability | Seven payload size limits duplicated across REST and MCP boundaries. | Export from `validation.ts` (the SoT) and import in `tool-defs.ts`. | Removes drift risk | M | auto-fix | ✅ Fixed |
| 4 | `src/server/db.ts` + `src/server/stores/search-store.ts` | Maintainability | Byte-identical `rowToListItem` mapper in two places. | Consolidate into `rowToStashListItem()` in `stores/_parsers.ts`. | Single mapper, no lockstep edits | M | auto-fix | ✅ Fixed |

## Deferred

- Device-flow poll TOCTOU (`backup/device/poll`): admin-gated, GitHub `slow_down`-bounded; clean fix needs a per-session lock.
- `getStash`-per-candidate in backup sync plan: each stash's content is genuinely required for hashing/tree-building, so no cheap batch shortcut.

## Out of Scope

- Dependency changes (none). Larger BACKLOG refactors (#105/#106). Verified-clean security surfaces (timing-safe compare, parameterized SQL, SSRF-safe GitHub client, path-traversal-safe filenames, markdown XSS sanitiser) left untouched.

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvfX6sA6MuPpjnS4hFjrB9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvfX6sA6MuPpjnS4hFjrB9)_