### PR TITLE
ux: best-practice sweep (Next.js)

### DIFF
--- a/src/components/GraphViewer.tsx
+++ b/src/components/GraphViewer.tsx
@@ -1452,6 +1452,7 @@ export default function GraphViewer({
                     setSearchOpen(false);
                   }}
                   title="Clear search"
+                  aria-label="Clear search"
                 >
                   <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
                     <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
@@ -1486,6 +1487,7 @@ export default function GraphViewer({
                           className="graph-search-result-focus"
                           onClick={() => handleFocusTag(t.tag)}
                           title="Focus graph on this tag"
+                          aria-label="Focus graph on this tag"
                         >
                           <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
                             <path d="M8 2a6 6 0 1 0 0 12A6 6 0 0 0 8 2Zm0 1.5a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Zm0 2a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z" />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -329,6 +329,7 @@ export default function Sidebar({
                       setTagSearch('');
                     }}
                     title="Clear tag filter"
+                    aria-label="Clear tag filter"
                   >
                     <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
                       <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />

--- a/src/components/api/McpTab.tsx
+++ b/src/components/api/McpTab.tsx
@@ -112,6 +112,7 @@ export default function McpTab({ baseUrl, mcpSpec, mcpTools }: Props) {
               className="btn btn-ghost btn-sm api-code-copy-btn"
               onClick={() => handleCopy(streamableConfigJson, 'MCP Config')}
               title="Copy configuration"
+              aria-label="Copy Streamable HTTP configuration"
             >
               <CopyIcon />
             </button>
@@ -132,6 +133,7 @@ export default function McpTab({ baseUrl, mcpSpec, mcpTools }: Props) {
               className="btn btn-ghost btn-sm api-code-copy-btn"
               onClick={() => handleCopy(stdioConfigJson, 'Stdio MCP Config')}
               title="Copy configuration"
+              aria-label="Copy stdio transport configuration"
             >
               <CopyIcon />
             </button>

--- a/src/components/api/TokensTab.tsx
+++ b/src/components/api/TokensTab.tsx
@@ -294,6 +294,7 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec }: Props) {
                 className="btn btn-sm api-copy-btn"
                 onClick={() => handleCopy(newlyCreated.token, newlyCreated.label || 'Token')}
                 title="Copy token"
+                aria-label="Copy token"
               >
                 <CopyIcon />
               </button>
@@ -342,6 +343,7 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec }: Props) {
                         )
                       }
                       title={newlyCreated?.id === token.id ? 'Copy full token' : 'Copy prefix'}
+                      aria-label={newlyCreated?.id === token.id ? 'Copy full token' : 'Copy prefix'}
                     >
                       <CopyIcon size={12} />
                     </button>

--- a/src/components/editor/StashEditor.tsx
+++ b/src/components/editor/StashEditor.tsx
@@ -383,6 +383,7 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
                     className="btn btn-sm btn-ghost btn-remove"
                     onClick={() => removeFile(index)}
                     title="Remove this file"
+                    aria-label="Remove this file"
                   >
                     <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
                       <path d="M11 1.75V3h2.25a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1 0-1.5H5V1.75C5 .784 5.784 0 6.75 0h2.5C10.216 0 11 .784 11 1.75ZM4.496 6.675l.66 6.6a.25.25 0 0 0 .249.225h5.19a.25.25 0 0 0 .249-.225l.66-6.6a.75.75 0 0 1 1.492.149l-.66 6.6A1.748 1.748 0 0 1 10.595 15h-5.19a1.75 1.75 0 0 1-1.741-1.575l-.66-6.6a.75.75 0 1 1 1.492-.15ZM6.5 1.75V3h3V1.75a.25.25 0 0 0-.25-.25h-2.5a.25.25 0 0 0-.25.25Z" />


### PR DESCRIPTION
Automated UX best-practice sweep. Two additive a11y commits — one per finding. Icon-only buttons that named themselves only via `title` now also carry an explicit `aria-label`, matching the app's existing convention. No behaviour change; `title` is preserved. `npx tsc --noEmit` clean (0 errors, unchanged from baseline); changed files pass `prettier --check`.

## Findings

| # | Datei | Kategorie | Befund | Fix | Aufwand | Status |
|---|-------|-----------|--------|-----|---------|--------|
| 1 | `src/components/api/McpTab.tsx`, `src/components/api/TokensTab.tsx` | a11y | 4 icon-only copy buttons named only via `title` (the two MCP buttons shared the identical title "Copy configuration") | Add `aria-label`; distinct labels for the two MCP buttons (Streamable HTTP vs stdio) | S | ✅ |
| 2 | `src/components/Sidebar.tsx`, `src/components/editor/StashEditor.tsx`, `src/components/GraphViewer.tsx` | a11y | 4 icon-only action buttons (tag-filter clear, remove-file, graph search clear + focus) named only via `title` | Add matching `aria-label` | S | ✅ |

**Deferred (see issue):** Sidebar pointer-only tag-name span, StashGraphCanvas popup tag spans, SearchOverlay `aria-activedescendant`.

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aETGbeor3YCa9a1xTm3Zy

---
_Generated by [Claude Code](https://claude.ai/code/session_018aETGbeor3YCa9a1xTm3Zy)_