### PR TITLE
chore: docs quality maintenance (Next.js/MCP)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to ClawStash! Here's how to get started
 
 ## Development Setup
 
-**Prerequisites:** Node.js 26+ (project pins Node 26 in Docker; `better-sqlite3` 12.x requires ≥ 20)
+**Prerequisites:** Node.js 20+ (project pins Node 26 in Docker/CI; `next` requires ≥ 20.9, `better-sqlite3` 12.x supports 20.x–26.x — no dependency needs 26+ for local dev)
 
 ```bash
 git clone https://github.com/fo0/clawstash.git


### PR DESCRIPTION
Automated repo-quality-maintenance sweep. Additive documentation only — no runtime config, no secrets, no code or dependency changes.

### Change
| Pass | File | Finding | Fix |
|---|---|---|---|
| Docs consistency | `CONTRIBUTING.md` | Prerequisites said "Node.js 26+" while README said "Node.js 20+" — contradiction | fix to 20+ (verified: no dependency requires 26; next `>=20.9.0`, better-sqlite3 20.x–26.x — 26 is only the Docker/CI pin) |

`.env.example` (9 keys) and all referenced docs were already complete.

Scope: docs/config-example artifacts only. Housekeeping/dependency work is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeV8bkzR7jKXsQd9oNcHyf

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeV8bkzR7jKXsQd9oNcHyf)_