### PR TITLE
security: hardening sweep (Next.js)

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -6,6 +6,11 @@
  */
 export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+  if (!process.env.ADMIN_PASSWORD) {
+    console.warn(
+      '[security] ADMIN_PASSWORD is not set: ClawStash is running in OPEN MODE. All REST/MCP routes (including admin data export, token CRUD, and GitHub-backup config) are reachable without authentication. Set ADMIN_PASSWORD to require login.',
+    );
+  }
   try {
     // Dynamic import: keeps better-sqlite3 (native addon) out of the
     // edge/client bundles that also evaluate this module's exports.

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -58,7 +58,26 @@ export function sanitizeHtml(html: string): string {
   doc
     .querySelectorAll('script,style,iframe,object,embed,form,link,base,meta,noscript')
     .forEach((el) => el.remove());
+  // Strip SVG/MathML foreign content + SMIL animation elements. Markdown never
+  // legitimately emits these, and they are the vector for mutation-XSS and the
+  // SMIL `<animate attributeName=href values="javascript:...">` bypass of the
+  // href/on* checks below. Match on lowercased tagName so case-sensitive SVG
+  // element names (animateTransform, foreignObject) are caught regardless of case.
+  const FOREIGN_ELEMENTS = new Set([
+    'svg',
+    'math',
+    'animate',
+    'animatetransform',
+    'animatemotion',
+    'set',
+    'foreignobject',
+    'template',
+  ]);
   doc.querySelectorAll('*').forEach((el) => {
+    if (FOREIGN_ELEMENTS.has(el.tagName.toLowerCase())) {
+      el.remove();
+      return;
+    }
     for (const attr of [...el.attributes]) {
       const lowerName = attr.name.toLowerCase();
       const isEventHandler = lowerName.startsWith('on');


### PR DESCRIPTION
## Summary

Two `safe`, non-breaking hardening fixes from an automated security sweep of the web layer (REST + MCP + web GUI). The higher-value root fixes and remaining items are tracked in #372. **Not auto-merged** — the routine leaves the merge decision to a human.

## Changes

- **Strip SVG/MathML/SMIL foreign elements in the HTML sanitizer** (`src/utils/markdown.ts`) — `sanitizeHtml` (which feeds `dangerouslySetInnerHTML` for stash descriptions + markdown files) removed `script/style/iframe/…` but not SVG/MathML foreign content or SMIL animation elements, so `<a><animate attributeName=href values="javascript:…">` and the mutation-XSS re-serialization class could bypass the `href`/`on*` attribute checks. Now also strips `svg, math, animate, animateTransform, animateMotion, set, foreignObject, template` (matched on lowercased `tagName`). Markdown never legitimately emits these, so no content is lost. Interim hardening — the full remediation (DOMPurify + strict `script-src` CSP) is flagged in #372.
- **Warn at boot in open (no-auth) mode** (`src/instrumentation.ts`) — when `ADMIN_PASSWORD` is unset, every REST/MCP route is reachable unauthenticated; added a one-time `console.warn` at server boot. Log-only, no behavior change.

## Testing

- Formatting verified locally with Prettier 3.9.5 — `format:check` passes.
- `tsc --noEmit` / `npm test` / `npm run build` were **not** run locally (the sweep environment has no installed dependencies) — relying on this PR's CI for those. The sanitizer change is additive element removal; the boot change is log-only.

## Checklist

- [x] Formatting passes (`npm run format:check`) — verified with Prettier 3.9.5
- [ ] Code compiles without errors (`npx tsc --noEmit`) — to be confirmed by CI
- [ ] Tests pass (`npm test`) — to be confirmed by CI
- [ ] Build succeeds (`npm run build`) — to be confirmed by CI
- [x] Changes are documented (security issue #372)

Refs #372

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbQCvHcC23ng2JJnqj2hEe)_