### PR TITLE
feat: comfort sweep (Next.js)

### DIFF
--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -443,6 +443,17 @@ export default function StashViewer({
     });
   }, []);
 
+  // True when every file is collapsed — drives the master toggle's
+  // collapse-all vs expand-all behavior and its label/icon.
+  const allFilesCollapsed = stash.files.length > 0 && collapsedFiles.size === stash.files.length;
+
+  /** Collapse every file, or — when all are already collapsed — expand them all. */
+  const toggleAllFilesCollapsed = useCallback(() => {
+    setCollapsedFiles((prev) =>
+      prev.size === stash.files.length ? new Set() : new Set(stash.files.map((f) => f.id)),
+    );
+  }, [stash.files]);
+
   /**
    * Clicking the header bar surface toggles collapse. Clicks on the filename
    * (kept selectable), the action buttons, or the actions area keep their own
@@ -862,6 +873,30 @@ export default function StashViewer({
 
       {activeTab === 'content' && (
         <div className="viewer-files" ref={filesContainerRef}>
+          {stash.files.length > 1 && (
+            <div className="viewer-files-toolbar">
+              <button
+                type="button"
+                className="btn btn-sm btn-ghost viewer-files-collapse-all"
+                onClick={toggleAllFilesCollapsed}
+                aria-expanded={!allFilesCollapsed}
+                title={allFilesCollapsed ? 'Expand all files' : 'Collapse all files'}
+                aria-label={allFilesCollapsed ? 'Expand all files' : 'Collapse all files'}
+              >
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                  className={`file-collapse-chevron ${allFilesCollapsed ? '' : 'expanded'}`}
+                  aria-hidden="true"
+                >
+                  <path d="M6.22 3.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L9.94 8 6.22 4.28a.75.75 0 0 1 0-1.06Z" />
+                </svg>
+                {allFilesCollapsed ? 'Expand all' : 'Collapse all'}
+              </button>
+            </div>
+          )}
           {stash.files.map((file, fileIndex) => {
             const lang = resolvedLanguages.get(file.id) || 'text';
             const renderable = isRenderableLanguage(lang);

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -318,6 +318,30 @@ function CopyButtonContent({
   );
 }
 
+/**
+ * Small "open in new tab" affordance next to an API-endpoint row. The copy
+ * buttons hand back the relative path (for curl/scripts); this lets the user
+ * load the live endpoint directly without retyping it into the address bar.
+ * `noopener noreferrer` per the usual target=_blank safety.
+ */
+function ApiOpenLink({ path, label }: { path: string; label: string }) {
+  return (
+    <a
+      className="btn btn-sm btn-ghost api-open-link"
+      href={path}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={label}
+      aria-label={label}
+    >
+      <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+        <path d="M3.75 2A1.75 1.75 0 0 0 2 3.75v8.5C2 13.216 2.784 14 3.75 14h8.5A1.75 1.75 0 0 0 14 12.25v-3.5a.75.75 0 0 0-1.5 0v3.5a.25.25 0 0 1-.25.25h-8.5a.25.25 0 0 1-.25-.25v-8.5a.25.25 0 0 1 .25-.25h3.5a.75.75 0 0 0 0-1.5Z" />
+        <path d="M9.75 2a.75.75 0 0 0 0 1.5h1.69L6.22 8.72a.75.75 0 1 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75Z" />
+      </svg>
+    </a>
+  );
+}
+
 export default function StashViewer({
   stash,
   onEdit,
@@ -1174,6 +1198,10 @@ export default function StashViewer({
                     failed={apiClipboard.isFailed(`get-${stash.id}`)}
                   />
                 </button>
+                <ApiOpenLink
+                  path={`/api/stashes/${stash.id}`}
+                  label="Open API endpoint in a new tab"
+                />
               </div>
               {stash.files.map((f) => (
                 <div key={f.id} className="api-example">
@@ -1204,6 +1232,10 @@ export default function StashViewer({
                       failed={apiClipboard.isFailed(`raw-${f.id}`)}
                     />
                   </button>
+                  <ApiOpenLink
+                    path={`/api/stashes/${stash.id}/files/${encodeURIComponent(f.filename)}/raw`}
+                    label={`Open raw ${f.filename} in a new tab`}
+                  />
                 </div>
               ))}
             </div>

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -56,6 +56,7 @@ function SourceBadge({ source }: { source: string }) {
 
 const RENDER_PREF_KEY = 'clawstash-render-preview';
 const ACTIVE_TAB_KEY = 'clawstash-viewer-tab';
+const TOC_PREF_KEY = 'clawstash-toc-expanded';
 
 type ViewerTab = 'content' | 'metadata' | 'access-log' | 'history';
 const VALID_TABS: ViewerTab[] = ['content', 'metadata', 'access-log', 'history'];
@@ -72,6 +73,23 @@ function getRenderPreference(): boolean {
 function setRenderPreference(enabled: boolean): void {
   try {
     localStorage.setItem(RENDER_PREF_KEY, String(enabled));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Read the persisted Table-of-Contents expanded state. Defaults to expanded. */
+function getTocPreference(): boolean {
+  try {
+    return localStorage.getItem(TOC_PREF_KEY) !== 'false'; // default to true
+  } catch {
+    return true;
+  }
+}
+
+function setTocPreference(expanded: boolean): void {
+  try {
+    localStorage.setItem(TOC_PREF_KEY, String(expanded));
   } catch {
     /* ignore */
   }
@@ -357,7 +375,7 @@ export default function StashViewer({
   const [accessLog, setAccessLog] = useState<AccessLogEntry[]>([]);
   const [logLoading, setLogLoading] = useState(false);
   const [renderPreview, setRenderPreview] = useState(getRenderPreference);
-  const [tocExpanded, setTocExpanded] = useState(true);
+  const [tocExpanded, setTocExpanded] = useState(getTocPreference);
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
   const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const filesContainerRef = useRef<HTMLDivElement>(null);
@@ -845,7 +863,13 @@ export default function StashViewer({
         <div className="viewer-toc">
           <button
             className="viewer-toc-toggle"
-            onClick={() => setTocExpanded(!tocExpanded)}
+            onClick={() =>
+              setTocExpanded((prev) => {
+                const next = !prev;
+                setTocPreference(next);
+                return next;
+              })
+            }
             aria-expanded={tocExpanded}
             aria-controls="viewer-toc-nav"
           >

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1885,6 +1885,21 @@ body {
   gap: 20px;
 }
 
+/* Collapse-all / expand-all toolbar above the file list. Only rendered for
+   multi-file stashes; pins the master toggle to the right so it lines up with
+   the per-file action buttons below it. */
+.viewer-files-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: -8px;
+}
+
+.viewer-files-collapse-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .viewer-file {
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2289,6 +2289,14 @@ body {
   white-space: nowrap;
 }
 
+/* "Open in new tab" anchor next to an API-endpoint copy button. Anchors don't
+   inherit the button's flex centering, so re-establish it for icon alignment. */
+.api-open-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* === Stash Editor === */
 .stash-editor {
   max-width: 100%;


### PR DESCRIPTION
Autonomous weekly comfort/quality sweep (2026-06-29) of the ClawStash web UI (Next.js 16 + React 19). Three small, self-contained end-user comfort features. No new dependencies; no DB/auth changes.

## Implemented

| # | Bereich/Datei | Kategorie | Feature | Nutzen | Aufwand | Empfehlung | Status |
|---|---------------|-----------|---------|--------|---------|------------|--------|
| 1 | `StashViewer.tsx`, `app.css` | Komfort | Collapse all / Expand all toggle above the file list (multi-file stashes only, ≥2 files) | Fold/unfold every file at once instead of clicking each header — big win for large multi-file stashes; reuses the existing `collapsedFiles` Set | S | umsetzen | gemerged |
| 2 | `StashViewer.tsx`, `app.css` | Komfort | "Open in new tab" link next to each API-endpoint (GET + RAW) copy button | Load the live endpoint directly without retyping the path into the address bar; copy buttons still hand back the relative path for curl/scripts. RAW filename is `encodeURIComponent`-encoded; `rel="noopener noreferrer"` | S | umsetzen | gemerged |
| 3 | `StashViewer.tsx` | Komfort | Persist the Table-of-Contents expanded/collapsed state across sessions (localStorage) | TOC no longer re-expands on every stash open / reload; remembers the user's last choice — mirrors the existing render-preview/active-tab preference pattern | S | umsetzen | gemerged |

## Deferred

- **Clickable tags in the viewer "Details" tab** (M) — needs `onFilterTag` threaded from `App.tsx` into `StashViewer` (cross-file prop plumbing). Exceeds the self-contained S/M bound.
- **Arrow-key grid navigation on the dashboard cards** (M) — roving-tabindex/focus management; non-trivial keyboard-nav state.

## Verification

`npm ci` → `npx tsc --noEmit` (clean) → `npm test` (26 files, 260 passed / 5 skipped) → `npm run build` (compiled successfully). All green.

Closes #328


---
_Generated by [Claude Code](https://claude.ai/code/session_01S4xVRT8RQ2XyJ7u1Q1BqWp)_