### PR TITLE
feat: comfort sweep (Next.js)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { api, setAuthToken } from './api';
 import { loadFavoriteIds, saveFavoriteIds, toggleFavorite } from './utils/favorites';
 import { loadSortMode, saveSortMode } from './utils/sort';
 import { loadShowArchived, saveShowArchived } from './utils/archived';
+import { recordRecentView } from './utils/recent-views';
 import { SEARCH_DEBOUNCE_MS } from './utils/constants';
 import Sidebar from './components/Sidebar';
 import Dashboard from './components/Dashboard';
@@ -473,6 +474,13 @@ export default function App() {
       setView('view');
       pushUrl(`/stash/${id}`);
       setSidebarOpen(false);
+      // Remember this stash for the quick-search "Recently viewed" shortcut.
+      // Captured here (not on URL/popstate loads) so the list reflects
+      // deliberate user navigation. Title mirrors the viewer/card fallback.
+      recordRecentView({
+        id: stash.id,
+        title: stash.name || stash.files[0]?.filename || 'Untitled',
+      });
     } catch (err) {
       console.error('Failed to load stash:', err);
       showError('Failed to load stash. Please try again.');
@@ -800,7 +808,7 @@ export default function App() {
             />
           )}
         </main>
-        <Footer />
+        <Footer onShowShortcuts={() => setShortcutsHelpOpen(true)} />
       </div>
       <SearchOverlay
         open={searchOpen}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -7,7 +7,16 @@ interface BuildInfo {
   branch: string;
 }
 
-export default function Footer() {
+interface FooterProps {
+  /**
+   * Opens the keyboard-shortcuts help dialog. Optional so the footer still
+   * renders standalone (e.g. in isolation) when no handler is wired up — the
+   * shortcuts button is simply omitted in that case.
+   */
+  onShowShortcuts?: () => void;
+}
+
+export default function Footer({ onShowShortcuts }: FooterProps) {
   const [showDetails, setShowDetails] = useState(false);
   const [buildInfo, setBuildInfo] = useState<BuildInfo | null>(null);
 
@@ -164,6 +173,31 @@ export default function Footer() {
                 </span>
               )}
             </div>
+          )}
+          {onShowShortcuts && (
+            <button
+              type="button"
+              className="footer-info-btn"
+              onClick={onShowShortcuts}
+              title="Show keyboard shortcuts (press ?)"
+              aria-label="Show keyboard shortcuts"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <rect width="20" height="16" x="2" y="4" rx="2" ry="2" />
+                <path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M8 12h.01M12 12h.01M16 12h.01M7 16h10" />
+              </svg>
+              <span className="footer-info-label">Shortcuts</span>
+            </button>
           )}
           <a
             href="https://github.com/fo0/clawstash"

--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -4,6 +4,7 @@ import { api } from '../api';
 import { formatRelativeTime } from '../utils/format';
 import { splitHighlight } from '../utils/highlight';
 import { SEARCH_DEBOUNCE_MS } from '../utils/constants';
+import { loadRecentViews, type RecentView } from '../utils/recent-views';
 import Spinner from './shared/Spinner';
 
 interface Props {
@@ -15,6 +16,7 @@ interface Props {
 export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<StashListItem[]>([]);
+  const [recent, setRecent] = useState<RecentView[]>([]);
   const [loading, setLoading] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -40,6 +42,9 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
       setResults([]);
       setActiveIndex(0);
       setLoading(false);
+      // Refresh the "Recently viewed" shortcut list each time the overlay
+      // opens so it reflects stashes opened since the last open.
+      setRecent(loadRecentViews());
       // Small delay to ensure the DOM is rendered
       requestAnimationFrame(() => inputRef.current?.focus());
     }
@@ -257,7 +262,31 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
           </div>
         )}
 
