### PR TITLE
feat: comfort sweep (Next.js + React)

### DIFF
--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -16,6 +16,10 @@ interface Props {
 export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<StashListItem[]>([]);
+  // Full server-side match count. The result list is capped (see the `limit`
+  // below), so `total > results.length` means matches are hidden — surfaced to
+  // the user, mirroring the dashboard/sidebar "showing N" honesty pattern.
+  const [total, setTotal] = useState(0);
   const [recent, setRecent] = useState<RecentView[]>([]);
   const [loading, setLoading] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
@@ -40,6 +44,7 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
       }
       setQuery('');
       setResults([]);
+      setTotal(0);
       setActiveIndex(0);
       setLoading(false);
       // Refresh the "Recently viewed" shortcut list each time the overlay
@@ -54,6 +59,7 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
   const doSearch = useCallback(async (q: string) => {
     if (!q.trim()) {
       setResults([]);
+      setTotal(0);
       setLoading(false);
       return;
     }
@@ -63,10 +69,12 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
       const res = await api.listStashes({ search: q, limit: 12 });
       if (gen !== searchGenRef.current) return;
       setResults(res.stashes);
+      setTotal(res.total);
       setActiveIndex(0);
     } catch {
       if (gen !== searchGenRef.current) return;
       setResults([]);
+      setTotal(0);
     } finally {
       if (gen === searchGenRef.current) setLoading(false);
     }
@@ -236,7 +244,9 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
             aria-label={`${results.length} result${results.length !== 1 ? 's' : ''}`}
           >
             <div className="search-overlay-results-count" aria-live="polite" role="status">
-              {results.length} result{results.length !== 1 ? 's' : ''}
+              {total > results.length
+                ? `Showing first ${results.length} of ${total} matches — refine to narrow`
+                : `${results.length} result${results.length !== 1 ? 's' : ''}`}
             </div>
             {results.map((stash, idx) => (
               <button

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -16,6 +16,7 @@ import { Marked } from 'marked';
 import { renderDescriptionMarkdown, isUnsafeUrl, sanitizeHtml } from '../utils/markdown';
 import { hydrateMermaidPlaceholders, encodeMermaidSource } from '../utils/mermaid-hydrate';
 import { DELETE_CONFIRM_TIMEOUT_MS } from '../utils/constants';
+import { formatBytes } from '../utils/format';
 import { escapeHtml } from '../utils/html';
 import { buildStashUrl } from '../utils/stash-url';
 import MermaidDiagram from './MermaidDiagram';
@@ -685,6 +686,14 @@ export default function StashViewer({
     [stash.description],
   );
 
+  // Total content size (UTF-8 bytes) across all files. The list/card view
+  // already shows this via `total_size`, but the full Stash payload carries
+  // only file content, so recompute it here for the Details table.
+  const totalBytes = useMemo(
+    () => stash.files.reduce((sum, f) => sum + new TextEncoder().encode(f.content).length, 0),
+    [stash.files],
+  );
+
   return (
     <div className="stash-viewer">
       {/* Screen-reader announcement for copy status */}
@@ -1221,6 +1230,10 @@ export default function StashViewer({
                 <tr>
                   <td>Files</td>
                   <td>{stash.files.length}</td>
+                </tr>
+                <tr>
+                  <td>Size</td>
+                  <td>{formatBytes(totalBytes)}</td>
                 </tr>
                 <tr>
                   <td>Created</td>

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -58,6 +58,7 @@ function SourceBadge({ source }: { source: string }) {
 const RENDER_PREF_KEY = 'clawstash-render-preview';
 const ACTIVE_TAB_KEY = 'clawstash-viewer-tab';
 const TOC_PREF_KEY = 'clawstash-toc-expanded';
+const WRAP_PREF_KEY = 'clawstash-wrap-lines';
 
 type ViewerTab = 'content' | 'metadata' | 'access-log' | 'history';
 const VALID_TABS: ViewerTab[] = ['content', 'metadata', 'access-log', 'history'];
@@ -74,6 +75,27 @@ function getRenderPreference(): boolean {
 function setRenderPreference(enabled: boolean): void {
   try {
     localStorage.setItem(RENDER_PREF_KEY, String(enabled));
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Read the persisted "wrap long lines" preference for the raw code view.
+ * Defaults to false (long lines scroll horizontally, preserving the original
+ * layout). Mirrors the render-preview / TOC preference helpers above.
+ */
+function getWrapPreference(): boolean {
+  try {
+    return localStorage.getItem(WRAP_PREF_KEY) === 'true'; // default to false
+  } catch {
+    return false;
+  }
+}
+
+function setWrapPreference(enabled: boolean): void {
+  try {
+    localStorage.setItem(WRAP_PREF_KEY, String(enabled));
   } catch {
     /* ignore */
   }
@@ -382,6 +404,7 @@ export default function StashViewer({
   const [logError, setLogError] = useState(false);
   const [logReloadKey, setLogReloadKey] = useState(0);
   const [renderPreview, setRenderPreview] = useState(getRenderPreference);
+  const [wrapLines, setWrapLines] = useState(getWrapPreference);
   const [tocExpanded, setTocExpanded] = useState(getTocPreference);
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
   const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -452,6 +475,15 @@ export default function StashViewer({
     setRenderPreview((prev) => {
       const next = !prev;
       setRenderPreference(next);
+      return next;
+    });
+  }, []);
+
+  /** Toggle raw-code line wrapping and persist the choice (global preference). */
+  const toggleWrapLines = useCallback(() => {
+    setWrapLines((prev) => {
+      const next = !prev;
+      setWrapPreference(next);
       return next;
     });
   }, []);
@@ -1060,6 +1092,30 @@ export default function StashViewer({
                         {showRendered ? 'Raw' : 'Preview'}
                       </button>
                     )}
+                    {!showRendered && (
+                      <button
+                        className={`btn btn-sm btn-ghost wrap-toggle ${wrapLines ? 'wrap-active' : ''}`}
+                        onClick={toggleWrapLines}
+                        aria-pressed={wrapLines}
+                        title={
+                          wrapLines
+                            ? 'Stop wrapping — scroll long lines horizontally'
+                            : 'Wrap long lines to fit the width'
+                        }
+                        aria-label={wrapLines ? 'Stop wrapping long lines' : 'Wrap long lines'}
+                      >
+                        <svg
+                          width="12"
+                          height="12"
+                          viewBox="0 0 16 16"
+                          fill="currentColor"
+                          aria-hidden="true"
+                        >
+                          <path d="M1.75 3.5a.75.75 0 0 1 0-1.5h12.5a.75.75 0 0 1 0 1.5H1.75Zm0 5a.75.75 0 0 1 0-1.5h9.5a2.75 2.75 0 0 1 0 5.5H8.56l.72.72a.75.75 0 1 1-1.06 1.06l-2-2a.75.75 0 0 1 0-1.06l2-2a.75.75 0 0 1 1.06 1.06l-.72.72h2.69a1.25 1.25 0 0 0 0-2.5h-9.5Zm0 5a.75.75 0 0 1 0-1.5h3.5a.75.75 0 0 1 0 1.5h-3.5Z" />
+                        </svg>
+                        Wrap
+                      </button>
+                    )}
                     <button
                       className="btn btn-sm btn-ghost"
                       onClick={() => fileClipboard.copy(file.id, file.content)}
@@ -1117,7 +1173,7 @@ export default function StashViewer({
                       title={`Preview of ${file.filename}`}
                     />
                   ) : (
-                    <pre className="file-content">
+                    <pre className={`file-content${wrapLines ? ' file-content-wrap' : ''}`}>
                       <code
                         dangerouslySetInnerHTML={{
                           __html: highlightedContent.get(file.id) || '',

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2050,12 +2050,29 @@ body {
   white-space: pre;
 }
 
+/* "Wrap lines" toggle: break long lines to fit the width instead of
+   scrolling horizontally. Overrides the default `white-space: pre` above. */
+.file-content-wrap code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 /* === Render Toggle === */
 .render-toggle {
   gap: 4px;
 }
 
 .render-toggle.render-active {
+  color: var(--accent-blue);
+}
+
+/* === Wrap Toggle === */
+.wrap-toggle {
+  gap: 4px;
+}
+
+.wrap-toggle.wrap-active {
   color: var(--accent-blue);
 }
 


### PR DESCRIPTION
This PR adds three small, additive end-user comfort improvements to the ClawStash web dashboard, following existing idioms (localStorage-persisted prefs, BEM-like global CSS, English UI) with no new dependencies. All checks green locally (Prettier, tsc, 287 Vitest tests, production build).

| # | Feature | Nutzen für User | Aufwand |
|---|---|---|---|
| 1 | Word-wrap toggle for the raw code view | Long lines wrap to fit instead of horizontal scroll; per-file toggle, globally persisted | S |
| 2 | Total "Size" row in the stash Details table | Detail view shows total content size, consistent with card/list views | S |
| 3 | Capped-result hint in the quick search overlay | Surfaces hidden matches beyond the 12-row cap ("Showing first N of M — refine") | S |

Closes #383

---
_Generated by [Claude Code](https://claude.ai/code/session_0116W4QKhPapf1ebSm39Q3Lq)_