### PR TITLE
ux: best-practice sweep (Next.js 16 + React 19)

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -698,6 +698,21 @@ interface Props {
   onSettingsSection: (section: SettingsSection) => void;
 }
 
+// Every other top-level view (Dashboard, API Documentation) starts with a
+// visible <h1>, but these settings sections previously started at <h2> with
+// no <h1> anywhere in the tree — a missing top-level heading for screen
+// reader / assistive-tech navigation. 'api' is excluded: ApiManager renders
+// its own visible <h1> ("API Documentation"), so adding one here would
+// duplicate it.
+const SETTINGS_SECTION_TITLES: Record<SettingsSection, string> = {
+  welcome: 'Admin Dashboard',
+  general: 'General',
+  api: 'API Documentation',
+  backup: 'GitHub Backup',
+  storage: 'Storage',
+  about: 'About',
+};
+
 export default function Settings({
   activeSection,
   layout,
@@ -706,6 +721,16 @@ export default function Settings({
 }: Props) {
   return (
     <div className="settings">
+      {/*
+        Visually-hidden heading restoring a proper <h1> landmark without
+        changing any visible heading or its CSS — several of the visible
+        h2/h3 below are styled via tag-selector rules (e.g.
+        `.settings-section-title h2`), so renumbering them would need a much
+        larger CSS pass. This is purely additive for assistive tech.
+      */}
+      {activeSection !== 'api' && (
+        <h1 className="sr-only">{SETTINGS_SECTION_TITLES[activeSection]}</h1>
+      )}
       {activeSection === 'welcome' && <WelcomeSection onNavigate={onSettingsSection} />}
       {activeSection === 'general' && (
         <GeneralSection layout={layout} onLayoutChange={onLayoutChange} />

--- a/src/components/StashGraphCanvas.tsx
+++ b/src/components/StashGraphCanvas.tsx
@@ -1475,7 +1475,12 @@ export default function StashGraphCanvas({
 
         {/* Popup */}
         {popup && popup.node.type === 'stash' && (
-          <div className="graph-node-popup" style={getPopupStyle()} role="dialog">
+          <div
+            className="graph-node-popup"
+            style={getPopupStyle()}
+            role="dialog"
+            aria-label={`Stash: ${popup.node.label}`}
+          >
             <div className="graph-popup-header">
               <div className="graph-popup-tag">
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
@@ -1605,7 +1610,12 @@ export default function StashGraphCanvas({
 
         {/* Tag Popup */}
         {popup && popup.node.type === 'tag' && (
-          <div className="graph-node-popup" style={getPopupStyle()} role="dialog">
+          <div
+            className="graph-node-popup"
+            style={getPopupStyle()}
+            role="dialog"
+            aria-label={`Tag: ${popup.node.label}`}
+          >
             <div className="graph-popup-header">
               <div className="graph-popup-tag">
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -696,6 +696,15 @@ export default function StashViewer({
 
   return (
     <div className="stash-viewer">
+      {/*
+        This view has no <h1> above it in the tree (App.tsx renders no
+        app-level heading), so the visible ".viewer-title" <h2> below was the
+        highest heading on the page — a missing top-level landmark for
+        assistive tech. A visually-hidden <h1> restores the hierarchy
+        (h1 -> h2 -> h3) without changing the visible heading or its
+        tag-selector CSS.
+      */}
+      <h1 className="sr-only">{title}</h1>
       {/* Screen-reader announcement for copy status */}
       <div className="sr-only" aria-live="polite">
         {copyAllClipboard.status === 'copied' && 'All files copied to clipboard'}


### PR DESCRIPTION
Additive a11y sweep (missing page-level `<h1>` landmarks + un-named dialogs). Verified green: tsc + `next build` + vitest (287 passed/5 skipped) + format:check.

## Merged findings
| # | File | Category | Fix | Effort |
|---|------|----------|-----|--------|
| 1 | Settings.tsx | a11y | visually-hidden h1 per settings section | S |
| 2 | StashViewer.tsx | a11y | visually-hidden h1 with stash title | S |
| 3 | StashGraphCanvas.tsx | a11y | aria-label for both graph node/tag popups | S |

Affected: Settings, Stash detail view, tag-graph node popups. Purely additive (+46/−2), no visual change (sr-only headings).

Closes #387

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUXkMBBwzJEmyqbU6LWNiB)_