### PR TITLE
chore: quality & housekeeping sweep (Next.js/TS + MCP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ Rules:
 
 ## Deployment
 
-- **Trigger:** push/tag on `main` -> GitHub Actions workflow `docker-publish.yml`
+- **Trigger:** manual `workflow_dispatch` on GitHub Actions workflow `docker-publish.yml`
 - **Pipeline:** type-check -> build -> Docker build (multi-stage, standalone output) -> push image to GHCR
 - **Environments:** single image deployed to any container host; database persisted via volume mounted at `/app/data`
 - **Agent scope:** Agent can push to feature branches, open/update PRs, suggest merge. **Agent does NOT trigger production deploys** without explicit user command.

--- a/agent_docs/project-structure.md
+++ b/agent_docs/project-structure.md
@@ -31,7 +31,7 @@ clawstash/
 │       ├── 0001-record-architecture-decisions.md
 │       └── 0002-github-backup-architecture.md
 ├── .claude/
-│   └── skills/
+│   └── skills/                 # Agent workflow skills: done, pr, review, security-review, rollback, ci, stuck, verify
 │       └── gitnexus/           # GitNexus code intelligence skills (explore, debug, refactor, review, impact, query)
 ├── .github/
 │   └── workflows/
@@ -101,9 +101,11 @@ clawstash/
 │   │   ├── db-schema.ts        # SQLite table / index definitions
 │   │   ├── db-migrations.ts    # Schema migrations runner
 │   │   ├── db-types.ts         # Shared DB row / domain types
+│   │   ├── db-access-check.ts  # Fail-fast guard: actionable error when the SQLite path is not writable
 │   │   ├── singleton.ts        # DB singleton with globalThis for HMR protection
 │   │   ├── auth.ts             # Auth utility (token extraction, validation, scope checking)
 │   │   ├── auth-rate-limit.ts  # In-memory per-IP rate limiter (login, token-validate, session)
+│   │   ├── log-sanitize.ts     # Strip control/bidi chars from request-derived values (IP, UA) before logging
 │   │   ├── detect-language.ts  # Filename → language tag (server persistence)
 │   │   ├── shared-text.ts      # Shared text constants (PURPOSE, TOKEN_EFFICIENT_GUIDE)
 │   │   ├── tool-defs.ts        # MCP tool definitions (Zod schemas + descriptions)
@@ -138,14 +140,20 @@ clawstash/
 │   │   ├── useClipboard.ts     # useClipboard + useClipboardWithKey hooks
 │   │   └── useClickOutside.ts  # Click-outside detection hook (used by Sidebar, TagCombobox, MetadataEditor)
 │   ├── utils/
+│   │   ├── archived.ts         # localStorage persistence for the "show archived" dashboard toggle
 │   │   ├── clipboard.ts        # Copy-to-clipboard with fallback for non-HTTPS
 │   │   ├── constants.ts        # Shared client/server constants
 │   │   ├── favorites.ts        # Favorite-stash localStorage helpers
 │   │   ├── format.ts           # Date formatting (formatDate, formatDateTime, formatRelativeTime)
+│   │   ├── highlight.ts        # Split text into matched/unmatched segments to <mark> search terms
 │   │   ├── html.ts             # HTML sanitization helpers
 │   │   ├── markdown.ts         # Markdown rendering for descriptions (Marked + sanitization)
 │   │   ├── mermaid.ts          # Lazy-loaded Mermaid renderer (shared util for .mmd files + inline ```mermaid blocks)
-│   │   └── __tests__/          # Util unit tests (vitest: favorites, format, html)
+│   │   ├── mermaid-hydrate.ts  # Hydrate inline ```mermaid placeholders inside rendered Markdown HTML
+│   │   ├── recent-views.ts     # Recently-viewed stashes MRU list (localStorage) for the search overlay
+│   │   ├── sort.ts             # Dashboard sort-order state + pure sort helper
+│   │   ├── stash-url.ts        # Build a shareable deep-link URL for a stash
+│   │   └── __tests__/          # Util unit tests (vitest)
 │   ├── components/
 │   │   ├── Sidebar.tsx         # Left sidebar with search, tag filter, stash list, settings nav
 │   │   ├── Footer.tsx          # App footer with version (fetched from /api/version), build info toggle

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -136,12 +136,12 @@ cp .env.example .env
 
 ## CI/CD (GitHub Actions)
 
-The repository includes `.github/workflows/docker-publish.yml` which automatically:
+The repository includes `.github/workflows/docker-publish.yml` which, when triggered:
 
 1. **Check code** — TypeScript type-check, optional lint/tests, Next.js build
 2. **Build & push** — Multi-stage Docker image pushed to GitHub Container Registry (GHCR)
 
-Triggers on push to `main`/`master` and manual dispatch.
+Triggered manually via `workflow_dispatch` (GitHub → **Actions** tab); there is no automatic push trigger.
 
 ## Architecture Notes
 


### PR DESCRIPTION
Automated quality & housekeeping sweep. Corrected the CI-trigger documentation (`docker-publish.yml` is `workflow_dispatch`-only) and re-synced `agent_docs/project-structure.md` with the current tree. Docs-only, no dependency changes.

## Merged findings
| # | Pass | Datei(en) | Fix | Aufwand | Empfehlung |
|---|------|-----------|-----|---------|------------|
| 1 | E Docs | docs/deployment.md, CLAUDE.md | Trigger-Doku auf `workflow_dispatch` (manuell) korrigiert | M | auto-fix |
| 2 | E Docs | agent_docs/project-structure.md | Fehlende Module/Utils + aktualisiertes `.claude/skills/`-Listing ergänzt | S | auto-fix |

## Tooling-Status
| Tool | Aktiv | Grün |
|------|-------|------|
| Formatter (Prettier) | ja | ja |
| Linter (ESLint) | nein (bewusst) | na |
| Tests (vitest) | ja | ja |

Verifikation: `npm ci && npx prettier --check . && npx tsc --noEmit && npm run test:run` grün. Production-`build` übersprungen (docs/markdown-only, kein Source berührt).

**Keine Version-Bumps enthalten.**

Closes #401

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCTB3AZtkTi9EcibXdJj5w)_