### PR TITLE
refactor: best-practice sweep (Next.js + React)

### DIFF
--- a/src/components/StashGraphCanvas.tsx
+++ b/src/components/StashGraphCanvas.tsx
@@ -986,6 +986,11 @@ export default function StashGraphCanvas({
         hoveredRef.current = node;
         canvas.style.cursor = node ? 'pointer' : 'grab';
         setHoveredLabel(node ? node.label : null);
+        // Hover emphasis is painted only inside the rAF draw() (it reads
+        // hoveredRef); re-kick the idle loop so hovering still updates the
+        // canvas after the layout settles. Mirrors the drag/pan branches above
+        // and GraphViewer's onMouseMove.
+        kickAnimation();
       }
     };
 
@@ -1324,6 +1329,11 @@ export default function StashGraphCanvas({
       trackedTagsRef.current = next;
       return next;
     });
+    // Tracked-tag node/edge highlighting is painted inside the rAF draw()
+    // (it reads trackedTagsRef); no effect depends on trackedTags, so re-kick
+    // the idle loop here or the highlight will not update after the layout
+    // settles.
+    kickAnimation();
   };
 
   const handleToggleIgnoreTag = (tagName: string) => {

--- a/src/components/StashGraphCanvas.tsx
+++ b/src/components/StashGraphCanvas.tsx
@@ -914,12 +914,18 @@ export default function StashGraphCanvas({
       canvas.height = rect.height * dpr;
       canvas.style.width = rect.width + 'px';
       canvas.style.height = rect.height + 'px';
+      // Resizing the canvas resets its bitmap (clears it). Once the physics
+      // loop has settled it stops itself, so without re-kicking it here the
+      // graph stays blank after any resize (window / sidebar collapse / mobile
+      // URL bar / ResizeObserver). kickAnimation() draws one frame when idle.
+      // Mirrors GraphViewer's resize handler.
+      kickAnimation();
     };
     resize();
     const observer = new ResizeObserver(resize);
     observer.observe(container);
     return () => observer.disconnect();
-  }, []);
+  }, [kickAnimation]);
 
   // Mouse events
   useEffect(() => {


### PR DESCRIPTION
Best-practice refactoring sweep. Two behavior-restoring correctness fixes, both in `src/components/StashGraphCanvas.tsx`, same root cause: the self-halting force-simulation loop is not re-kicked on several interactions, so after the layout settles (~16 s) the canvas goes stale. The sibling `GraphViewer.tsx` re-kicks its loop on every one of these interactions — this file was missing three of them.

`kickAnimation()` is provably safe: it is a no-op while the loop runs and draws exactly **one** frame when idle (it does not reset `alphaRef`, so no physics re-run).

## Findings

| # | Datei | Kategorie | Befund | Fix | Aufwand | Status |
|---|-------|-----------|--------|-----|---------|--------|
| 1 | `src/components/StashGraphCanvas.tsx` | Correctness | Resize resets (clears) the canvas bitmap but never redraws → graph blanks on window/sidebar/mobile-URL-bar/`ResizeObserver` resize after settle. | Re-kick the idle loop in `resize` + add `kickAnimation` to the effect deps. | S | fixed |
| 2 | `src/components/StashGraphCanvas.tsx` | Correctness | Hover change (`hoveredRef`) and `handleToggleTrackTag` (`trackedTagsRef`) mutate refs only `draw()` consumes but never re-kick the loop → hover emphasis and green tag-track highlighting are dead after settle. | Add `kickAnimation()` in the hover branch and in `handleToggleTrackTag`. | S | fixed |

## Deferred

- **Unbounded pagination `limit`** (`stores/_parsers.ts` `clampPagination` + `tool-defs.ts` + `app/api/stashes/route.ts`) — no upper cap on `limit`. Capping changes behavior for large-limit API callers (not behavior-equivalent) and the 50/20 values are a documented UI-driven default (BACKLOG #120), so it is out of scope for this sweep.

## Verification

Local, all green: `prettier --check .` ✓ · `tsc --noEmit` ✓ · `vitest run` (287 passed / 5 skipped) ✓ · `next build` ✓.

Closes #385

---
_Generated by [Claude Code](https://claude.ai/code/session_016tkggNBwN1vgonErfs22Dx)_