### PR TITLE
fix(settings): stdio MCP config path, spec-load states, OAuth client ID persistence

### DIFF
--- a/src/app/api/backup/device/start/route.ts
+++ b/src/app/api/backup/device/start/route.ts
@@ -33,13 +33,14 @@ export async function POST(req: NextRequest) {
       { status: 400 },
     );
   }
-  // Remember a newly entered client ID for the next login.
-  if (parsed.data.clientId && parsed.data.clientId !== settings.oauthClientId) {
-    writeBackupSettings(db, { ...settings, oauthClientId: parsed.data.clientId });
-  }
-
   try {
     const flow = await new GitHubClient(null).startDeviceFlow(clientId);
+    // Remember a newly entered client ID for the next login — but only after
+    // GitHub accepted it. Persisting before the flow start stored typo'd /
+    // rejected IDs, which then pre-filled the connection form on every visit.
+    if (parsed.data.clientId && parsed.data.clientId !== settings.oauthClientId) {
+      writeBackupSettings(db, { ...settings, oauthClientId: parsed.data.clientId });
+    }
     const session = createDeviceSession({
       clientId,
       deviceCode: flow.deviceCode,

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -387,6 +387,17 @@ function StorageSection() {
     };
   }, []);
 
+  // Tracks whether the storage section is still mounted, so async ops launched
+  // from event handlers don't trigger setState-after-unmount warnings if the
+  // user navigates away mid-import / mid-export.
+  const sectionMountedRef = useRef(true);
+  useEffect(() => {
+    sectionMountedRef.current = true;
+    return () => {
+      sectionMountedRef.current = false;
+    };
+  }, []);
+
   const handleExport = async () => {
     setExporting(true);
     setImportResult(null);
@@ -402,22 +413,13 @@ function StorageSection() {
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
     } catch (err) {
-      setImportError(err instanceof Error ? err.message : 'Export failed');
+      if (sectionMountedRef.current) {
+        setImportError(err instanceof Error ? err.message : 'Export failed');
+      }
     } finally {
-      setExporting(false);
+      if (sectionMountedRef.current) setExporting(false);
     }
   };
-
-  // Tracks whether the storage section is still mounted, so async ops launched
-  // from event handlers don't trigger setState-after-unmount warnings if the
-  // user navigates away mid-import / mid-export.
-  const sectionMountedRef = useRef(true);
-  useEffect(() => {
-    sectionMountedRef.current = true;
-    return () => {
-      sectionMountedRef.current = false;
-    };
-  }, []);
 
   const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/src/components/api/ApiManager.tsx
+++ b/src/components/api/ApiManager.tsx
@@ -188,7 +188,8 @@ export default function ApiManager({ onBack, embedded }: Props) {
           baseUrl={baseUrl}
           openApiJson={openApiJson}
           mcpSpec={mcpSpec}
-          specLoadFailed={mcpSpecFailed}
+          openApiFailed={openApiFailed}
+          mcpSpecFailed={mcpSpecFailed}
         />
       )}
       {activeTab === 'rest' && (
@@ -199,7 +200,8 @@ export default function ApiManager({ onBack, embedded }: Props) {
           baseUrl={baseUrl}
           mcpSpec={mcpSpec}
           mcpTools={mcpTools ?? []}
-          specLoadFailed={mcpSpecFailed || mcpToolsFailed}
+          mcpSpecFailed={mcpSpecFailed}
+          mcpToolsFailed={mcpToolsFailed}
         />
       )}
     </div>

--- a/src/components/api/McpTab.tsx
+++ b/src/components/api/McpTab.tsx
@@ -2,17 +2,26 @@ import { buildMcpStreamableConfig, buildMcpStdioConfig } from './api-data';
 import { ServerIcon, WifiIcon, KeyIcon, CopyIcon, ChevronIcon, CheckIcon } from './icons';
 import { useCopyToast, useExpandableSpecs } from './useCopyToast';
 import CodeExample from './CodeExample';
+import SpecPreview from './SpecPreview';
 import Spinner from '../shared/Spinner';
 
 interface Props {
   baseUrl: string;
   mcpSpec: string;
   mcpTools: Array<{ name: string; description: string }>;
-  /** True when a spec/tool fetch failed — show an error instead of an endless spinner. */
-  specLoadFailed?: boolean;
+  /** True when the MCP spec fetch failed — show an error instead of an endless spinner. */
+  mcpSpecFailed?: boolean;
+  /** True when the tool-summary fetch failed — show an error instead of an endless spinner. */
+  mcpToolsFailed?: boolean;
 }
 
-export default function McpTab({ baseUrl, mcpSpec, mcpTools, specLoadFailed }: Props) {
+export default function McpTab({
+  baseUrl,
+  mcpSpec,
+  mcpTools,
+  mcpSpecFailed,
+  mcpToolsFailed,
+}: Props) {
   const { copyNotice, handleCopy } = useCopyToast();
   const { expandedSpecs, toggleSpecPreview } = useExpandableSpecs();
 
@@ -58,18 +67,9 @@ export default function McpTab({ baseUrl, mcpSpec, mcpTools, specLoadFailed }: P
             Copies complete MCP specification with tool definitions (JSON Schema), data types,
             token-efficient usage patterns, and purpose description.
           </span>
-          {expandedSpecs.has('mcp-tab') &&
-            (mcpSpec ? (
-              <pre className="api-code-block api-spec-preview">{mcpSpec}</pre>
-            ) : specLoadFailed ? (
-              <div className="api-loading" role="alert">
-                Failed to load the MCP spec — use Retry above.
-              </div>
-            ) : (
-              <div className="api-loading">
-                <Spinner /> Loading spec...
-              </div>
-            ))}
+          {expandedSpecs.has('mcp-tab') && (
+            <SpecPreview content={mcpSpec} failed={mcpSpecFailed} label="MCP spec" />
+          )}
         </div>
       </section>
 
@@ -165,7 +165,7 @@ export default function McpTab({ baseUrl, mcpSpec, mcpTools, specLoadFailed }: P
               </div>
             ))}
           </div>
-        ) : specLoadFailed ? (
+        ) : mcpToolsFailed ? (
           <div className="api-loading" role="alert">
             Failed to load the tool list — use Retry above.
           </div>

--- a/src/components/api/RestTab.tsx
+++ b/src/components/api/RestTab.tsx
@@ -1,4 +1,5 @@
 import Spinner from '../shared/Spinner';
+import SpecPreview from './SpecPreview';
 import SwaggerViewer from './SwaggerViewer';
 import CodeExample from './CodeExample';
 import { getRestConfigText } from './api-data';
@@ -36,6 +37,7 @@ export default function RestTab({ baseUrl, openApiJson, specLoadFailed }: Props)
               className="btn btn-primary api-copy-config-btn"
               onClick={() => handleCopy(getRestConfigText(baseUrl, openApiJson), 'REST API Spec')}
               title="Copy complete REST API reference with OpenAPI schema for AI agents"
+              disabled={!openApiJson}
             >
               <CopyIcon size={16} /> Copy REST API Spec for AI
             </button>
@@ -52,9 +54,11 @@ export default function RestTab({ baseUrl, openApiJson, specLoadFailed }: Props)
             OpenAPI 3.0 specification.
           </span>
           {expandedSpecs.has('rest-tab') && (
-            <pre className="api-code-block api-spec-preview">
-              {getRestConfigText(baseUrl, openApiJson)}
-            </pre>
+            <SpecPreview
+              content={openApiJson ? getRestConfigText(baseUrl, openApiJson) : ''}
+              failed={specLoadFailed}
+              label="OpenAPI schema"
+            />
           )}
         </div>
       </section>

--- a/src/components/api/SpecPreview.tsx
+++ b/src/components/api/SpecPreview.tsx
@@ -1,0 +1,34 @@
+import Spinner from '../shared/Spinner';
+
+interface Props {
+  /** The spec text to preview; empty while loading or after a failed fetch. */
+  content: string;
+  /** True when the fetch failed — show the error instead of an endless spinner. */
+  failed?: boolean;
+  /** Human name of the resource for the failure message (e.g. "OpenAPI schema"). */
+  label: string;
+}
+
+/**
+ * Expandable spec preview body shared by the REST/MCP tabs: renders the spec
+ * text when loaded, a Retry hint when its fetch failed (the Retry button
+ * lives in the ApiManager banner), and a spinner while still loading.
+ * Callers keep the expand/collapse gate (`expandedSpecs`) at the call site.
+ */
+export default function SpecPreview({ content, failed, label }: Props) {
+  if (content) {
+    return <pre className="api-code-block api-spec-preview">{content}</pre>;
+  }
+  if (failed) {
+    return (
+      <div className="api-loading" role="alert">
+        Failed to load the {label} — use Retry above.
+      </div>
+    );
+  }
+  return (
+    <div className="api-loading">
+      <Spinner /> Loading spec...
+    </div>
+  );
+}

--- a/src/components/api/TokensTab.tsx
+++ b/src/components/api/TokensTab.tsx
@@ -3,6 +3,7 @@ import type { TokenListItem, TokenScope, NewlyCreatedToken } from '../../types';
 import { api } from '../../api';
 import { formatDateTime } from '../../utils/format';
 import Spinner from '../shared/Spinner';
+import SpecPreview from './SpecPreview';
 import { SCOPE_LABELS, SCOPE_OPTIONS, getRestConfigText } from './api-data';
 import {
   BookIcon,
@@ -21,11 +22,19 @@ interface Props {
   baseUrl: string;
   openApiJson: string;
   mcpSpec: string;
-  /** True when a spec fetch failed — show an error instead of an endless spinner. */
-  specLoadFailed?: boolean;
+  /** True when the OpenAPI fetch failed — show an error instead of an endless spinner. */
+  openApiFailed?: boolean;
+  /** True when the MCP spec fetch failed — show an error instead of an endless spinner. */
+  mcpSpecFailed?: boolean;
 }
 
-export default function TokensTab({ baseUrl, openApiJson, mcpSpec, specLoadFailed }: Props) {
+export default function TokensTab({
+  baseUrl,
+  openApiJson,
+  mcpSpec,
+  openApiFailed,
+  mcpSpecFailed,
+}: Props) {
   const [tokens, setTokens] = useState<TokenListItem[]>([]);
   const [tokensLoading, setTokensLoading] = useState(true);
   const [tokensError, setTokensError] = useState<string | null>(null);
@@ -151,6 +160,7 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec, specLoadFaile
                 className="btn btn-primary api-copy-config-btn"
                 onClick={() => handleCopy(getRestConfigText(baseUrl, openApiJson), 'REST API Spec')}
                 title="Copy complete REST API reference with all endpoints, OpenAPI schema, and purpose description"
+                disabled={!openApiJson}
               >
                 <CopyIcon size={14} /> Copy REST API Spec
               </button>
@@ -163,9 +173,11 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec, specLoadFaile
               </button>
             </div>
             {expandedSpecs.has('rest-quick') && (
-              <pre className="api-code-block api-spec-preview">
-                {getRestConfigText(baseUrl, openApiJson)}
-              </pre>
+              <SpecPreview
+                content={openApiJson ? getRestConfigText(baseUrl, openApiJson) : ''}
+                failed={openApiFailed}
+                label="OpenAPI schema"
+              />
             )}
           </div>
           <div className="api-spec-copy-group">
@@ -186,18 +198,9 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec, specLoadFaile
                 <ChevronIcon expanded={expandedSpecs.has('mcp-quick')} /> Preview
               </button>
             </div>
-            {expandedSpecs.has('mcp-quick') &&
-              (mcpSpec ? (
-                <pre className="api-code-block api-spec-preview">{mcpSpec}</pre>
-              ) : specLoadFailed ? (
-                <div className="api-loading" role="alert">
-                  Failed to load the MCP spec — use Retry above.
-                </div>
-              ) : (
-                <div className="api-loading">
-                  <Spinner /> Loading spec...
-                </div>
-              ))}
+            {expandedSpecs.has('mcp-quick') && (
+              <SpecPreview content={mcpSpec} failed={mcpSpecFailed} label="MCP spec" />
+            )}
           </div>
         </div>
       </section>
@@ -345,7 +348,7 @@ export default function TokensTab({ baseUrl, openApiJson, mcpSpec, specLoadFaile
                       onClick={() =>
                         handleCopy(
                           newlyCreated?.id === token.id ? newlyCreated.token : token.tokenPrefix,
-                          token.label,
+                          token.label || 'Unnamed Token',
                         )
                       }
                       title={newlyCreated?.id === token.id ? 'Copy full token' : 'Copy prefix'}

--- a/src/components/api/__tests__/api-data.test.ts
+++ b/src/components/api/__tests__/api-data.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  buildMcpStdioConfig,
+  buildMcpStreamableConfig,
+  MCP_STDIO_ENTRY,
+  MCP_STDIO_CWD_PLACEHOLDER,
+  getRestConfigText,
+} from '../api-data';
+
+describe('buildMcpStdioConfig', () => {
+  // Regression: the copied snippet once pointed at `server/mcp.ts` (the file
+  // lives under `src/server/mcp.ts`), so every copy-pasted client config
+  // failed with "Cannot find module".
+  it('points at a stdio entry file that actually exists in the repo', () => {
+    expect(existsSync(resolve(process.cwd(), MCP_STDIO_ENTRY))).toBe(true);
+  });
+
+  it('stays in sync with the package.json `mcp` script', () => {
+    const pkg = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf8')) as {
+      scripts: Record<string, string>;
+    };
+    expect(pkg.scripts.mcp).toContain(MCP_STDIO_ENTRY);
+  });
+
+  it('uses the placeholder cwd the UI tells users to replace', () => {
+    const config = buildMcpStdioConfig();
+    expect(config.mcpServers.clawstash.args).toEqual(['tsx', MCP_STDIO_ENTRY]);
+    expect(config.mcpServers.clawstash.cwd).toBe(MCP_STDIO_CWD_PLACEHOLDER);
+  });
+});
+
+describe('buildMcpStreamableConfig', () => {
+  it('targets the /mcp endpoint of the given base URL', () => {
+    const config = buildMcpStreamableConfig('https://stash.example');
+    expect(config.mcpServers.clawstash.url).toBe('https://stash.example/mcp');
+  });
+});
+
+describe('getRestConfigText', () => {
+  it('derives the endpoint summary from the OpenAPI JSON', () => {
+    const spec = JSON.stringify({
+      paths: { '/api/stashes': { get: { summary: 'List stashes', tags: ['Stashes'] } } },
+    });
+    const text = getRestConfigText('https://stash.example', spec);
+    expect(text).toContain('## Endpoints');
+    expect(text).toContain('GET    https://stash.example/api/stashes');
+    expect(text).toContain('## OpenAPI 3.0 Specification');
+  });
+
+  it('omits endpoint and schema sections when no OpenAPI JSON is available', () => {
+    const text = getRestConfigText('https://stash.example');
+    expect(text).toContain('## Base URL');
+    expect(text).not.toContain('## Endpoints');
+    expect(text).not.toContain('## OpenAPI 3.0 Specification');
+  });
+});

--- a/src/components/api/api-data.ts
+++ b/src/components/api/api-data.ts
@@ -42,12 +42,19 @@ export function buildMcpStreamableConfig(baseUrl: string) {
  */
 export const MCP_STDIO_CWD_PLACEHOLDER = '<ABSOLUTE_PATH_TO_CLAWSTASH_REPO>';
 
+/**
+ * Entry point of the stdio MCP server, relative to the repo root. Must match
+ * the `mcp` script in package.json (`tsx src/server/mcp.ts`) — a drifted path
+ * here ships a copy-paste config that fails with "Cannot find module".
+ */
+export const MCP_STDIO_ENTRY = 'src/server/mcp.ts';
+
 export function buildMcpStdioConfig() {
   return {
     mcpServers: {
       clawstash: {
         command: 'npx',
-        args: ['tsx', 'server/mcp.ts'],
+        args: ['tsx', MCP_STDIO_ENTRY],
         cwd: MCP_STDIO_CWD_PLACEHOLDER,
       },
     },

--- a/src/components/settings/BackupConnectCard.tsx
+++ b/src/components/settings/BackupConnectCard.tsx
@@ -63,8 +63,16 @@ export default function BackupConnectCard({ response, onUpdated }: Props) {
   // single misclick is inconsistent with the app's other destructive actions.
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
   const [codeCopied, setCodeCopied] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const copyResetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cancelledRef = useRef(false);
+
+  // Clear the copy-feedback timer on unmount so it cannot fire afterwards.
+  useEffect(() => {
+    return () => {
+      if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
+    };
+  }, []);
 
   // Auto-disarm the disconnect confirm (mirrors the token-delete confirm).
   useEffect(() => {
@@ -76,7 +84,10 @@ export default function BackupConnectCard({ response, onUpdated }: Props) {
   const handleCopyCode = async (code: string) => {
     const ok = await copyToClipboard(code);
     setCodeCopied(ok ? 'copied' : 'failed');
-    setTimeout(() => setCodeCopied('idle'), COPY_TOAST_DURATION_MS);
+    // Track the reset timer so a repeated copy re-arms the full display
+    // window instead of the first timer cutting the second notice short.
+    if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
+    copyResetTimer.current = setTimeout(() => setCodeCopied('idle'), COPY_TOAST_DURATION_MS);
   };
 
   const stopPolling = () => {


### PR DESCRIPTION
## Summary

Bug/smell sweep of the settings area (frontend + backend): fixes a broken copy-paste stdio MCP client config, missing loading/failure states and premature copy buttons in the API docs tabs, an imprecise failure flag in the MCP tab, a copy-toast/timer glitch, a missing unmount guard, and the backend persisting unvalidated OAuth client IDs.

## Changes

- **`api-data.ts`**: the copyable stdio MCP client config pointed at `server/mcp.ts`; the entry point lives at `src/server/mcp.ts` (matching the `npm run mcp` script), so every copied config failed with "Cannot find module". Extracted `MCP_STDIO_ENTRY` + added a regression test asserting the file exists and stays in sync with `package.json`.
- **`TokensTab`/`RestTab`**: "Copy REST API Spec" was clickable before the OpenAPI schema loaded (or after its fetch failed), silently copying a spec without endpoints/schema — now disabled until loaded, matching the MCP-side buttons.
- **`SpecPreview` (new)**: shared preview body (spec text | failure + Retry hint | spinner) replacing four hand-rolled variants; the REST previews previously rendered partial text with no loading/failure state at all.
- **`McpTab`**: spec preview and tool list shared a single `specLoadFailed` flag, so a failed tool fetch mislabeled the still-loading spec as failed (and vice versa) — flags are now separate (`mcpSpecFailed` / `mcpToolsFailed`).
- **`TokensTab`**: copy toast showed `"" copied` for unnamed tokens — falls back to "Unnamed Token" like the aria-labels.
- **`BackupConnectCard`**: device-code copy feedback timer was untracked — a repeated copy was cut short by the first timer, and the timeout could fire after unmount. Now ref-tracked and cleaned up.
- **`Settings.tsx` (StorageSection)**: `handleExport` now uses the same `sectionMountedRef` guards as `handleImport` (no setState after unmount).
- **`api/backup/device/start`**: a newly entered OAuth client ID was persisted *before* GitHub validated it, so a typo'd ID was stored and pre-filled the connection form on every visit — it is now saved only after `startDeviceFlow` succeeds.

## Testing

- `npm run format:check`, `npx tsc --noEmit`, `npm test` (30 files, 293 passed / 5 skipped, incl. new `api-data.test.ts`), `npm run build` — all green.
- New regression tests: stdio entry file exists on disk and matches the `package.json` `mcp` script; streamable config targets `/mcp`; `getRestConfigText` with and without OpenAPI JSON.

## Checklist

- [x] Formatting passes (`npm run format:check`)
- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Changes are documented (docs already reference the correct `src/server/mcp.ts` path; no doc updates needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHeahyWNH8i6jLQ52kH5Ks

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHeahyWNH8i6jLQ52kH5Ks)_