### PR TITLE
refine: ux sweep (Next.js)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -734,6 +734,7 @@ export default function App() {
                 setSelectedStash(stash);
                 loadStashes();
               }}
+              onVersionRestored={() => showSuccess('Version restored.')}
             />
           )}
           {(view === 'new' || view === 'edit') && (

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -30,6 +30,10 @@ interface Props {
   onBack: () => void;
   onAnalyzeStash: (id: string) => void;
   onStashUpdated?: (stash: Stash) => void;
+  // Fired specifically when a previous version is restored from the history
+  // tab, so the shell can surface a success toast. Restoring previously gave
+  // no confirmation, unlike save / archive / delete which all show one.
+  onVersionRestored?: (stash: Stash) => void;
 }
 
 function SourceBadge({ source }: { source: string }) {
@@ -322,6 +326,7 @@ export default function StashViewer({
   onBack,
   onAnalyzeStash,
   onStashUpdated,
+  onVersionRestored,
 }: Props) {
   const [activeTab, setActiveTab] = useState<ViewerTab>(getTabPreference);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -1234,7 +1239,10 @@ export default function StashViewer({
         <VersionHistory
           stashId={stash.id}
           currentVersion={stash.version}
-          onRestore={(restored) => onStashUpdated?.(restored)}
+          onRestore={(restored) => {
+            onStashUpdated?.(restored);
+            onVersionRestored?.(restored);
+          }}
         />
       )}
     </div>

--- a/src/components/api/TokensTab.tsx
+++ b/src/components/api/TokensTab.tsx
@@ -220,7 +220,9 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec }: Props) {
               onKeyDown={(e) => {
                 // Enter in the label field creates the token, matching the
                 // submit-on-Enter behaviour users expect from a form.
-                if (e.key === 'Enter' && !creating) {
+                // Requires at least one scope so Enter can't silently create a
+                // read-only token, mirroring the disabled Create button below.
+                if (e.key === 'Enter' && !creating && selectedScopes.length > 0) {
                   e.preventDefault();
                   handleCreateToken();
                 }
@@ -237,6 +239,7 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec }: Props) {
                   key={scope}
                   className={`api-scope-btn ${selectedScopes.includes(scope) ? 'active' : ''}`}
                   onClick={() => toggleScope(scope)}
+                  aria-pressed={selectedScopes.includes(scope)}
                 >
                   {SCOPE_LABELS[scope]}
                 </button>
@@ -258,10 +261,17 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec }: Props) {
               </div>
             </div>
           </div>
+          {selectedScopes.length === 0 && (
+            <p className="api-hint" role="status" style={{ marginTop: 0 }}>
+              Select at least one scope to create a token.
+            </p>
+          )}
           <button
             className="btn btn-primary api-create-token-btn"
             onClick={handleCreateToken}
-            disabled={creating}
+            // Block creation with no scope selected — previously the form
+            // silently fell back to a read-only token, which surprised users.
+            disabled={creating || selectedScopes.length === 0}
           >
             <PlusIcon />
             {creating ? 'Creating...' : 'Create Token'}

--- a/src/components/editor/MetadataEditor.tsx
+++ b/src/components/editor/MetadataEditor.tsx
@@ -40,6 +40,9 @@ export default function MetadataEditor({ entries, onChange, availableKeys }: Pro
   const [showAll, setShowAll] = useState(false);
   const [keyInput, setKeyInput] = useState('');
   const [showKeyDropdown, setShowKeyDropdown] = useState(false);
+  // Inline notice shown when the user tries to add a key that already exists.
+  // Previously a duplicate add silently cleared the input with no explanation.
+  const [dupWarning, setDupWarning] = useState<string | null>(null);
   const keyInputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -79,11 +82,17 @@ export default function MetadataEditor({ entries, onChange, availableKeys }: Pro
 
   const addEntry = (key: string) => {
     const trimmed = key.trim();
-    if (trimmed && !entries.some((e) => e.key === trimmed)) {
-      entryIds.current.push(idCounter.current++);
-      onChange([...entries, { key: trimmed, value: '' }]);
-      setShowAll(true);
+    if (!trimmed) return;
+    if (entries.some((e) => e.key === trimmed)) {
+      // Duplicate key — keep the typed value and tell the user why nothing
+      // was added instead of silently clearing the field.
+      setDupWarning(`Key "${trimmed}" already exists.`);
+      return;
     }
+    entryIds.current.push(idCounter.current++);
+    onChange([...entries, { key: trimmed, value: '' }]);
+    setShowAll(true);
+    setDupWarning(null);
     setKeyInput('');
     setShowKeyDropdown(false);
   };
@@ -161,12 +170,14 @@ export default function MetadataEditor({ entries, onChange, availableKeys }: Pro
           onChange={(e) => {
             setKeyInput(e.target.value);
             setShowKeyDropdown(true);
+            if (dupWarning) setDupWarning(null);
           }}
           onFocus={() => setShowKeyDropdown(true)}
           onKeyDown={handleKeyInputKeyDown}
           placeholder="Add key..."
           className="form-input metadata-add-input"
           aria-label="Add metadata key"
+          aria-invalid={dupWarning ? true : undefined}
           autoComplete="off"
         />
         <button
@@ -191,6 +202,16 @@ export default function MetadataEditor({ entries, onChange, availableKeys }: Pro
           </div>
         )}
       </div>
+      {dupWarning && (
+        <div
+          className="metadata-dup-warning"
+          role="status"
+          aria-live="polite"
+          style={{ color: 'var(--accent-orange)', fontSize: 12, marginTop: 4 }}
+        >
+          {dupWarning}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Autonomous UX-refinement sweep — additive + local only (no new features, no refactors, no deps).

## Refinements

| # | Existing feature | Area / file | Category | UX gap | Improvement | Effort |
| - | ---------------- | ----------- | -------- | ------ | ----------- | ------ |
| 1 | Version history restore | `StashViewer.tsx`, `App.tsx` | toast-feedback | Restoring a previous version gave no confirmation, unlike save / archive / delete | New optional `onVersionRestored` callback → shell fires `showSuccess('Version restored.')`; backup-toggle path unchanged | S |
| 2 | API token creation | `api/TokensTab.tsx` | validation + aria-label | Deselecting every scope silently created a read-only token; scope toggle buttons exposed no on/off state | Disable Create (+ Enter path) while no scope selected + inline hint; add `aria-pressed` to scope toggles | S |
| 3 | Metadata key-value editor | `editor/MetadataEditor.tsx` | validation | Adding an existing key silently cleared the input | Keep the value + inline "Key already exists" notice (`aria-live` + `aria-invalid`), cleared on edit | S |

## Verifikation

`npm ci` → `npx tsc --noEmit` (clean) → `npm test` (25 files, 249 passed / 5 skipped) → `npm run build` (exit 0) → `prettier --check` on touched files (clean). All green.

## Out of Scope

New features, refactors, dependency/architectural changes. `.claude/**`, `CLAUDE.md`, `agent_docs/**` untouched.

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HupszNkfHkYciKNZvMHgHw

---
_Generated by [Claude Code](https://claude.ai/code/session_01HupszNkfHkYciKNZvMHgHw)_