-        {!query.trim() && (
+        {!query.trim() && recent.length > 0 && (
+          <div
+            className="search-overlay-results"
+            role="listbox"
+            aria-label={`${recent.length} recently viewed stash${recent.length !== 1 ? 'es' : ''}`}
+          >
+            <div className="search-overlay-results-count">Recently viewed</div>
+            {recent.map((item) => (
+              <button
+                type="button"
+                key={item.id}
+                className="search-overlay-item"
+                role="option"
+                aria-selected={false}
+                onClick={() => handleSelect(item.id)}
+              >
+                <div className="search-overlay-item-main">
+                  <span className="search-overlay-item-name">{item.title}</span>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {!query.trim() && recent.length === 0 && (
           <div className="search-overlay-hint">
             <span>Type to search by name, filename, or content</span>
           </div>

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -17,6 +17,7 @@ import { renderDescriptionMarkdown, isUnsafeUrl, sanitizeHtml } from '../utils/m
 import { hydrateMermaidPlaceholders, encodeMermaidSource } from '../utils/mermaid-hydrate';
 import { DELETE_CONFIRM_TIMEOUT_MS } from '../utils/constants';
 import { escapeHtml } from '../utils/html';
+import { buildStashUrl } from '../utils/stash-url';
 import MermaidDiagram from './MermaidDiagram';
 import MarkdownBody from './MarkdownBody';
 import Spinner from './shared/Spinner';
@@ -382,6 +383,7 @@ export default function StashViewer({
   const pendingScrollIdRef = useRef<string | null>(null);
   const copyAllClipboard = useClipboard();
   const titleClipboard = useClipboard();
+  const linkClipboard = useClipboard();
   const fileClipboard = useClipboardWithKey();
   const apiClipboard = useClipboardWithKey();
 
@@ -599,6 +601,16 @@ export default function StashViewer({
     copyAllClipboard.copy(allContent);
   };
 
+  /**
+   * Copy a shareable deep-link to this stash. Uses the live page origin so the
+   * copied URL works in whatever context the app is served from (dev, custom
+   * port, reverse-proxied host). Runs only in the browser (click handler), so
+   * `window` is always available here.
+   */
+  const copyStashLink = () => {
+    linkClipboard.copy(buildStashUrl(window.location.origin, stash.id));
+  };
+
   const handleDelete = () => {
     if (showDeleteConfirm) {
       onDelete(stash.id);
@@ -630,6 +642,8 @@ export default function StashViewer({
         {copyAllClipboard.status === 'failed' && 'Copy failed'}
         {titleClipboard.status === 'copied' && 'Stash name copied to clipboard'}
         {titleClipboard.status === 'failed' && 'Copy failed'}
+        {linkClipboard.status === 'copied' && 'Stash link copied to clipboard'}
+        {linkClipboard.status === 'failed' && 'Copy failed'}
         {fileClipboard.copiedKey && 'File copied to clipboard'}
         {fileClipboard.failedKey && 'Copy failed'}
         {apiClipboard.copiedKey && 'API endpoint copied to clipboard'}
@@ -670,6 +684,26 @@ export default function StashViewer({
           </button>
         </h2>
         <div className="viewer-actions">
+          <button
+            className="btn btn-secondary"
+            onClick={copyStashLink}
+            title={
+              linkClipboard.copied
+                ? 'Link copied!'
+                : linkClipboard.status === 'failed'
+                  ? 'Copy failed'
+                  : 'Copy a shareable link to this stash'
+            }
+            aria-label="Copy a shareable link to this stash"
+          >
+            <CopyButtonContent
+              copied={linkClipboard.copied}
+              failed={linkClipboard.status === 'failed'}
+              size={14}
+              labelCopy="Copy Link"
+              labelCopied="Link copied"
+            />
+          </button>
           <button
             className="btn btn-secondary"
             onClick={copyAllFiles}

--- a/src/utils/__tests__/recent-views.test.ts
+++ b/src/utils/__tests__/recent-views.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  loadRecentViews,
+  saveRecentViews,
+  addRecentView,
+  recordRecentView,
+  MAX_RECENT_VIEWS,
+  type RecentView,
+} from '../recent-views';
+
+const STORAGE_KEY = 'clawstash_recent_views';
+
+function installLocalStorageStub() {
+  const store = new Map<string, string>();
+  const stub = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+  };
+  vi.stubGlobal('localStorage', stub);
+  vi.stubGlobal('window', { localStorage: stub });
+  return store;
+}
+
+const view = (id: string, title = `title-${id}`): RecentView => ({ id, title });
+
+describe('addRecentView (pure)', () => {
+  it('prepends the newest view', () => {
+    expect(addRecentView([view('a')], view('b'))).toEqual([view('b'), view('a')]);
+  });
+
+  it('dedupes by id and moves the repeat to the front', () => {
+    const result = addRecentView([view('a'), view('b')], view('a', 'renamed'));
+    expect(result).toEqual([view('a', 'renamed'), view('b')]);
+  });
+
+  it('caps the list at MAX_RECENT_VIEWS', () => {
+    let list: RecentView[] = [];
+    for (let i = 0; i < MAX_RECENT_VIEWS + 3; i++) list = addRecentView(list, view(String(i)));
+    expect(list).toHaveLength(MAX_RECENT_VIEWS);
+    // Newest first: the last id added is at the front.
+    expect(list[0].id).toBe(String(MAX_RECENT_VIEWS + 2));
+  });
+
+  it('does not mutate the input list', () => {
+    const input = [view('a')];
+    addRecentView(input, view('b'));
+    expect(input).toEqual([view('a')]);
+  });
+});
+
+describe('load/save/record (localStorage)', () => {
+  beforeEach(() => installLocalStorageStub());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('returns an empty list when nothing is stored', () => {
+    expect(loadRecentViews()).toEqual([]);
+  });
+
+  it('round-trips a saved list', () => {
+    saveRecentViews([view('a'), view('b')]);
+    expect(loadRecentViews()).toEqual([view('a'), view('b')]);
+  });
+
+  it('drops corrupted / non-conforming entries', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([view('a'), { id: 1 }, 'nope', { title: 'x' }, view('b')]),
+    );
+    expect(loadRecentViews()).toEqual([view('a'), view('b')]);
+  });
+
+  it('returns an empty list on non-array JSON', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ id: 'a' }));
+    expect(loadRecentViews()).toEqual([]);
+  });
+
+  it('recordRecentView persists prepended + capped and returns the list', () => {
+    recordRecentView(view('a'));
+    const result = recordRecentView(view('b'));
+    expect(result).toEqual([view('b'), view('a')]);
+    expect(loadRecentViews()).toEqual([view('b'), view('a')]);
+  });
+});

--- a/src/utils/__tests__/stash-url.test.ts
+++ b/src/utils/__tests__/stash-url.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { buildStashUrl } from '../stash-url';
+
+describe('buildStashUrl', () => {
+  it('joins an origin and the stash path', () => {
+    expect(buildStashUrl('https://stash.example', 'abc-123')).toBe(
+      'https://stash.example/stash/abc-123',
+    );
+  });
+
+  it('trims a single trailing slash on the origin', () => {
+    expect(buildStashUrl('https://stash.example/', 'abc')).toBe('https://stash.example/stash/abc');
+  });
+
+  it('trims multiple trailing slashes on the origin', () => {
+    expect(buildStashUrl('https://stash.example///', 'abc')).toBe(
+      'https://stash.example/stash/abc',
+    );
+  });
+
+  it('preserves a port in the origin', () => {
+    expect(buildStashUrl('http://localhost:3000', 'id')).toBe('http://localhost:3000/stash/id');
+  });
+
+  it('falls back to a relative path when the origin is empty', () => {
+    expect(buildStashUrl('', 'id')).toBe('/stash/id');
+  });
+});

--- a/src/utils/recent-views.ts
+++ b/src/utils/recent-views.ts
@@ -1,0 +1,79 @@
+// Recently-viewed stashes — a small most-recently-used list surfaced in the
+// quick-search overlay so the last few stashes a user opened are one click
+// away before they type anything.
+//
+// Persistence mirrors the `clawstash_favorite_stashes` pattern in
+// `favorites.ts`: a JSON-encoded array under a stable localStorage key. Each
+// entry stores just the id + a display title (captured at view time). The
+// title may go stale if the stash is later renamed or deleted — that is an
+// acceptable trade-off for a convenience list: a deleted entry simply surfaces
+// the existing "failed to load" toast when clicked.
+//
+// Pure helpers (no React) so they can be unit-tested directly and reused.
+
+const STORAGE_KEY = 'clawstash_recent_views';
+
+/** How many recently-viewed stashes to remember. */
+export const MAX_RECENT_VIEWS = 5;
+
+export interface RecentView {
+  id: string;
+  title: string;
+}
+
+/** Type guard for a single persisted entry (defends against hand-edited JSON). */
+function isRecentView(value: unknown): value is RecentView {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as RecentView).id === 'string' &&
+    typeof (value as RecentView).title === 'string'
+  );
+}
+
+/**
+ * Read the recently-viewed list from localStorage, newest first. Safe during
+ * SSR (returns `[]` when `window` / `localStorage` is unavailable) and on a
+ * corrupted / hand-edited value (drops non-conforming entries).
+ */
+export function loadRecentViews(): RecentView[] {
+  if (typeof window === 'undefined' || typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isRecentView).slice(0, MAX_RECENT_VIEWS);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Return a NEW list with `view` moved to the front (deduped by id) and capped
+ * at {@link MAX_RECENT_VIEWS}. Pure — the input list is never mutated.
+ */
+export function addRecentView(list: readonly RecentView[], view: RecentView): RecentView[] {
+  const deduped = list.filter((v) => v.id !== view.id);
+  return [view, ...deduped].slice(0, MAX_RECENT_VIEWS);
+}
+
+/** Persist the recently-viewed list to localStorage. No-op during SSR / on quota errors. */
+export function saveRecentViews(list: readonly RecentView[]): void {
+  if (typeof window === 'undefined' || typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list.slice(0, MAX_RECENT_VIEWS)));
+  } catch {
+    // Quota exceeded / private mode — the list stays in memory only.
+  }
+}
+
+/**
+ * Record a viewed stash: load → prepend (deduped, capped) → save. Returns the
+ * updated list so callers can reuse it without a second read.
+ */
+export function recordRecentView(view: RecentView): RecentView[] {
+  const next = addRecentView(loadRecentViews(), view);
+  saveRecentViews(next);
+  return next;
+}

--- a/src/utils/stash-url.ts
+++ b/src/utils/stash-url.ts
@@ -1,0 +1,13 @@
+/**
+ * Build a shareable deep-link URL for a stash from a page origin + stash id.
+ *
+ * Mirrors the App router's `/stash/:id` route (see `getInitialRoute` in
+ * `App.tsx`) so a copied link opens the stash directly. A trailing slash on
+ * `origin` is trimmed so we never emit `…//stash/…`. When `origin` is empty
+ * (SSR / unknown origin) the value degrades to the relative `/stash/:id`
+ * path, which is still a valid, clickable link rather than `undefined/stash/…`.
+ */
+export function buildStashUrl(origin: string, id: string): string {
+  const base = origin.replace(/\/+$/, '');
+  return `${base}/stash/${id}`;
+}


### PR DESCRIPTION
Autonomous end-user comfort sweep — three frontend-only comfort features, no new dependencies, no server/DB changes. Reuses existing patterns (`useClipboard` + `CopyButtonContent`, the `favorites.ts` localStorage helper shape, existing footer/search-overlay CSS classes) — zero new CSS.

## Features

| # | Bereich/Datei | Kategorie | Feature | Nutzen | Aufwand | Status |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | `components/StashViewer.tsx`, `utils/stash-url.ts` | Komfort | **"Copy Link"** button copies a shareable deep-link (`<origin>/stash/<id>`) | Share a stash in one click without hunting for the URL bar | S | Done |
| 2 | `components/SearchOverlay.tsx`, `utils/recent-views.ts`, `App.tsx` | Komfort | **"Recently viewed"** list (last 5 opened) in the empty quick-search overlay | Jump back to a just-opened stash before typing | M | Done |
| 3 | `components/Footer.tsx`, `App.tsx` | Komfort | Footer **"Shortcuts"** button opens the keyboard-shortcuts help | Discover shortcuts without knowing the hidden `?` key | S | Done |

New pure helpers (`buildStashUrl`, `recent-views`) are unit-tested (2 new test files).

## Verification

`npm ci` → `npm run format:check` (clean) → `npx tsc --noEmit` (clean) → `npm test` (29 files, **284 passed / 5 skipped**) → `npm run build` (**compiled successfully**, exit 0). All green.

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCWAGrv8hm7sfsrj9PEJm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCWAGrv8hm7sfsrj9PEJm)_