### PR TITLE
refine: ux sweep (Next.js + React)

### DIFF
--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -74,6 +74,9 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
 
   const handleInputChange = (value: string) => {
     setQuery(value);
+    // Clearing the field falls back to the "Recently viewed" list — re-home the
+    // highlight to its first item so arrow-nav resumes from a valid position.
+    if (!value.trim()) setActiveIndex(0);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => doSearch(value), SEARCH_DEBOUNCE_MS);
   };
@@ -115,17 +118,22 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
     onClose();
   };
 
+  // Arrow/Enter navigation targets whichever list is on screen: search results
+  // when a query is present, otherwise the "Recently viewed" shortcuts. Both
+  // item shapes expose an `id`, so selection is uniform.
+  const navItems: { id: string }[] = query.trim() ? results : recent;
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      setActiveIndex((i) => (i < results.length - 1 ? i + 1 : i));
+      setActiveIndex((i) => (i < navItems.length - 1 ? i + 1 : i));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       setActiveIndex((i) => (i > 0 ? i - 1 : 0));
     } else if (e.key === 'Enter') {
       e.preventDefault();
-      if (results[activeIndex]) {
-        handleSelect(results[activeIndex].id);
+      if (navItems[activeIndex]) {
+        handleSelect(navItems[activeIndex].id);
       }
     } else if (e.key === 'Escape') {
       e.preventDefault();
@@ -269,13 +277,14 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
             aria-label={`${recent.length} recently viewed stash${recent.length !== 1 ? 'es' : ''}`}
           >
             <div className="search-overlay-results-count">Recently viewed</div>
-            {recent.map((item) => (
+            {recent.map((item, idx) => (
               <button
                 type="button"
                 key={item.id}
-                className="search-overlay-item"
+                className={`search-overlay-item ${idx === activeIndex ? 'active' : ''}`}
                 role="option"
-                aria-selected={false}
+                aria-selected={idx === activeIndex}
+                onMouseEnter={() => setActiveIndex(idx)}
                 onClick={() => handleSelect(item.id)}
               >
                 <div className="search-overlay-item-main">

--- a/src/components/editor/MetadataEditor.tsx
+++ b/src/components/editor/MetadataEditor.tsx
@@ -40,6 +40,10 @@ export default function MetadataEditor({ entries, onChange, availableKeys }: Pro
   const [showAll, setShowAll] = useState(false);
   const [keyInput, setKeyInput] = useState('');
   const [showKeyDropdown, setShowKeyDropdown] = useState(false);
+  // Highlighted suggestion index for keyboard navigation of the key dropdown.
+  // -1 = nothing highlighted (mirrors TagCombobox). Keeps the key input
+  // arrow-navigable + Enter-selectable instead of mouse-click only.
+  const [activeIndex, setActiveIndex] = useState(-1);
   // Inline notice shown when the user tries to add a key that already exists.
   // Previously a duplicate add silently cleared the input with no explanation.
   const [dupWarning, setDupWarning] = useState<string | null>(null);
@@ -68,6 +72,12 @@ export default function MetadataEditor({ entries, onChange, availableKeys }: Pro
   const filteredKeys = availableKeys
     .filter((k) => !existingKeys.includes(k))
     .filter((k) => !keyInput || k.toLowerCase().includes(keyInput.toLowerCase()));
+  // Cap mirrors the render slice below so keyboard navigation and the visible
+  // option list stay in lockstep.
+  const visibleKeys = filteredKeys.slice(0, 8);
+  const dropdownVisible = showKeyDropdown && visibleKeys.length > 0;
+  const activeOptionId =
+    dropdownVisible && activeIndex >= 0 ? `metadata-key-option-${activeIndex}` : undefined;
 
   const updateEntry = (index: number, field: 'key' | 'value', val: string) => {
     const updated = [...entries];
@@ -95,14 +105,32 @@ export default function MetadataEditor({ entries, onChange, availableKeys }: Pro
     setDupWarning(null);
     setKeyInput('');
     setShowKeyDropdown(false);
+    setActiveIndex(-1);
   };
 
   const handleKeyInputKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'ArrowDown') {
       e.preventDefault();
-      if (keyInput.trim()) addEntry(keyInput);
+      setShowKeyDropdown(true);
+      setActiveIndex((prev) =>
+        visibleKeys.length === 0 ? -1 : Math.min(prev + 1, visibleKeys.length - 1),
+      );
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setShowKeyDropdown(true);
+      setActiveIndex((prev) => Math.max(prev - 1, -1));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      // Prefer the highlighted suggestion; otherwise fall back to adding the
+      // typed key (preserves the original Enter-adds-typed-key behaviour).
+      if (dropdownVisible && activeIndex >= 0 && visibleKeys[activeIndex]) {
+        addEntry(visibleKeys[activeIndex]);
+      } else if (keyInput.trim()) {
+        addEntry(keyInput);
+      }
     } else if (e.key === 'Escape') {
       setShowKeyDropdown(false);
+      setActiveIndex(-1);
     }
   };
 
@@ -170,12 +198,19 @@ export default function MetadataEditor({ entries, onChange, availableKeys }: Pro
           onChange={(e) => {
             setKeyInput(e.target.value);
             setShowKeyDropdown(true);
+            setActiveIndex(-1);
             if (dupWarning) setDupWarning(null);
           }}
           onFocus={() => setShowKeyDropdown(true)}
           onKeyDown={handleKeyInputKeyDown}
           placeholder="Add key..."
           className="form-input metadata-add-input"
+          role="combobox"
+          aria-expanded={dropdownVisible}
+          aria-haspopup="listbox"
+          aria-autocomplete="list"
+          aria-controls="metadata-key-listbox"
+          aria-activedescendant={activeOptionId}
           aria-label="Add metadata key"
           aria-invalid={dupWarning ? true : undefined}
           autoComplete="off"
@@ -192,10 +227,22 @@ export default function MetadataEditor({ entries, onChange, availableKeys }: Pro
           </svg>
           Add
         </button>
-        {showKeyDropdown && filteredKeys.length > 0 && (
-          <div className="tag-combobox-dropdown metadata-key-dropdown">
-            {filteredKeys.slice(0, 8).map((k) => (
-              <button key={k} className="tag-combobox-option" onClick={() => addEntry(k)}>
+        {dropdownVisible && (
+          <div
+            id="metadata-key-listbox"
+            className="tag-combobox-dropdown metadata-key-dropdown"
+            role="listbox"
+          >
+            {visibleKeys.map((k, i) => (
+              <button
+                key={k}
+                id={`metadata-key-option-${i}`}
+                className={`tag-combobox-option${activeIndex === i ? ' active' : ''}`}
+                onClick={() => addEntry(k)}
+                onMouseEnter={() => setActiveIndex(i)}
+                role="option"
+                aria-selected={activeIndex === i}
+              >
                 {k}
               </button>
             ))}

--- a/src/components/editor/StashEditor.tsx
+++ b/src/components/editor/StashEditor.tsx
@@ -194,7 +194,12 @@ export default function StashEditor({ stash, onSave, onCancel }: Props) {
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
       if (dirtyRef.current) {
+        // preventDefault() alone is enough for spec-compliant browsers, but
+        // several (older Chrome/Safari, some mobile engines) only raise the
+        // native "unsaved changes" prompt when the legacy returnValue is also
+        // set. Setting both makes the data-loss guard fire reliably everywhere.
         e.preventDefault();
+        e.returnValue = '';
       }
     };
     window.addEventListener('beforeunload', handler);


### PR DESCRIPTION
Closes #370

Automated UX-refine-sweep — 3 small, additive keyboard/data-safety refinements to existing ClawStash features. No new features, no dependency changes. All 3 reuse existing CSS (no new styles).

| # | Feature | Datei | Kategorie | UX-Lücke | Verbesserung | Aufwand |
|---|---------|-------|-----------|----------|--------------|---------|
| 1 | Editor unsaved-changes guard | components/editor/StashEditor.tsx | Qualität/Feedback | `beforeunload` set no legacy `returnValue` → prompt skipped in some browsers | Set `e.returnValue=''` so the data-loss warning fires cross-browser | S |
| 2 | Metadata key-suggestion dropdown | components/editor/MetadataEditor.tsx | A11y/Polish | Mouse-only; no listbox/option roles | Arrow/Enter/Escape nav + combobox/listbox/option ARIA + `aria-activedescendant` | M |
| 3 | Quick-search "Recently viewed" | components/SearchOverlay.tsx | A11y/Polish | Recents list mouse/Tab-only in the keyboard-first Alt+K overlay | Arrow/Enter navigation over recents + `aria-selected` + hover sync | S |

**Verification:** `tsc --noEmit` green · vitest 287 passed / 5 skipped · `next build` green.

<!-- screenshot: optional -->

_Not auto-merged — ready for review._

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kf4eW2guMFveggopuktqaL)_