### PR TITLE
chore: repo quality maintenance (Next.js/TS + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ npm install
 cp .env.example .env   # adjust DATABASE_PATH / ADMIN_PASSWORD as needed
 
 npm run dev            # Next.js dev server at http://localhost:3000
+npm run format         # auto-format with Prettier (CI verifies formatting via format:check)
 npm test               # vitest test suite
 npm run build          # production build
 npm start              # serve the production build


### PR DESCRIPTION
## Summary

Automated repo-quality-maintenance sweep (2026-07-22) — additive, documentation-only change. The README dev-command block listed `dev`/`test`/`build`/`start`/`mcp` but not `npm run format`, even though CI enforces `format:check` and the script exists (it was only documented in `CONTRIBUTING.md`). Added the missing line so contributors format before pushing.

## Changes

- `README.md`: added one aligned `npm run format` line to the dev-commands block (auto-format with Prettier; CI verifies via `format:check`).

## Testing

Documentation-only — one added line inside an existing ```bash fence. No code paths affected; Prettier-safe by construction. (`node_modules` was not installed in the sweep environment, so `format:check` / `tsc` / `test` were not executed; the change cannot affect them.)

## Checklist

- [ ] Formatting passes (`npm run format:check`) — not run (docs-only, no node_modules); line is inside a fenced block, Prettier-safe
- [ ] Code compiles without errors (`npx tsc --noEmit`) — n/a, no code changed
- [ ] Tests pass (`npm test`) — n/a, no code changed
- [ ] Build succeeds (`npm run build`) — n/a, no code changed
- [x] Changes are documented (if applicable) — this IS the documentation change

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJDTSEzn2UwKaW2FFzXTdv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJDTSEzn2UwKaW2FFzXTdv)_