### PR TITLE
refactor: best-practice sweep (Next.js 16 App Router + TypeScript + MCP SDK)

### DIFF
--- a/scripts/generate-build-info.js
+++ b/scripts/generate-build-info.js
@@ -8,20 +8,25 @@
  * over local git information.
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { writeFileSync } from 'fs';
 
-function git(cmd) {
+/**
+ * Run a git command via `execFileSync` with an argv array, so no shell is
+ * spawned (mirrors `git()` in src/server/version.ts). Returns '' when git is
+ * unavailable or the command fails.
+ */
+function git(...args) {
   try {
-    return execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    return execFileSync('git', args, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
   } catch {
     return '';
   }
 }
 
-const branch = process.env.BUILD_BRANCH || git('git rev-parse --abbrev-ref HEAD');
+const branch = process.env.BUILD_BRANCH || git('rev-parse', '--abbrev-ref', 'HEAD');
 
-let commitHash = process.env.BUILD_COMMIT_SHA || git('git rev-parse --short HEAD');
+let commitHash = process.env.BUILD_COMMIT_SHA || git('rev-parse', '--short', 'HEAD');
 if (commitHash.length > 7) commitHash = commitHash.substring(0, 7);
 
 const buildDate = new Date().toISOString();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -83,6 +83,10 @@ const SECURITY_HEADERS: Record<string, string> = {
 // received over plain HTTP anyway, so the gate costs nothing.
 const STRICT_TRANSPORT_SECURITY = 'max-age=31536000'; // 1 year
 
+// Applied to API/MCP responses only. Page responses keep Next.js's own
+// caching headers so the static shell and `_next` assets stay cacheable.
+const CACHE_CONTROL_API = 'no-store';
+
 function isHttpsRequest(req: NextRequest): boolean {
   if (req.nextUrl.protocol === 'https:') return true;
   // Mirrors isTrustedProxy() in src/server/auth-rate-limit.ts. That module
@@ -120,6 +124,13 @@ export function middleware(req: NextRequest) {
     for (const [key, value] of Object.entries(CORS_HEADERS)) {
       response.headers.set(key, value);
     }
+    // API/MCP responses carry stash content, token metadata and backup
+    // configuration. Mark them non-storable so neither the browser cache nor
+    // an intermediary keeps a copy. `Authorization` alone is not enough here:
+    // ClawStash also accepts `?token=` (see server/auth.ts), and a response to
+    // a request WITHOUT an Authorization header is storable by a shared cache
+    // under RFC 9111 — so a proxy could serve one caller's stash to the next.
+    response.headers.set('Cache-Control', CACHE_CONTROL_API);
   }
 
   // Security headers on all routes

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -87,6 +87,15 @@ export type {
   StashGraphResult,
 } from './db-types';
 
+/** Stash-graph rows fetched when the caller does not pass a `limit`. */
+const DEFAULT_GRAPH_STASHES = 200;
+/**
+ * Hard upper bound on stash-graph rows. `getStashGraph` builds edges with
+ * nested loops over the fetched rows, so this cap is what keeps the endpoint's
+ * cost bounded regardless of the requested `limit`.
+ */
+const MAX_GRAPH_STASHES = 1000;
+
 export class ClawStashDB {
   private db: Database.Database;
   private tokens: TokenStore;
@@ -987,10 +996,20 @@ export class ClawStashDB {
       since,
       until,
       tag,
-      limit = 200,
+      limit = DEFAULT_GRAPH_STASHES,
       include_versions = false,
       min_shared_tags = 1,
     } = options;
+
+    // Edge building below is O(n^2) over the fetched rows (shared-tag pairs +
+    // temporal-proximity pairs), so the row cap is the only thing bounding the
+    // work this endpoint can be made to do. An uncapped `limit` — or the
+    // previous `limit <= 0` meaning "no LIMIT clause at all" — let a single
+    // `read`-scope request (unauthenticated in open mode) pull every stash and
+    // burn quadratic CPU. Clamp instead: the graph is a visualisation surface
+    // where thousands of nodes are unreadable anyway, and the UI never sends a
+    // limit (it uses the 200 default).
+    const rowLimit = limit > 0 ? Math.min(limit, MAX_GRAPH_STASHES) : MAX_GRAPH_STASHES;
 
     // Fetch stashes with optional filters
     let query =
@@ -1015,11 +1034,8 @@ export class ClawStashDB {
     if (conditions.length > 0) {
       query += ' WHERE ' + conditions.join(' AND ');
     }
-    query += ' GROUP BY s.id ORDER BY s.updated_at DESC';
-    if (limit > 0) {
-      query += ' LIMIT ?';
-      params.push(limit);
-    }
+    query += ' GROUP BY s.id ORDER BY s.updated_at DESC LIMIT ?';
+    params.push(rowLimit);
 
     const stashRows = this.db.prepare(query).all(...params) as {
       id: string;

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -21,6 +21,11 @@ export function createMcpServer(db: ClawStashDB, baseUrl?: string): McpServer {
 ${TOKEN_EFFICIENT_GUIDE}`,
   });
 
+  // Convention: a tool result that reports a failure MUST carry
+  // `isError: true`. Without it the MCP spec says the call succeeded, so a
+  // client has to string-match the text to notice — and an agent will happily
+  // treat `Error: Stash "…" not found.` as a valid answer.
+
   // Create a new stash
   const createDef = getToolDef('create_stash');
   server.registerTool(
@@ -60,7 +65,10 @@ ${TOKEN_EFFICIENT_GUIDE}`,
       if (include_content) {
         const stash = db.getStash(id);
         if (!stash) {
-          return { content: [{ type: 'text', text: `Error: Stash "${id}" not found.` }] };
+          return {
+            content: [{ type: 'text', text: `Error: Stash "${id}" not found.` }],
+            isError: true,
+          };
         }
         db.logAccess(stash.id, 'mcp', 'read');
         const result = {
@@ -87,7 +95,10 @@ ${TOKEN_EFFICIENT_GUIDE}`,
 
       const meta = db.getStashMeta(id);
       if (!meta) {
-        return { content: [{ type: 'text', text: `Error: Stash "${id}" not found.` }] };
+        return {
+          content: [{ type: 'text', text: `Error: Stash "${id}" not found.` }],
+          isError: true,
+        };
       }
       db.logAccess(meta.id, 'mcp', 'read');
       return {
@@ -126,7 +137,10 @@ ${TOKEN_EFFICIENT_GUIDE}`,
       // File not found — check if stash exists to provide the right error
       const stashMeta = db.getStashMeta(id);
       if (!stashMeta) {
-        return { content: [{ type: 'text', text: `Error: Stash "${id}" not found.` }] };
+        return {
+          content: [{ type: 'text', text: `Error: Stash "${id}" not found.` }],
+          isError: true,
+        };
       }
       const available = stashMeta.files.map((f) => f.filename).join(', ');
       return {
@@ -136,6 +150,7 @@ ${TOKEN_EFFICIENT_GUIDE}`,
             text: `Error: File "${filename}" not found in stash "${id}". Available files: ${available}`,
           },
         ],
+        isError: true,
       };
     },
   );
@@ -166,7 +181,10 @@ ${TOKEN_EFFICIENT_GUIDE}`,
     async ({ id, name, description, files, tags, metadata }) => {
       const stash = db.updateStash(id, { name, description, files, tags, metadata }, 'mcp');
       if (!stash) {
-        return { content: [{ type: 'text', text: `Error: Stash "${id}" not found.` }] };
+        return {
+          content: [{ type: 'text', text: `Error: Stash "${id}" not found.` }],
+          isError: true,
+        };
       }
       db.logAccess(stash.id, 'mcp', 'update');
       const fileInfos = stash.files.map((f) => ({
@@ -202,7 +220,10 @@ ${TOKEN_EFFICIENT_GUIDE}`,
     async ({ id }) => {
       const deleted = db.deleteStash(id, { source: 'mcp' });
       if (!deleted) {
-        return { content: [{ type: 'text', text: `Error: Stash "${id}" not found.` }] };
+        return {
+          content: [{ type: 'text', text: `Error: Stash "${id}" not found.` }],
+          isError: true,
+        };
       }
       return { content: [{ type: 'text', text: `Stash "${id}" deleted successfully.` }] };
     },
@@ -216,7 +237,10 @@ ${TOKEN_EFFICIENT_GUIDE}`,
     async ({ id, archived }) => {
       const stash = db.archiveStash(id, archived);
       if (!stash) {
-        return { content: [{ type: 'text', text: `Error: Stash "${id}" not found.` }] };
+        return {
+          content: [{ type: 'text', text: `Error: Stash "${id}" not found.` }],
+          isError: true,
+        };
       }
       db.logAccess(stash.id, 'mcp', archived ? 'archive' : 'unarchive');
       const summary = {

--- a/src/server/stores/_parsers.ts
+++ b/src/server/stores/_parsers.ts
@@ -57,9 +57,22 @@ export function safeParseMetadata(raw: unknown): Record<string, unknown> {
 }
 
 /**
+ * Hard upper bound on rows returned by one page.
+ *
+ * The clamp had no maximum, so `?limit=99999` was passed straight to SQLite.
+ * The row IDs of a page are then fed back as bound parameters — `WHERE
+ * stash_id IN (?, ?, …)` in the batched file loads — and SQLite caps a
+ * statement at SQLITE_MAX_VARIABLE_NUMBER (32766) bound parameters, so a
+ * large enough page turned a listing into a 500 instead of a page of rows.
+ * 1000 is ten times the "max recommended: 100" the tool schema documents, so
+ * no realistic caller notices the cap.
+ */
+export const MAX_PAGE_LIMIT = 1000;
+
+/**
  * Clamp pagination params at the DB layer so callers that bypass the REST
  * route's parsePositiveInt (MCP tool layer, direct DB consumers) cannot
- * produce SQLite OFFSET errors or empty `LIMIT 0` pages.
+ * produce SQLite OFFSET errors, empty `LIMIT 0` pages, or oversized pages.
  */
 export function clampPagination(
   page: unknown,
@@ -67,7 +80,8 @@ export function clampPagination(
   defaultLimit: number,
 ): { page: number; limit: number; offset: number } {
   const safePage = typeof page === 'number' && Number.isInteger(page) && page > 0 ? page : 1;
-  const safeLimit =
+  const requestedLimit =
     typeof limit === 'number' && Number.isInteger(limit) && limit > 0 ? limit : defaultLimit;
+  const safeLimit = Math.min(requestedLimit, MAX_PAGE_LIMIT);
   return { page: safePage, limit: safeLimit, offset: (safePage - 1) * safeLimit };
 }

--- a/src/server/version.ts
+++ b/src/server/version.ts
@@ -7,7 +7,7 @@
  * Results are cached for 1 hour to avoid excessive API calls.
  */
 import { readFileSync, existsSync } from 'fs';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import path from 'path';
 import { formatBuildVersion } from '../utils/format';
 
@@ -41,9 +41,22 @@ interface BuildInfo {
 // `new Date().toISOString()`, so the null branch is unreachable.
 const UNKNOWN_VERSION = 'unknown';
 
-function git(cmd: string): string {
+/**
+ * Run a git command and return its trimmed stdout, or '' when git is
+ * unavailable / the command fails.
+ *
+ * `execFileSync` with an argv array — NOT `execSync` with a command string,
+ * which spawns `/bin/sh -c` and would interpret shell metacharacters. The
+ * arguments here are compile-time constants, so this is defense-in-depth:
+ * it removes the shell from the process tree entirely (no quoting rules to
+ * get wrong on a future argument, and no `sh` dependency in slim images).
+ */
+function git(...args: string[]): string {
   try {
-    return execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    return execFileSync('git', args, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
   } catch {
     return '';
   }
@@ -61,8 +74,8 @@ function loadBuildInfo(): BuildInfo {
   }
 
   // Development: read directly from git
-  const branch = process.env.BUILD_BRANCH || git('git rev-parse --abbrev-ref HEAD');
-  let commitHash = process.env.BUILD_COMMIT_SHA || git('git rev-parse --short HEAD');
+  const branch = process.env.BUILD_BRANCH || git('rev-parse', '--abbrev-ref', 'HEAD');
+  let commitHash = process.env.BUILD_COMMIT_SHA || git('rev-parse', '--short', 'HEAD');
 
   // Normalize to 7-char short hash (git may return more for uniqueness)
   if (commitHash.length > 7) {
@@ -70,7 +83,7 @@ function loadBuildInfo(): BuildInfo {
   }
 
   // Use git commit date so the version is stable across server restarts
-  const buildDate = git('git log -1 --format=%cI') || new Date().toISOString();
+  const buildDate = git('log', '-1', '--format=%cI') || new Date().toISOString();
 
   return { branch, commitHash, buildDate };
 }


### PR DESCRIPTION
Five tightly-scoped best-practice fixes, one commit each. No feature changes, no style-only diffs.

| #   | Commit                                                        | Datei                                                     | Kategorie   | Fix                                                                                                                                     | Aufwand | Empfehlung |
| --- | ------------------------------------------------------------- | --------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------- | ---------- |
| 1   | `refactor(version): run git via execFileSync instead of a shell string` | `src/server/version.ts`, `scripts/generate-build-info.js` | Security    | `execSync(cmd)` spawns `/bin/sh -c`; both git helpers only run fixed argument lists → `execFileSync('git', [...])`. Same output, same `''` fallback, no shell. | S       | auto-fix   |
| 2   | `refactor(db): bound the stash-graph row cap`                  | `src/server/db.ts`                                        | Security    | `getStashGraph` builds edges with nested loops over the fetched rows, but `limit` was unclamped and `limit <= 0` emitted no `LIMIT` at all. Always `LIMIT`, capped at 1000 (default stays 200; the UI sends no limit). | S       | auto-fix   |
| 3   | `refactor(middleware): mark API/MCP responses no-store`        | `src/middleware.ts`                                       | Security    | `/api/**` and `/mcp` set no `Cache-Control`. `?token=` auth means a request can arrive without `Authorization`, which under RFC 9111 makes the response storable by a shared cache. | S       | auto-fix   |
| 4   | `refactor(mcp): flag failing tool results with isError`        | `src/server/mcp-server.ts`                                | Correctness | Seven `Error: …` results carried no `isError`, so the MCP spec reported the call as successful. Flag set; message text unchanged.         | S       | auto-fix   |
| 5   | `refactor(db): cap the page limit in clampPagination`          | `src/server/stores/_parsers.ts`                           | Correctness | Lower bound only. Page IDs are bound back as parameters (`IN (?, …)`) and SQLite caps a statement at 32766 of them, so a big enough page returned a 500. Capped at 1000. | S       | auto-fix   |

### Verification

`npm ci` → `npm run format:check` → `npx tsc --noEmit` → `npm test` (388 passed, 5 skipped) → `npm run build` — all green, run once after all five commits.

Deferred findings and the out-of-scope notes are recorded on the issue.

Closes #415


---
_Generated by [Claude Code](https://claude.ai/code/session_0134KhyTZ15wfbKLCvoDyHKe)_