### PR TITLE
refine: ux sweep (Next.js)

### DIFF
--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -89,6 +89,26 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
     debounceRef.current = setTimeout(() => doSearch(value), SEARCH_DEBOUNCE_MS);
   };
 
+  // Clear the query without closing the overlay — Escape closes it entirely, so
+  // there was previously no way to wipe the field and fall back to the "Recently
+  // viewed" list short of selecting-all + delete. Mirrors the sidebar search's
+  // inline clear button.
+  const handleClearQuery = () => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = undefined;
+    }
+    // Invalidate any in-flight search so a late response cannot repopulate the
+    // list after the field has been cleared.
+    searchGenRef.current++;
+    setQuery('');
+    setResults([]);
+    setTotal(0);
+    setActiveIndex(0);
+    setLoading(false);
+    inputRef.current?.focus();
+  };
+
   // Cleanup debounce on unmount
   useEffect(() => {
     return () => {
@@ -219,6 +239,25 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
               navItems.length > 0 ? `search-overlay-option-${activeIndex}` : undefined
             }
           />
+          {query && (
+            <button
+              type="button"
+              className="search-overlay-input-clear"
+              onClick={handleClearQuery}
+              title="Clear search"
+              aria-label="Clear search"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+              </svg>
+            </button>
+          )}
           <kbd className="search-overlay-kbd">Esc</kbd>
         </div>
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -330,6 +330,7 @@ export default function Sidebar({
                     role="button"
                     tabIndex={0}
                     aria-expanded={tagDropdownOpen}
+                    aria-haspopup="true"
                     aria-label={`Change tag filter, currently "${filterTag}"`}
                     title="Click to change tag filter"
                   >
@@ -359,6 +360,7 @@ export default function Sidebar({
                   }}
                   title="Filter stashes by tag"
                   aria-expanded={tagDropdownOpen}
+                  aria-haspopup="true"
                 >
                   <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
                     <path d="M1 7.775V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 0 1 0 2.474l-5.026 5.026a1.75 1.75 0 0 1-2.474 0l-6.25-6.25A1.752 1.752 0 0 1 1 7.775Zm1.5 0c0 .066.026.13.073.177l6.25 6.25a.25.25 0 0 0 .354 0l5.025-5.025a.25.25 0 0 0 0-.354l-6.25-6.25a.25.25 0 0 0-.177-.073H2.75a.25.25 0 0 0-.25.25ZM6 5a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z" />
@@ -367,7 +369,22 @@ export default function Sidebar({
                 </button>
               )}
               {tagDropdownOpen && (
-                <div className="sidebar-tag-dropdown">
+                <div
+                  className="sidebar-tag-dropdown"
+                  // Escape dismisses the dropdown — matches the Escape-to-close
+                  // idiom used by the stash search field, quick-search overlay,
+                  // and tag combobox. stopPropagation also prevents Escape on an
+                  // option button from bubbling to the global handler, which
+                  // would otherwise navigate back to the dashboard from an open
+                  // stash / graph view.
+                  onKeyDown={(e) => {
+                    if (e.key === 'Escape') {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      closeTagDropdown();
+                    }
+                  }}
+                >
                   {tags.length > 5 && (
                     <div className="sidebar-tag-search">
                       <input

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -1102,7 +1102,9 @@ export default function StashViewer({
                       <button
                         className={`btn btn-sm btn-ghost render-toggle ${showRendered ? 'render-active' : ''}`}
                         onClick={toggleRenderPreview}
+                        aria-pressed={showRendered}
                         title={showRendered ? 'Show raw source code' : 'Show rendered preview'}
+                        aria-label={showRendered ? 'Show raw source code' : 'Show rendered preview'}
                       >
                         <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
                           <path d="M8 2c1.981 0 3.671.992 4.933 2.078 1.27 1.091 2.187 2.345 2.637 3.023a1.62 1.62 0 0 1 0 1.798c-.45.678-1.367 1.932-2.637 3.023C11.67 13.008 9.981 14 8 14c-1.981 0-3.671-.992-4.933-2.078C1.797 10.831.88 9.577.43 8.9a1.619 1.619 0 0 1 0-1.798c.45-.678 1.367-1.932 2.637-3.023C4.33 2.992 6.019 2 8 2ZM1.679 7.932a.12.12 0 0 0 0 .136c.411.622 1.241 1.75 2.366 2.717C5.176 11.758 6.527 12.5 8 12.5c1.473 0 2.825-.742 3.955-1.715 1.124-.967 1.954-2.096 2.366-2.717a.12.12 0 0 0 0-.136c-.412-.621-1.242-1.75-2.366-2.717C10.824 4.242 9.473 3.5 8 3.5c-1.473 0-2.825.742-3.955 1.715-1.124.967-1.954 2.096-2.366 2.717ZM8 10a2 2 0 1 1-.001-3.999A2 2 0 0 1 8 10Z" />

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -856,6 +856,39 @@ body {
   flex-shrink: 0;
 }
 
+/* Inline clear button shown while the quick-search field has a value — clears
+   the query and returns to "Recently viewed" without closing the overlay.
+   Mirrors the sidebar search's .search-input-clear (flex child, not absolute). */
+.search-overlay-input-clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    color 0.15s,
+    background 0.15s,
+    border-color 0.15s;
+}
+
+.search-overlay-input-clear:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.search-overlay-input-clear:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 1px;
+  color: var(--text-primary);
+}
+
 .search-overlay-status {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Small, additive UX-comfort/a11y polish on existing user-facing features. No new features, no behavior changes to defaults, no dependency/API/DB changes. Verified green: `npm ci && npm run format:check && npx tsc --noEmit && npm test && npm run build` (287 tests pass, build clean).

| Feature | UX-Lücke | Verbesserung | Aufwand | Empfehlung |
|---------|----------|--------------|---------|------------|
| Quick-Search-Overlay (Alt+K) | Kein Inline-Weg, die Suchanfrage zu leeren (Escape schließt das ganze Overlay) | Inline-Clear-(×)-Button → zurück auf „Recently viewed", bricht Debounce/Request ab, refokussiert Input | S | mergen |
| Sidebar Tag-Filter-Dropdown | Escape schloss es nicht + Escape leakte an globalen Handler → versehentliche Zurück-Navigation | Escape schließt Dropdown (+ `stopPropagation`); `aria-haspopup` an Togglern | S | mergen |
| Stash-Viewer „Preview/Raw"-Toggle | Toggle-Zustand nicht an Screenreader gemeldet | `aria-pressed` + `aria-label` ergänzt | S | mergen |

Closes #391

---
_Generated by [Claude Code](https://claude.ai/code/session_0165V1Yq9Lr9XfmVqbbinMdE)_