### PR TITLE
feat: comfort sweep (Next.js 16 + React 19)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -755,6 +755,20 @@ export default function App() {
     pushUrl('/');
   };
 
+  /**
+   * Tag clicked inside the stash viewer: apply the filter and go back to the
+   * dashboard to show the result. Unlike `handleFilterTag` this never toggles
+   * the tag OFF — the viewer shows no active-filter chip, so re-clicking the
+   * already-active tag would look like the click did nothing while silently
+   * clearing the dashboard filter.
+   */
+  const handleViewerFilterTag = (tag: string) => {
+    if (tag !== filterTagRef.current) handleFilterTag(tag);
+    setSelectedStash(null);
+    setView('home');
+    pushUrl('/');
+  };
+
   const handleGraphView = () => {
     if (!confirmDiscardUnsaved()) return;
     setSelectedStash(null);
@@ -921,6 +935,7 @@ export default function App() {
               onArchive={handleArchiveStash}
               onBack={handleGoHome}
               onAnalyzeStash={handleAnalyzeStash}
+              onFilterTag={handleViewerFilterTag}
               onStashUpdated={(stash) => {
                 setSelectedStash(stash);
                 loadStashes();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import { loadFavoriteIds, saveFavoriteIds, toggleFavorite } from './utils/favori
 import { loadSortMode, saveSortMode } from './utils/sort';
 import { loadShowArchived, saveShowArchived } from './utils/archived';
 import { recordRecentView } from './utils/recent-views';
-import { SEARCH_DEBOUNCE_MS } from './utils/constants';
+import { SEARCH_DEBOUNCE_MS, STASH_PAGE_SIZE } from './utils/constants';
 import Sidebar from './components/Sidebar';
 import Dashboard from './components/Dashboard';
 import StashViewer from './components/StashViewer';
@@ -121,6 +121,10 @@ export default function App() {
   const [filterTag, setFilterTag] = useState('');
   const [tags, setTags] = useState<TagInfo[]>([]);
   const [recentTags, setRecentTags] = useState<string[]>(getStoredRecentTags);
+  // How many pages' worth of stashes the dashboard currently requests. Bumped
+  // by "Load more", reset to 1 whenever the search / tag / archived filter
+  // changes (the result set is a different one, so the old depth is meaningless).
+  const [loadedPages, setLoadedPages] = useState(1);
   const [loading, setLoading] = useState(true);
   // True after a failed stash list load — lets the dashboard replace the
   // misleading "No stashes yet" empty state with an error state + retry.
@@ -275,6 +279,8 @@ export default function App() {
         // Toggle the "show archived" dashboard filter and persist it (mirrors
         // the click handler). Functional setState keeps the effect dependency-free.
         e.preventDefault();
+        // Mirrors handleToggleShowArchived, including the "Load more" reset.
+        setLoadedPages(1);
         setShowArchived((prev) => {
           const next = !prev;
           saveShowArchived(next);
@@ -530,6 +536,10 @@ export default function App() {
         tag: filterTag || undefined,
         // undefined = show all (active + archived), false = show only active (hide archived)
         archived: showArchived ? undefined : false,
+        // Always send an explicit limit: the server defaults differ between
+        // browse (50) and search (20), which would make "Load more" grow the
+        // list in different steps depending on whether a query is active.
+        limit: STASH_PAGE_SIZE * loadedPages,
       });
       if (gen !== loadStashesGenRef.current) return;
       setStashes(result.stashes);
@@ -545,7 +555,7 @@ export default function App() {
     } finally {
       if (gen === loadStashesGenRef.current) setLoading(false);
     }
-  }, [search, filterTag, showArchived, showError]);
+  }, [search, filterTag, showArchived, loadedPages, showError]);
 
   // Search term used by the previous load — lets the effect below debounce
   // ONLY typed-search changes, not every reload trigger.
@@ -737,9 +747,20 @@ export default function App() {
     filterTagRef.current = filterTag;
   }, [filterTag]);
 
+  /**
+   * Change the stash search term. Resets the "Load more" depth because the
+   * result set is a different one — keeping the old depth would silently
+   * request e.g. 150 rows for a fresh single-keystroke query.
+   */
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    setLoadedPages(1);
+  };
+
   const handleFilterTag = (tag: string) => {
     const newTag = tag === filterTagRef.current ? '' : tag;
     setFilterTag(newTag);
+    setLoadedPages(1);
     if (newTag) {
       setRecentTags((prev) => {
         const updated = [newTag, ...prev.filter((t) => t !== newTag)].slice(0, 3);
@@ -807,11 +828,17 @@ export default function App() {
   // Toggle the "show archived" filter and persist it so the choice survives a
   // reload (mirrors the layout/sort preference handlers above).
   const handleToggleShowArchived = () => {
+    setLoadedPages(1);
     setShowArchived((prev) => {
       const next = !prev;
       saveShowArchived(next);
       return next;
     });
+  };
+
+  /** Widen the dashboard list by one more page (see STASH_PAGE_SIZE). */
+  const handleLoadMore = () => {
+    setLoadedPages((prev) => prev + 1);
   };
 
   // Show login screen if auth is required and user is not authenticated
@@ -832,7 +859,7 @@ export default function App() {
         total={total}
         selectedId={selectedStash?.id || null}
         search={search}
-        onSearch={setSearch}
+        onSearch={handleSearchChange}
         filterTag={filterTag}
         onFilterTag={handleFilterTag}
         tags={tags}
@@ -914,7 +941,9 @@ export default function App() {
               loadError={loadError}
               onRetryLoad={loadStashes}
               search={search}
-              onClearSearch={() => setSearch('')}
+              onClearSearch={() => handleSearchChange('')}
+              hasMore={stashes.length < total}
+              onLoadMore={handleLoadMore}
               filterTag={filterTag}
               showArchived={showArchived}
               favoriteIds={favoriteIds}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -20,6 +20,10 @@ interface Props {
    * must show it (filter chip + honest empty state). */
   search: string;
   onClearSearch: () => void;
+  /** True when the server reported more matches than are currently rendered. */
+  hasMore: boolean;
+  /** Widen the list by one more page. */
+  onLoadMore: () => void;
   filterTag: string;
   showArchived: boolean;
   favoriteIds: ReadonlySet<string>;
@@ -42,6 +46,8 @@ export default function Dashboard({
   onRetryLoad,
   search,
   onClearSearch,
+  hasMore,
+  onLoadMore,
   filterTag,
   showArchived,
   favoriteIds,
@@ -74,7 +80,7 @@ export default function Dashboard({
           {stashes.length < total && (
             <span
               className="stash-count"
-              title={`The list is capped — ${stashes.length} of ${total} stashes are shown. Use search or tag filters to narrow down.`}
+              title={`${stashes.length} of ${total} stashes are shown. Use "Load more" at the bottom, or narrow down with search / tag filters.`}
             >
               showing {stashes.length}
             </span>
@@ -257,54 +263,78 @@ export default function Dashboard({
           </button>
         </div>
       ) : (
-        // While `loading` is true but we still have a previous result set we
-        // keep the grid visible and overlay a subtle spinner. This avoids the
-        // "flash to empty" jank every time the user toggles a tag filter or
-        // types in the sidebar search field.
-        <div
-          className={`stash-grid ${layout}${loading ? ' stash-grid-refreshing' : ''}`}
-          aria-busy={loading || undefined}
-        >
-          {/*
+        <>
+          {/* While `loading` is true but we still have a previous result set we
+            keep the grid visible and overlay a subtle spinner. This avoids the
+            "flash to empty" jank every time the user toggles a tag filter or
+            types in the sidebar search field. */}
+          <div
+            className={`stash-grid ${layout}${loading ? ' stash-grid-refreshing' : ''}`}
+            aria-busy={loading || undefined}
+          >
+            {/*
             Keyboard-accessible "new stash" card. Was a bare <div onClick>
             previously, so keyboard-only users (and most assistive tech)
             could not invoke it. role+tabIndex+Enter/Space handler bring it
             in line with the StashCard buttons next to it without changing
             the existing pointer-click behavior.
           */}
-          <div
-            className="new-stash-card"
-            onClick={onNewStash}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                onNewStash();
-              }
-            }}
-            role="button"
-            tabIndex={0}
-            aria-label="Create a new stash"
-            title="Create a new stash"
-          >
-            <div className="new-stash-icon">
-              <svg width="36" height="36" viewBox="0 0 16 16" fill="currentColor">
-                <path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2Z" />
-              </svg>
+            <div
+              className="new-stash-card"
+              onClick={onNewStash}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onNewStash();
+                }
+              }}
+              role="button"
+              tabIndex={0}
+              aria-label="Create a new stash"
+              title="Create a new stash"
+            >
+              <div className="new-stash-icon">
+                <svg width="36" height="36" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2Z" />
+                </svg>
+              </div>
+              <div className="new-stash-text">New Stash</div>
             </div>
-            <div className="new-stash-text">New Stash</div>
+            {orderedStashes.map((stash) => (
+              <StashCard
+                key={stash.id}
+                stash={stash}
+                layout={layout}
+                isFavorite={favoriteIds.has(stash.id)}
+                onClick={() => onSelectStash(stash.id)}
+                onFilterTag={onFilterTag}
+                onToggleFavorite={onToggleFavorite}
+              />
+            ))}
           </div>
-          {orderedStashes.map((stash) => (
-            <StashCard
-              key={stash.id}
-              stash={stash}
-              layout={layout}
-              isFavorite={favoriteIds.has(stash.id)}
-              onClick={() => onSelectStash(stash.id)}
-              onFilterTag={onFilterTag}
-              onToggleFavorite={onToggleFavorite}
-            />
-          ))}
-        </div>
+          {/* The server caps every list response, so without this the stashes
+            beyond the cap were unreachable from the dashboard entirely — the
+            header admitted "showing 50" and offered no way to see the rest. */}
+          {hasMore && (
+            <div className="dashboard-load-more">
+              <button
+                className="btn btn-secondary"
+                onClick={onLoadMore}
+                disabled={loading}
+                title={`Show more of the ${total} matching stashes`}
+              >
+                {loading ? (
+                  <>
+                    <Spinner size={14} />
+                    Loading...
+                  </>
+                ) : (
+                  `Load more (${stashes.length} of ${total})`
+                )}
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -31,6 +31,13 @@ interface Props {
   onArchive: (id: string, archived: boolean) => void;
   onBack: () => void;
   onAnalyzeStash: (id: string) => void;
+  /**
+   * Apply a tag filter and return to the dashboard. The tag chips below the
+   * header carry `.stash-tag`, which is styled with `cursor: pointer` and a
+   * hover state (shared with the clickable chips on `StashCard`) — without a
+   * handler they looked interactive but did nothing.
+   */
+  onFilterTag: (tag: string) => void;
   onStashUpdated?: (stash: Stash) => void;
   // Fired specifically when a previous version is restored from the history
   // tab, so the shell can surface a success toast. Restoring previously gave
@@ -416,6 +423,7 @@ export default function StashViewer({
   onArchive,
   onBack,
   onAnalyzeStash,
+  onFilterTag,
   onStashUpdated,
   onVersionRestored,
 }: Props) {
@@ -879,8 +887,24 @@ export default function StashViewer({
 
       {(stash.tags.length > 0 || Object.keys(stash.metadata).length > 0) && (
         <div className="viewer-meta-bar">
+          {/* Same interaction contract as the tag chips on StashCard: click (or
+              Enter/Space) filters the dashboard by the tag. */}
           {stash.tags.map((tag) => (
-            <span key={tag} className="stash-tag" title={`Tag: ${tag}`}>
+            <span
+              key={tag}
+              className="stash-tag"
+              onClick={() => onFilterTag(tag)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onFilterTag(tag);
+                }
+              }}
+              role="button"
+              tabIndex={0}
+              aria-label={`Filter by tag: ${tag}`}
+              title={`Filter by tag: ${tag}`}
+            >
               {tag}
             </span>
           ))}

--- a/src/components/editor/FileCodeEditor.tsx
+++ b/src/components/editor/FileCodeEditor.tsx
@@ -7,6 +7,13 @@ interface Props {
   file: FileInput;
   index: number;
   updateFile: (index: number, field: keyof FileInput, value: string) => void;
+  /**
+   * Soft-wrap long lines instead of scrolling horizontally. Mirrors the raw
+   * code view's wrap toggle in `StashViewer`; applied via a class because
+   * react-simple-code-editor sets `white-space` through inline styles that
+   * only a class-scoped `!important` rule can override.
+   */
+  wrap?: boolean;
 }
 
 /**
@@ -17,7 +24,7 @@ interface Props {
  */
 const SYNTAX_HIGHLIGHT_MAX_CHARS = 100_000;
 
-export default function FileCodeEditor({ file, index, updateFile }: Props) {
+export default function FileCodeEditor({ file, index, updateFile, wrap = false }: Props) {
   const highlight = useMemo(
     () => (code: string) => highlightCode(code, resolvePrismLanguage(file.language, file.filename)),
     [file.language, file.filename],
@@ -40,7 +47,9 @@ export default function FileCodeEditor({ file, index, updateFile }: Props) {
         value={file.content}
         onChange={(e) => handleChange(e.target.value)}
         placeholder="File content..."
-        className="code-editor code-editor-textarea code-editor-plain"
+        className={`code-editor code-editor-textarea code-editor-plain${
+          wrap ? ' code-editor-wrap' : ''
+        }`}
         spellCheck={false}
         aria-label="File content (plain editor — syntax highlighting disabled for large file)"
       />
@@ -58,7 +67,7 @@ export default function FileCodeEditor({ file, index, updateFile }: Props) {
         highlight={highlight}
         padding={16}
         placeholder="File content..."
-        className="code-editor"
+        className={`code-editor${wrap ? ' code-editor-wrap' : ''}`}
         textareaClassName="code-editor-textarea"
         textareaId={textareaId}
       />

--- a/src/components/editor/StashEditor.tsx
+++ b/src/components/editor/StashEditor.tsx
@@ -20,6 +20,31 @@ interface Props {
   onDirtyChange?: (dirty: boolean) => void;
 }
 
+/**
+ * Soft-wrap preference for the file editors. Kept separate from the viewer's
+ * `clawstash-wrap-lines` key: reading a stash and editing it are different
+ * contexts, and silently flipping one because the other was toggled would be
+ * surprising.
+ */
+const EDITOR_WRAP_PREF_KEY = 'clawstash-editor-wrap-lines';
+
+/** Read the persisted editor wrap preference. Defaults to off (horizontal scroll). */
+function getEditorWrapPreference(): boolean {
+  try {
+    return localStorage.getItem(EDITOR_WRAP_PREF_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function setEditorWrapPreference(enabled: boolean): void {
+  try {
+    localStorage.setItem(EDITOR_WRAP_PREF_KEY, String(enabled));
+  } catch {
+    /* Storage disabled / full — the preference stays in memory for this session. */
+  }
+}
+
 function InfoIcon({ tooltip }: { tooltip: string }) {
   return (
     <span className="info-icon" title={tooltip}>
@@ -49,6 +74,9 @@ export default function StashEditor({ stash, onSave, onCancel, onDirtyChange }: 
   // or null. Removing a file destroys its typed content, so it gets the
   // same two-step confirm as every other destructive action in the app.
   const [confirmRemoveIndex, setConfirmRemoveIndex] = useState<number | null>(null);
+  // Soft-wrap long lines in the file editors (persisted, applies to all files
+  // of the stash — same scope as the viewer's wrap toggle).
+  const [wrapLines, setWrapLines] = useState<boolean>(getEditorWrapPreference);
   const [availableTags, setAvailableTags] = useState<TagInfo[]>([]);
   const [availableMetaKeys, setAvailableMetaKeys] = useState<string[]>([]);
   const [firstFileManuallyEdited, setFirstFileManuallyEdited] = useState(!!stash);
@@ -146,6 +174,15 @@ export default function StashEditor({ stash, onSave, onCancel, onDirtyChange }: 
     },
     [firstFileManuallyEdited],
   );
+
+  /** Toggle soft-wrapping in the file editors and persist the choice. */
+  const toggleWrapLines = () => {
+    setWrapLines((prev) => {
+      const next = !prev;
+      setEditorWrapPreference(next);
+      return next;
+    });
+  };
 
   const addFile = () => {
     markDirty();
@@ -457,16 +494,40 @@ export default function StashEditor({ stash, onSave, onCancel, onDirtyChange }: 
               Files
               <InfoIcon tooltip="Each stash can contain one or more files. Files are the actual content you want to store — code snippets, configs, prompts, or any text. The language is auto-detected from the file extension." />
             </h3>
-            <button
-              className="btn btn-sm btn-secondary"
-              onClick={addFile}
-              title="Add another file to this stash"
-            >
-              <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-                <path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2Z" />
-              </svg>
-              Add File
-            </button>
+            <div className="files-header-actions">
+              <button
+                className={`btn btn-sm btn-ghost wrap-toggle ${wrapLines ? 'wrap-active' : ''}`}
+                onClick={toggleWrapLines}
+                aria-pressed={wrapLines}
+                title={
+                  wrapLines
+                    ? 'Stop wrapping — scroll long lines horizontally'
+                    : 'Wrap long lines to fit the editor width'
+                }
+                aria-label={wrapLines ? 'Stop wrapping long lines' : 'Wrap long lines'}
+              >
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path d="M1.75 3.5a.75.75 0 0 1 0-1.5h12.5a.75.75 0 0 1 0 1.5H1.75Zm0 5a.75.75 0 0 1 0-1.5h9.5a2.75 2.75 0 0 1 0 5.5H8.56l.72.72a.75.75 0 1 1-1.06 1.06l-2-2a.75.75 0 0 1 0-1.06l2-2a.75.75 0 0 1 1.06 1.06l-.72.72h2.69a1.25 1.25 0 0 0 0-2.5h-9.5Zm0 5a.75.75 0 0 1 0-1.5h3.5a.75.75 0 0 1 0 1.5h-3.5Z" />
+                </svg>
+                Wrap
+              </button>
+              <button
+                className="btn btn-sm btn-secondary"
+                onClick={addFile}
+                title="Add another file to this stash"
+              >
+                <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2Z" />
+                </svg>
+                Add File
+              </button>
+            </div>
           </div>
 
           {files.map((file, index) => (
@@ -515,7 +576,12 @@ export default function StashEditor({ stash, onSave, onCancel, onDirtyChange }: 
                   ))}
               </div>
               <div className="code-editor-wrapper">
-                <FileCodeEditor file={file} index={index} updateFile={updateFile} />
+                <FileCodeEditor
+                  file={file}
+                  index={index}
+                  updateFile={updateFile}
+                  wrap={wrapLines}
+                />
               </div>
             </div>
           ))}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1348,6 +1348,17 @@ body {
 
 /* Soft dim while a refresh is in-flight so the stale rows hint that newer
    data is on the way without yanking the grid out from under the cursor. */
+/* "Load more" row under the dashboard grid. */
+.dashboard-load-more {
+  display: flex;
+  justify-content: center;
+  padding: 24px 0 8px;
+}
+
+.dashboard-load-more .btn {
+  gap: 8px;
+}
+
 .stash-grid-refreshing {
   opacity: 0.6;
   transition: opacity 0.15s ease-out;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2579,6 +2579,14 @@ body {
   font-weight: 600;
 }
 
+/* Groups the Wrap + Add File buttons so `.files-header`'s space-between keeps
+   the heading left and both actions together on the right. */
+.files-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .editor-file {
   margin-bottom: 16px;
   border: 1px solid var(--border-color);
@@ -2655,6 +2663,18 @@ body {
   white-space: pre !important;
   word-wrap: normal !important;
   overflow-wrap: normal !important;
+}
+
+/* Wrap mode: opt back into soft wrapping. The textarea and the highlighted
+   <pre> are overlaid on top of each other, so BOTH must wrap identically or
+   the caret drifts away from the rendered glyphs. Overrides the `pre` rule
+   above (and the plain-textarea fallback's own `white-space`). */
+.code-editor.code-editor-wrap textarea,
+.code-editor.code-editor-wrap pre,
+textarea.code-editor-plain.code-editor-wrap {
+  white-space: pre-wrap !important;
+  word-wrap: break-word !important;
+  overflow-wrap: break-word !important;
 }
 
 /* PrismJS dark theme tokens (matches ClawStash dark palette) */

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -18,3 +18,15 @@ export const COPY_TOAST_DURATION_MS = 2000;
  * flows that ask the user to click twice within this window to commit.
  */
 export const DELETE_CONFIRM_TIMEOUT_MS = 3000;
+
+/**
+ * How many stashes the dashboard requests per "page". "Load more" raises the
+ * requested limit by one more page instead of appending a fetched page, so the
+ * list stays a single server-ranked result set — appending pages would let a
+ * concurrent create/delete shift rows across the page boundary and produce
+ * duplicated or skipped cards.
+ *
+ * Matches the server-side default list limit (`clampPagination(…, 50)` in
+ * `server/stores/_parsers.ts`), so the first page is unchanged from before.
+ */
+export const STASH_PAGE_SIZE = 50;


### PR DESCRIPTION
## Summary

Three end-user comfort features for the web GUI. Each closes a gap where the UI either promised an interaction it did not deliver, lacked parity with an equivalent control elsewhere in the app, or made content outright unreachable. Client-side only — no API, MCP, DB-schema or auth changes, and no new dependencies.

## Changes

| # | Feature | Nutzen für User | Aufwand | Empfehlung |
|---|---------|-----------------|---------|------------|
| 1 | **Tag chips in the stash viewer now filter the dashboard** (`StashViewer.tsx`, `App.tsx`) | The chips carry `.stash-tag`, styled with `cursor: pointer` + a hover state because the identically-classed chips on `StashCard` are clickable — in the viewer they were inert `<span>`s. They now filter by tag and return to the dashboard (click or Enter/Space, `role="button"`, `aria-label`), so a visible affordance stops lying. | S | auto-build |
| 2 | **Word-wrap toggle in the file editors** (`StashEditor.tsx`, `FileCodeEditor.tsx`, `app.css`) | The viewer has had a Wrap toggle for raw code; the editor hard-forced `white-space: pre`, so editing long Markdown prose or a config with long values meant horizontal scrolling on every line with no way out. Same icon, label, `aria-pressed` and `.wrap-toggle`/`.wrap-active` classes as the viewer. | S | auto-build |
| 3 | **"Load more" on the dashboard** (`App.tsx`, `Dashboard.tsx`, `utils/constants.ts`, `app.css`) | List responses are capped server-side (50 browsing / 20 searching). The header was honest — "showing 50" beside a total of 137 — but the client never sent `page`/`limit`, so those stashes were **unreachable** except by guessing a search term precise enough to surface them. | M | auto-build |

### Implementation notes

- **#1** deliberately never toggles the tag *off*. The viewer renders no active-filter chip, so re-clicking the currently active tag would look like a no-op while silently clearing the dashboard filter.
- **#2** wraps both the textarea **and** the highlighted `<pre>` — react-simple-code-editor overlays them, and wrapping only one drifts the caret away from the rendered glyphs. Persisted under its own `clawstash-editor-wrap-lines` key rather than sharing the viewer's `clawstash-wrap-lines`, so toggling wrap while reading does not silently change how editing behaves. Covers the large-file plain-textarea fallback too.
- **#3** raises the requested `limit` instead of fetching and appending page N+1. An append would let a concurrent create/delete shift rows across the page boundary and render duplicated or skipped cards; widening keeps the list a single server-ranked result set, so the existing last-wins generation guard in `loadStashes` keeps working unchanged. Depth resets to one page whenever the search term, tag filter or archived toggle changes (including via the `a` hotkey), and an explicit limit is always sent so the step size no longer depends on whether a query is active.

## Testing

Full local check chain on the final branch state, in CI order:

| Check | Result |
|-------|--------|
| `npm ci` | clean |
| `npm run format:check` | all matched files use Prettier code style |
| `npx tsc --noEmit` | clean |
| `npm test` | **30 files, 297 passed / 5 skipped** |
| `npm run build` | compiled successfully, all routes emitted |

Verified additionally that only the six intended source files are touched — no `.claude/**`, `CLAUDE.md`, `AGENTS.md` or `agent_docs/**` changes are staged.

## Checklist

- [x] Formatting passes (`npm run format:check`)
- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Changes are documented (if applicable) — behaviour is self-describing via tooltips/`aria-label`; no README/docs surface changes, since no API, env var or endpoint changed

Closes #407

<!-- screenshot: optional -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01TvVPvgyJw1pdqJiutimf4L)_