### PR TITLE
ux: best-practice sweep (Next.js 16)

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -79,6 +79,8 @@ export default function Footer() {
               className={`footer-info-btn${showDetails ? ' active' : ''}`}
               onClick={() => setShowDetails((prev) => !prev)}
               title="Toggle build details"
+              aria-label="Toggle build details"
+              aria-expanded={showDetails}
             >
               <svg
                 width="14"

--- a/src/components/GraphViewer.tsx
+++ b/src/components/GraphViewer.tsx
@@ -1286,7 +1286,12 @@ export default function GraphViewer({
       <div className="graph-viewer">
         <div className="graph-header">
           <div className="graph-title">
-            <button className="graph-back-btn" onClick={onGoHome} title="Back to dashboard">
+            <button
+              className="graph-back-btn"
+              onClick={onGoHome}
+              title="Back to dashboard"
+              aria-label="Back to dashboard"
+            >
               <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
                 <path d="M7.78 12.53a.75.75 0 0 1-1.06 0L2.47 8.28a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 1.06L4.81 7h7.44a.75.75 0 0 1 0 1.5H4.81l2.97 2.97a.75.75 0 0 1 0 1.06Z" />
               </svg>
@@ -1307,7 +1312,12 @@ export default function GraphViewer({
     <div className="graph-viewer">
       <div className="graph-header">
         <div className="graph-title">
-          <button className="graph-back-btn" onClick={onGoHome} title="Back to dashboard">
+          <button
+            className="graph-back-btn"
+            onClick={onGoHome}
+            title="Back to dashboard"
+            aria-label="Back to dashboard"
+          >
             <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
               <path d="M7.78 12.53a.75.75 0 0 1-1.06 0L2.47 8.28a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 1.06L4.81 7h7.44a.75.75 0 0 1 0 1.5H4.81l2.97 2.97a.75.75 0 0 1 0 1.06Z" />
             </svg>
@@ -1343,7 +1353,12 @@ export default function GraphViewer({
                   +
                 </button>
               </span>
-              <button className="graph-focus-clear" onClick={handleClearFocus} title="Clear focus">
+              <button
+                className="graph-focus-clear"
+                onClick={handleClearFocus}
+                title="Clear focus"
+                aria-label="Clear focus"
+              >
                 <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
                   <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
                 </svg>
@@ -1370,6 +1385,7 @@ export default function GraphViewer({
                 className="graph-highlight-clear"
                 onClick={clearHighlight}
                 title="Clear highlight"
+                aria-label="Clear highlight"
               >
                 <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
                   <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
@@ -1526,7 +1542,12 @@ export default function GraphViewer({
                 </svg>
                 <strong>{popup.tag}</strong>
               </div>
-              <button className="graph-popup-close" onClick={closePopup} title="Close">
+              <button
+                className="graph-popup-close"
+                onClick={closePopup}
+                title="Close"
+                aria-label="Close"
+              >
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
                   <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
                 </svg>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -361,6 +361,7 @@ export default function Sidebar({
                         value={tagSearch}
                         onChange={(e) => setTagSearch(e.target.value)}
                         className="sidebar-tag-search-input"
+                        aria-label="Search tags"
                         autoFocus
                       />
                     </div>

--- a/src/components/StashGraphCanvas.tsx
+++ b/src/components/StashGraphCanvas.tsx
@@ -1441,7 +1441,12 @@ export default function StashGraphCanvas({
                 </svg>
                 <strong>{popup.node.label}</strong>
               </div>
-              <button className="graph-popup-close" onClick={() => setPopup(null)} title="Close">
+              <button
+                className="graph-popup-close"
+                onClick={() => setPopup(null)}
+                title="Close"
+                aria-label="Close"
+              >
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
                   <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
                 </svg>
@@ -1554,7 +1559,12 @@ export default function StashGraphCanvas({
                 </svg>
                 <strong>{popup.node.label}</strong>
               </div>
-              <button className="graph-popup-close" onClick={() => setPopup(null)} title="Close">
+              <button
+                className="graph-popup-close"
+                onClick={() => setPopup(null)}
+                title="Close"
+                aria-label="Close"
+              >
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
                   <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
                 </svg>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -792,6 +792,12 @@ body {
   font-family: inherit;
 }
 
+.search-overlay-input:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 .search-overlay-input::placeholder {
   color: var(--text-muted);
 }


### PR DESCRIPTION
Automated UX best-practice sweep — additive a11y only (+46/−6 LoC).

| Datei | Fix |
|-------|-----|
| `GraphViewer.tsx` | `aria-label` on 5 icon-only buttons |
| `StashGraphCanvas.tsx` | `aria-label="Close"` on 2 popup-close buttons |
| `Footer.tsx` | `aria-label` + `aria-expanded` on build-details toggle |
| `Sidebar.tsx` | `aria-label="Search tags"` on tag-filter input |
| `src/styles/app.css` | `:focus-visible` ring for `.search-overlay-input` |

**Verification:** `tsc --noEmit` exit 0 · `prettier --check` clean. 5 commits. No visual change (except a restored focus ring).

Closes #330

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhfAXFxzus3yNeh6axwNTs)_