### PR TITLE
refactor: best-practice sweep (Next.js)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,13 @@ EXPOSE 3000
 
 VOLUME ["/app/data"]
 
+# Surface container health via the dedicated /api/health endpoint (200 when
+# the SQLite database is reachable, 503 otherwise — see its route handler,
+# which names Docker HEALTHCHECK as its primary consumer). `node -e` because
+# the slim image ships no curl/wget; global fetch is stable on Node >= 21.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD node -e 'fetch("http://127.0.0.1:"+(process.env.PORT||3000)+"/api/health").then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))'
+
 # No USER directive: docker-entrypoint.sh needs root for the one-time chown
 # and immediately drops to `node` (uid 1000) for the server process.
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,13 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh && command -v setpriv
 
 ENV NODE_ENV=production
 ENV PORT=3000
+# Bind to all interfaces: the standalone server.js listens on
+# `process.env.HOSTNAME || '0.0.0.0'`, and Docker sets HOSTNAME to the
+# container ID — without this override the server binds only to the
+# container-IP interface, so in-container loopback access (healthcheck,
+# curl localhost debugging, sidecars) fails. Same override as the official
+# Next.js Docker example.
+ENV HOSTNAME=0.0.0.0
 ENV DATABASE_PATH=/app/data/clawstash.db
 
 EXPOSE 3000

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,10 @@ const nextConfig: NextConfig = {
   serverExternalPackages: ['better-sqlite3'],
   // Output standalone build for Docker
   output: 'standalone',
+  // Don't advertise the framework via `X-Powered-By: Next.js` (response-header
+  // fingerprinting hygiene — complements the security headers set in
+  // src/middleware.ts, which adds but cannot remove this Next-added header).
+  poweredByHeader: false,
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,9 @@
         "prettier": "3.8.4",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       }
     },
     "node_modules/@antfu/install-pkg": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "url": "https://github.com/fo0/clawstash/issues"
   },
   "homepage": "https://github.com/fo0/clawstash#readme",
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "dev": "next dev",
     "prebuild": "node scripts/generate-build-info.js",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,12 +27,35 @@ import Footer from './components/Footer';
 
 function getStoredPreference<T extends string>(key: string, fallback: T): T {
   if (typeof window === 'undefined') return fallback;
-  return (localStorage.getItem(key) as T) || fallback;
+  try {
+    return (localStorage.getItem(key) as T) || fallback;
+  } catch {
+    return fallback;
+  }
 }
 
 function getStoredAdminToken(): string {
   if (typeof window === 'undefined') return '';
-  return localStorage.getItem('clawstash_admin_token') || '';
+  try {
+    return localStorage.getItem('clawstash_admin_token') || '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Write a localStorage entry, swallowing storage failures (quota exceeded,
+ * storage disabled in sandboxed iframes / strict privacy modes → throws).
+ * Mirrors the guarded `save*` helpers in utils/ (sort, archived, favorites);
+ * two call sites run inside setState updaters, where an uncaught throw would
+ * propagate into React's render phase and unmount the tree.
+ */
+function safeSetItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Preference stays in memory only.
+  }
 }
 
 /**
@@ -325,7 +348,9 @@ export default function App() {
 
   const handleLogin = useCallback(async (password: string) => {
     const result = await api.adminLogin(password);
-    localStorage.setItem('clawstash_admin_token', result.token);
+    // Guarded write: a disabled/full storage must not fail the login — the
+    // session then simply lives in memory for this tab.
+    safeSetItem('clawstash_admin_token', result.token);
     setAdminToken(result.token);
   }, []);
 
@@ -335,7 +360,11 @@ export default function App() {
     } catch {
       // Ignore logout errors
     }
-    localStorage.removeItem('clawstash_admin_token');
+    try {
+      localStorage.removeItem('clawstash_admin_token');
+    } catch {
+      // Storage disabled — nothing was persisted to remove.
+    }
     setAdminToken('');
     setAdminSession({ authenticated: false, authRequired: true });
   }, []);
@@ -417,7 +446,7 @@ export default function App() {
     setRecentTags((prev) => {
       const cleaned = prev.filter((t) => tagNames.has(t));
       if (cleaned.length !== prev.length) {
-        localStorage.setItem('clawstash_recent_tags', JSON.stringify(cleaned));
+        safeSetItem('clawstash_recent_tags', JSON.stringify(cleaned));
       }
       return cleaned.length !== prev.length ? cleaned : prev;
     });
@@ -559,7 +588,7 @@ export default function App() {
     if (newTag) {
       setRecentTags((prev) => {
         const updated = [newTag, ...prev.filter((t) => t !== newTag)].slice(0, 3);
-        localStorage.setItem('clawstash_recent_tags', JSON.stringify(updated));
+        safeSetItem('clawstash_recent_tags', JSON.stringify(updated));
         return updated;
       });
     }
@@ -596,7 +625,7 @@ export default function App() {
 
   const handleLayoutChange = (mode: LayoutMode) => {
     setLayout(mode);
-    localStorage.setItem('clawstash_layout', mode);
+    safeSetItem('clawstash_layout', mode);
   };
 
   const handleSortChange = (mode: SortMode) => {


### PR DESCRIPTION
## Summary

Autonomous best-practice sweep for the Next.js 16 stack. Five small, behavior-preserving fixes (one commit each): response-header hygiene, storage-failure hardening in the SPA shell, and three Docker/packaging alignments with the framework's documented deployment guidance.

Closes #344

## Changes

| # | Datei | Kategorie | Befund | Fix | Aufwand | Empfehlung |
|---|-------|-----------|--------|-----|---------|------------|
| 1 | next.config.ts | Security | `X-Powered-By: Next.js` emitted on every response (framework fingerprinting; middleware cannot remove it) | `poweredByHeader: false` | S | auto-fix |
| 2 | src/App.tsx | Correctness | 5 unguarded `localStorage` accesses — two writes inside setState updaters, where a storage throw propagates into React's render phase; rest of the repo guards every access | `safeSetItem` helper + try/catch on read helpers and logout `removeItem` | M | auto-fix |
| 3 | Dockerfile | Correctness | Standalone `server.js` binds to `HOSTNAME` (= container ID in Docker) → listens only on the container-IP interface, in-container loopback fails | `ENV HOSTNAME=0.0.0.0` (official Next.js Docker example) | S | auto-fix |
| 4 | Dockerfile | Maintainability | No `HEALTHCHECK` although `/api/health` documents Docker HEALTHCHECK as its primary consumer | `HEALTHCHECK` probing `/api/health` via `node -e` fetch | S | auto-fix |
| 5 | package.json (+lock) | Maintainability | Documented Node ≥ 20.9 requirement not machine-readable (three recent doc-drift fixes) | `"engines": { "node": ">=20.9.0" }` | S | auto-fix |

## Testing

- `npm run format:check` — clean
- `npx tsc --noEmit` — clean
- `npm test` — 27 files, 270 passed / 5 skipped
- `npm run build` — standalone production build succeeds
- Runtime smoke test of the built standalone server: `X-Powered-By` no longer present (middleware security headers intact), and the exact HEALTHCHECK one-liner exits 0 against `/api/health` (exits 1 without a server)

## Checklist

- [x] Formatting passes (`npm run format:check`)
- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Changes are documented (commit bodies + issue #344; no user-facing doc surface affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128iQ6UzgYxW49pUi3aHGBM

---
_Generated by [Claude Code](https://claude.ai/code/session_0128iQ6UzgYxW49pUi3aHGBM)_