### PR TITLE
refine: ux sweep (Next.js)

### DIFF
--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -375,6 +375,12 @@ export default function StashViewer({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [accessLog, setAccessLog] = useState<AccessLogEntry[]>([]);
   const [logLoading, setLogLoading] = useState(false);
+  // Distinguish a failed access-log fetch from a genuinely empty log — a
+  // swallowed error previously rendered the same "No access recorded yet."
+  // empty state, hiding the failure. `logReloadKey` lets the error's Retry
+  // button re-run the fetch effect without leaving the tab.
+  const [logError, setLogError] = useState(false);
+  const [logReloadKey, setLogReloadKey] = useState(0);
   const [renderPreview, setRenderPreview] = useState(getRenderPreference);
   const [tocExpanded, setTocExpanded] = useState(getTocPreference);
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
@@ -555,13 +561,17 @@ export default function StashViewer({
     if (activeTab !== 'access-log') return;
     let cancelled = false;
     setLogLoading(true);
+    setLogError(false);
     api
       .getAccessLog(stash.id, 100)
       .then((log) => {
         if (!cancelled) setAccessLog(log);
       })
       .catch(() => {
-        if (!cancelled) setAccessLog([]);
+        if (!cancelled) {
+          setAccessLog([]);
+          setLogError(true);
+        }
       })
       .finally(() => {
         if (!cancelled) setLogLoading(false);
@@ -569,7 +579,7 @@ export default function StashViewer({
     return () => {
       cancelled = true;
     };
-  }, [activeTab, stash.id]);
+  }, [activeTab, stash.id, logReloadKey]);
 
   // Cleanup delete confirmation timer on unmount
   useEffect(() => {
@@ -1328,6 +1338,26 @@ export default function StashViewer({
             <div className="loading" role="status" aria-live="polite">
               <Spinner size={16} />
               <span style={{ marginLeft: 10 }}>Loading access log...</span>
+            </div>
+          ) : logError ? (
+            <div className="access-log-empty" role="alert">
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                style={{ marginBottom: 8, color: 'var(--text-danger, #f85149)' }}
+                aria-hidden="true"
+              >
+                <path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" />
+              </svg>
+              <p>Failed to load access log.</p>
+              <button
+                className="btn btn-sm btn-secondary"
+                onClick={() => setLogReloadKey((k) => k + 1)}
+              >
+                Retry
+              </button>
             </div>
           ) : accessLog.length === 0 ? (
             <div className="access-log-empty">

--- a/src/components/api/CodeExample.tsx
+++ b/src/components/api/CodeExample.tsx
@@ -1,0 +1,35 @@
+import { CopyIcon } from './icons';
+
+interface Props {
+  title: string;
+  code: string;
+  onCopy: (value: string, label: string) => void;
+}
+
+/**
+ * A titled code snippet with a one-click copy button, used in the REST and
+ * MCP "Examples" sections. Reuses the same `.api-code-block-wrapper` +
+ * `.api-code-copy-btn` positioning as the MCP client-config blocks so the
+ * copy affordance is consistent across the whole API manager — previously the
+ * example snippets were the only code blocks with no copy button and had to be
+ * selected by hand. Copy feedback surfaces through the parent tab's shared
+ * copy toast via `onCopy` (the `useCopyToast` `handleCopy`).
+ */
+export default function CodeExample({ title, code, onCopy }: Props) {
+  return (
+    <div className="api-example-item">
+      <div className="api-example-title">{title}</div>
+      <div className="api-code-block-wrapper">
+        <pre className="api-code-block">{code}</pre>
+        <button
+          className="btn btn-ghost btn-sm api-code-copy-btn"
+          onClick={() => onCopy(code, title)}
+          title="Copy example to clipboard"
+          aria-label={`Copy example: ${title}`}
+        >
+          <CopyIcon />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/api/McpTab.tsx
+++ b/src/components/api/McpTab.tsx
@@ -1,6 +1,7 @@
 import { buildMcpStreamableConfig, buildMcpStdioConfig } from './api-data';
 import { ServerIcon, WifiIcon, KeyIcon, CopyIcon, ChevronIcon, CheckIcon } from './icons';
 import { useCopyToast, useExpandableSpecs } from './useCopyToast';
+import CodeExample from './CodeExample';
 import Spinner from '../shared/Spinner';
 
 interface Props {
@@ -174,9 +175,10 @@ export default function McpTab({ baseUrl, mcpSpec, mcpTools }: Props) {
           <h2>Examples</h2>
         </div>
         <div className="api-mgr-examples">
-          <div className="api-example-item">
-            <div className="api-example-title">MCP Tool Call - Create Stash</div>
-            <pre className="api-code-block">{`Tool: create_stash
+          <CodeExample
+            title="MCP Tool Call - Create Stash"
+            onCopy={handleCopy}
+            code={`Tool: create_stash
 Parameters: {
   "description": "My Notes",
   "files": [
@@ -186,24 +188,26 @@ Parameters: {
     }
   ],
   "tags": ["meeting", "notes"]
-}`}</pre>
-          </div>
-          <div className="api-example-item">
-            <div className="api-example-title">MCP Tool Call - Search Stashes</div>
-            <pre className="api-code-block">{`Tool: search_stashes
+}`}
+          />
+          <CodeExample
+            title="MCP Tool Call - Search Stashes"
+            onCopy={handleCopy}
+            code={`Tool: search_stashes
 Parameters: {
   "query": "meeting notes",
   "limit": 10
-}`}</pre>
-          </div>
-          <div className="api-example-item">
-            <div className="api-example-title">MCP Tool Call - List by Tag</div>
-            <pre className="api-code-block">{`Tool: list_stashes
+}`}
+          />
+          <CodeExample
+            title="MCP Tool Call - List by Tag"
+            onCopy={handleCopy}
+            code={`Tool: list_stashes
 Parameters: {
   "tag": "important",
   "limit": 20
-}`}</pre>
-          </div>
+}`}
+          />
         </div>
       </section>
 

--- a/src/components/api/RestTab.tsx
+++ b/src/components/api/RestTab.tsx
@@ -1,5 +1,6 @@
 import Spinner from '../shared/Spinner';
 import SwaggerViewer from './SwaggerViewer';
+import CodeExample from './CodeExample';
 import { getRestConfigText } from './api-data';
 import { BookIcon, KeyIcon, CopyIcon, ChevronIcon, CheckIcon } from './icons';
 import { useCopyToast, useExpandableSpecs } from './useCopyToast';
@@ -115,19 +116,22 @@ export default function RestTab({ baseUrl, openApiJson }: Props) {
           <h2>Examples</h2>
         </div>
         <div className="api-mgr-examples">
-          <div className="api-example-item">
-            <div className="api-example-title">cURL - List Stashes</div>
-            <pre className="api-code-block">{`curl -H "Authorization: Bearer YOUR_TOKEN" \\
-  ${baseUrl}/api/stashes`}</pre>
-          </div>
-          <div className="api-example-item">
-            <div className="api-example-title">cURL - Get Stash with Token</div>
-            <pre className="api-code-block">{`curl -H "Authorization: Bearer YOUR_TOKEN" \\
-  ${baseUrl}/api/stashes/STASH_ID`}</pre>
-          </div>
-          <div className="api-example-item">
-            <div className="api-example-title">cURL - Create Stash</div>
-            <pre className="api-code-block">{`curl -X POST ${baseUrl}/api/stashes \\
+          <CodeExample
+            title="cURL - List Stashes"
+            onCopy={handleCopy}
+            code={`curl -H "Authorization: Bearer YOUR_TOKEN" \\
+  ${baseUrl}/api/stashes`}
+          />
+          <CodeExample
+            title="cURL - Get Stash with Token"
+            onCopy={handleCopy}
+            code={`curl -H "Authorization: Bearer YOUR_TOKEN" \\
+  ${baseUrl}/api/stashes/STASH_ID`}
+          />
+          <CodeExample
+            title="cURL - Create Stash"
+            onCopy={handleCopy}
+            code={`curl -X POST ${baseUrl}/api/stashes \\
   -H "Content-Type: application/json" \\
   -H "Authorization: Bearer YOUR_TOKEN" \\
   -d '{
@@ -139,26 +143,29 @@ export default function RestTab({ baseUrl, openApiJson }: Props) {
         "content": "print('Hello World')"
       }
     ]
-  }'`}</pre>
-          </div>
-          <div className="api-example-item">
-            <div className="api-example-title">cURL - Create API Token</div>
-            <pre className="api-code-block">{`curl -X POST ${baseUrl}/api/tokens \\
+  }'`}
+          />
+          <CodeExample
+            title="cURL - Create API Token"
+            onCopy={handleCopy}
+            code={`curl -X POST ${baseUrl}/api/tokens \\
   -H "Content-Type: application/json" \\
   -H "Authorization: Bearer YOUR_ADMIN_TOKEN" \\
-  -d '{"label": "My Token", "scopes": ["read", "write"]}'`}</pre>
-          </div>
-          <div className="api-example-item">
-            <div className="api-example-title">JavaScript - List Stashes</div>
-            <pre className="api-code-block">{`const response = await fetch('${baseUrl}/api/stashes', {
+  -d '{"label": "My Token", "scopes": ["read", "write"]}'`}
+          />
+          <CodeExample
+            title="JavaScript - List Stashes"
+            onCopy={handleCopy}
+            code={`const response = await fetch('${baseUrl}/api/stashes', {
   headers: { 'Authorization': 'Bearer YOUR_TOKEN' },
 });
 const data = await response.json();
-console.log(data.stashes);`}</pre>
-          </div>
-          <div className="api-example-item">
-            <div className="api-example-title">JavaScript - Create Stash</div>
-            <pre className="api-code-block">{`const response = await fetch('${baseUrl}/api/stashes', {
+console.log(data.stashes);`}
+          />
+          <CodeExample
+            title="JavaScript - Create Stash"
+            onCopy={handleCopy}
+            code={`const response = await fetch('${baseUrl}/api/stashes', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
@@ -170,11 +177,12 @@ console.log(data.stashes);`}</pre>
     tags: ['notes'],
   }),
 });
-const stash = await response.json();`}</pre>
-          </div>
-          <div className="api-example-item">
-            <div className="api-example-title">Python - Search Stashes</div>
-            <pre className="api-code-block">{`import requests
+const stash = await response.json();`}
+          />
+          <CodeExample
+            title="Python - Search Stashes"
+            onCopy={handleCopy}
+            code={`import requests
 
 response = requests.get(
     '${baseUrl}/api/stashes',
@@ -182,8 +190,8 @@ response = requests.get(
     headers={'Authorization': 'Bearer YOUR_TOKEN'}
 )
 data = response.json()
-print(f"Found {data['total']} stashes")`}</pre>
-          </div>
+print(f"Found {data['total']} stashes")`}
+          />
         </div>
       </section>
 


### PR DESCRIPTION
Small, additive UX/comfort refinements to 2 existing features. No new features, deps, refactors, or behavior changes — reuses existing components/CSS/hooks.

| # | Feature | Datei(en) | Kategorie | UX-Lücke | Verbesserung | Aufwand |
|---|---------|-----------|-----------|----------|--------------|---------|
| 1 | API-Manager „Examples" | `api/CodeExample.tsx` (neu), `RestTab.tsx`, `McpTab.tsx` | Komfort | 10 Example-Snippets ohne Copy-Button | Shared `CodeExample` mit Ein-Klick-Copy (bestehendes Pattern, kein neues CSS) | S–M |
| 2 | Stash-Viewer Access-Log | `StashViewer.tsx` | Qualität | Fetch-Fehler = identischer Empty-State | Eigener Error-State + Retry-Button | S |

**Verifikation lokal:** `tsc --noEmit` grün · `prettier --check` grün · Vitest 284 passed · `package-lock.json` unberührt.

Closes #354

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqKhxBeVnChqWtH8CCC9Kw

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqKhxBeVnChqWtH8CCC9Kw)_