### PR TITLE
refine: ux sweep (Next.js)

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import type { StashListItem, LayoutMode, SortMode } from '../types';
 import { sortStashesWithFavorites } from '../utils/favorites';
 import { sortStashes, SORT_OPTIONS } from '../utils/sort';
+import { pluralize } from '../utils/format';
 import StashCard from './StashCard';
 import Spinner from './shared/Spinner';
 
@@ -53,7 +54,7 @@ export default function Dashboard({
         <div className="dashboard-title">
           <h1>Your Stashes</h1>
           <span className="stash-count" title="Total number of stashes stored">
-            {total} stashes
+            {pluralize(total, 'stash', 'stashes')}
           </span>
           {loading && stashes.length > 0 && (
             <span

--- a/src/components/GraphViewer.tsx
+++ b/src/components/GraphViewer.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect, useCallback, useState } from 'react';
 import type { StashListItem, TagInfo, TagGraphResult } from '../types';
 import { api } from '../api';
+import { pluralize } from '../utils/format';
 import StashGraphCanvas from './StashGraphCanvas';
 
 // --- Physics simulation constants (tag graph) --------------------------------
@@ -1324,7 +1325,7 @@ export default function GraphViewer({
           </button>
           {tabSwitcher}
           <span className="graph-stats">
-            {nodeCount} tags · {edgeCount} connections
+            {pluralize(nodeCount, 'tag')} · {pluralize(edgeCount, 'connection')}
           </span>
         </div>
         <div className="graph-actions">

--- a/src/components/LoginScreen.tsx
+++ b/src/components/LoginScreen.tsx
@@ -8,6 +8,7 @@ export default function LoginScreen({ onLogin }: Props) {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -39,17 +40,50 @@ export default function LoginScreen({ onLogin }: Props) {
         <label htmlFor="login-password" className="sr-only">
           Password
         </label>
-        <input
-          id="login-password"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder="Password"
-          className="form-input login-input"
-          disabled={loading}
-          autoFocus
-          aria-describedby={error ? 'login-error-msg' : undefined}
-        />
+        <div className="login-input-wrapper">
+          <input
+            id="login-password"
+            type={showPassword ? 'text' : 'password'}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+            className="form-input login-input"
+            disabled={loading}
+            autoFocus
+            aria-describedby={error ? 'login-error-msg' : undefined}
+          />
+          <button
+            type="button"
+            className="login-password-toggle"
+            onClick={() => setShowPassword((v) => !v)}
+            disabled={loading}
+            aria-pressed={showPassword}
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
+            title={showPassword ? 'Hide password' : 'Show password'}
+          >
+            {showPassword ? (
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M.143 2.31a.75.75 0 0 1 1.047-.167l14 10a.75.75 0 1 1-.88 1.214l-2.248-1.606A8.09 8.09 0 0 1 8 13.5C3.822 13.5.755 10.505.09 8.31a.75.75 0 0 1 0-.62A9.06 9.06 0 0 1 2.9 4.16L.31 2.357A.75.75 0 0 1 .143 2.31Zm4.107 2.936A5.25 5.25 0 0 0 8 11.25c.616 0 1.21-.106 1.762-.301L8.28 9.88a2 2 0 0 1-2.16-1.542L4.25 5.246ZM8 4.75c.24 0 .476.016.707.047a2 2 0 0 1 1.784 2.418l3.02 2.157A7.56 7.56 0 0 0 15.91 8.31a.75.75 0 0 0 0-.62C15.245 5.495 12.178 2.5 8 2.5c-.657 0-1.29.074-1.892.21l1.67 1.192A5.3 5.3 0 0 1 8 4.75Z" />
+              </svg>
+            ) : (
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M8 2.5c4.178 0 7.245 2.995 7.91 5.19a.75.75 0 0 1 0 .62C15.245 10.505 12.178 13.5 8 13.5S.755 10.505.09 8.31a.75.75 0 0 1 0-.62C.755 5.495 3.822 2.5 8 2.5Zm0 1.5C4.9 4 2.6 6.164 1.61 8 2.6 9.836 4.9 12 8 12s5.4-2.164 6.39-4C13.4 6.164 11.1 4 8 4Zm0 1.75a2.25 2.25 0 1 1 0 4.5 2.25 2.25 0 0 1 0-4.5Z" />
+              </svg>
+            )}
+          </button>
+        </div>
         <button type="submit" className="btn btn-primary login-btn" disabled={loading || !password}>
           {loading ? 'Signing in...' : 'Sign in'}
         </button>

--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import type { StashListItem } from '../types';
 import { api } from '../api';
 import { formatRelativeTime } from '../utils/format';
+import { splitHighlight } from '../utils/highlight';
 import { SEARCH_DEBOUNCE_MS } from '../utils/constants';
 import Spinner from './shared/Spinner';
 
@@ -127,6 +128,20 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
     }
   };
 
+  // Wrap the parts of `text` that match the current query in <mark> so the
+  // reason a result surfaced is visible. Segments render as React text nodes
+  // (XSS-safe); non-match segments stay bare strings (no key needed).
+  const renderHighlighted = (text: string) =>
+    splitHighlight(text, query).map((seg, i) =>
+      seg.match ? (
+        <mark key={i} className="search-overlay-mark">
+          {seg.text}
+        </mark>
+      ) : (
+        seg.text
+      ),
+    );
+
   if (!open) return null;
 
   return (
@@ -203,7 +218,7 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
               >
                 <div className="search-overlay-item-main">
                   <span className="search-overlay-item-name">
-                    {stash.name || stash.files[0]?.filename || 'Untitled'}
+                    {renderHighlighted(stash.name || stash.files[0]?.filename || 'Untitled')}
                   </span>
                   {stash.files.length > 0 && (
                     <span className="search-overlay-item-files">
@@ -213,9 +228,11 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
                 </div>
                 {stash.description && (
                   <div className="search-overlay-item-desc">
-                    {stash.description.length > 100
-                      ? stash.description.slice(0, 100) + '...'
-                      : stash.description}
+                    {renderHighlighted(
+                      stash.description.length > 100
+                        ? stash.description.slice(0, 100) + '...'
+                        : stash.description,
+                    )}
                   </div>
                 )}
                 <div className="search-overlay-item-meta">

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type ReactNode } from 'react';
 import type { SettingsSection, LayoutMode, Stats, TagInfo } from '../types';
 import { api } from '../api';
-import { formatExportTimestamp } from '../utils/format';
+import { formatExportTimestamp, pluralize } from '../utils/format';
 import ApiManager from './api/ApiManager';
 import BackupSection from './settings/BackupSection';
 import Spinner from './shared/Spinner';
@@ -185,7 +185,8 @@ function WelcomeSection({ onNavigate }: WelcomeSectionProps) {
         <span>System running normally</span>
         {stats && (
           <span className="settings-welcome-status-stats">
-            &mdash; {stats.totalStashes} stashes, {stats.totalFiles} files
+            &mdash; {pluralize(stats.totalStashes, 'stash', 'stashes')},{' '}
+            {pluralize(stats.totalFiles, 'file')}
           </span>
         )}
       </div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -933,6 +933,15 @@ body {
   margin-bottom: 4px;
 }
 
+.search-overlay-mark {
+  /* Accent-orange tint keeps the match visible on the dark surface without the
+     browser default black-on-yellow. `color: inherit` preserves item colors. */
+  background: rgba(210, 153, 34, 0.28);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
 .search-overlay-item-meta {
   display: flex;
   align-items: center;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -716,8 +716,50 @@ body {
   border: 1px solid rgba(218, 54, 51, 0.3);
 }
 
+.login-input-wrapper {
+  position: relative;
+  display: flex;
+}
+
 .login-input {
+  /* Symmetric horizontal padding keeps the centered text visually centered
+     while leaving room on the right for the reveal toggle. */
   text-align: center;
+  padding-left: 40px;
+  padding-right: 40px;
+  width: 100%;
+}
+
+.login-password-toggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 0 var(--radius) var(--radius) 0;
+  transition: color 0.08s;
+}
+
+.login-password-toggle:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.login-password-toggle:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.login-password-toggle:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: -2px;
 }
 
 .login-btn {

--- a/src/utils/__tests__/format.test.ts
+++ b/src/utils/__tests__/format.test.ts
@@ -5,6 +5,7 @@ import {
   formatDate,
   formatDateTime,
   formatRelativeTime,
+  pluralize,
 } from '../format';
 
 describe('formatBytes', () => {
@@ -52,6 +53,24 @@ describe('formatBuildVersion', () => {
     // the canonical output here so a regression to local-time formatting
     // is caught even when the test runs in TZ=America/Los_Angeles etc.
     expect(formatBuildVersion('2026-12-31T23:30:00Z')).toBe('v20261231-2330');
+  });
+});
+
+describe('pluralize', () => {
+  it('uses the singular noun only when the count is exactly 1', () => {
+    expect(pluralize(1, 'file')).toBe('1 file');
+    expect(pluralize(0, 'file')).toBe('0 files');
+    expect(pluralize(2, 'file')).toBe('2 files');
+  });
+
+  it('honors an explicit plural for irregular nouns', () => {
+    expect(pluralize(1, 'stash', 'stashes')).toBe('1 stash');
+    expect(pluralize(3, 'stash', 'stashes')).toBe('3 stashes');
+  });
+
+  it('defaults the plural to the singular + "s"', () => {
+    expect(pluralize(5, 'connection')).toBe('5 connections');
+    expect(pluralize(1, 'tag')).toBe('1 tag');
   });
 });
 

--- a/src/utils/__tests__/highlight.test.ts
+++ b/src/utils/__tests__/highlight.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { splitHighlight } from '../highlight';
+
+describe('splitHighlight', () => {
+  it('returns a single unmatched segment when the query is empty', () => {
+    expect(splitHighlight('hello world', '')).toEqual([{ text: 'hello world', match: false }]);
+    expect(splitHighlight('hello world', '   ')).toEqual([{ text: 'hello world', match: false }]);
+  });
+
+  it('returns an empty array for empty text', () => {
+    expect(splitHighlight('', 'foo')).toEqual([]);
+  });
+
+  it('marks a single case-insensitive match and preserves source casing', () => {
+    expect(splitHighlight('Deploy Notes', 'deploy')).toEqual([
+      { text: 'Deploy', match: true },
+      { text: ' Notes', match: false },
+    ]);
+  });
+
+  it('marks every occurrence', () => {
+    expect(splitHighlight('aXaXa', 'a')).toEqual([
+      { text: 'a', match: true },
+      { text: 'X', match: false },
+      { text: 'a', match: true },
+      { text: 'X', match: false },
+      { text: 'a', match: true },
+    ]);
+  });
+
+  it('handles a match at the end of the text', () => {
+    expect(splitHighlight('config.json', 'json')).toEqual([
+      { text: 'config.', match: false },
+      { text: 'json', match: true },
+    ]);
+  });
+
+  it('returns one unmatched segment when there is no match', () => {
+    expect(splitHighlight('nothing here', 'zzz')).toEqual([{ text: 'nothing here', match: false }]);
+  });
+
+  it('reassembles to the original text', () => {
+    const text = 'The quick brown fox';
+    const joined = splitHighlight(text, 'o')
+      .map((s) => s.text)
+      .join('');
+    expect(joined).toBe(text);
+  });
+});

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -92,3 +92,13 @@ export function formatBuildVersion(isoDate: string): string | null {
 export function formatExportTimestamp(date: Date = new Date()): string {
   return date.toISOString().slice(0, 19).replace(/[:.]/g, '-');
 }
+
+/**
+ * Format a count with its noun, choosing singular/plural by the count
+ * ("1 stash", "2 stashes", "0 files"). English-only; irregular plurals pass
+ * an explicit `plural` (the default appends "s"). Avoids the "1 stashes"
+ * grammar glitch in count labels across the dashboard, settings and graph.
+ */
+export function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}

--- a/src/utils/highlight.ts
+++ b/src/utils/highlight.ts
@@ -1,0 +1,33 @@
+export interface HighlightSegment {
+  text: string;
+  match: boolean;
+}
+
+/**
+ * Split `text` into consecutive segments, flagging the ones that
+ * case-insensitively match `query`. Used to <mark> the search term inside
+ * quick-search results so users can see *why* a stash matched.
+ *
+ * The query is treated as a literal (no regex), so arbitrary user input is
+ * safe; matched slices are taken from the original `text` to preserve the
+ * source casing. Rendering the segments as React text nodes keeps it
+ * XSS-safe — never feed them into dangerouslySetInnerHTML.
+ */
+export function splitHighlight(text: string, query: string): HighlightSegment[] {
+  if (!text) return [];
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [{ text, match: false }];
+
+  const segments: HighlightSegment[] = [];
+  const haystack = text.toLowerCase();
+  let start = 0;
+  let idx = haystack.indexOf(needle, start);
+  while (idx !== -1) {
+    if (idx > start) segments.push({ text: text.slice(start, idx), match: false });
+    segments.push({ text: text.slice(idx, idx + needle.length), match: true });
+    start = idx + needle.length;
+    idx = haystack.indexOf(needle, start);
+  }
+  if (start < text.length) segments.push({ text: text.slice(start), match: false });
+  return segments;
+}


### PR DESCRIPTION
Autonomous UX-refine sweep — three small, additive, local comfort/quality fixes to existing user-facing features. No new features, no refactors, no dep bumps, no behavior changes.

| Feature | Datei | Kategorie | UX-Lücke | Verbesserung | Aufwand |
|---|---|---|---|---|---|
| Admin login | `src/components/LoginScreen.tsx`, `src/styles/app.css` | Komfort | Password field has no reveal — users can't verify typed input | Accessible show/hide toggle (eye / eye-off, `aria-pressed`), `type` switches password↔text | S |
| Count labels (dashboard / settings / graph) | `src/utils/format.ts`, `Dashboard.tsx`, `Settings.tsx`, `GraphViewer.tsx` | Qualität | "1 stashes" / "1 tags · 1 connections" grammar glitch | New unit-tested `pluralize()` helper → correct singular/plural | S |
| Quick search (Alt+K) | `src/components/SearchOverlay.tsx`, `src/utils/highlight.ts`, `src/styles/app.css` | Komfort | Results don't show why they matched | `<mark>` the query terms in name/description via literal, XSS-safe `splitHighlight` (unit-tested) | M |

**Verification:** `npm ci` → prettier (changed files clean) → `npx tsc --noEmit` (clean) → `npx vitest run` (270 passed / 5 skipped) → `npm run build` (exit 0).

Closes #332

<!-- screenshot: optional -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01Khv4mgWVEzG4poWZF9cYar)_