### PR TITLE
ux: best-practice sweep (Next.js 16 + React 19)

### DIFF
--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -1278,7 +1278,7 @@ export default function StashViewer({
             <table className="metadata-table">
               <tbody>
                 <tr>
-                  <td>ID</td>
+                  <th scope="row">ID</th>
                   <td>
                     <span className="stash-id-cell">
                       <code>{stash.id}</code>
@@ -1303,24 +1303,24 @@ export default function StashViewer({
                   </td>
                 </tr>
                 <tr>
-                  <td>Files</td>
+                  <th scope="row">Files</th>
                   <td>{stash.files.length}</td>
                 </tr>
                 <tr>
-                  <td>Size</td>
+                  <th scope="row">Size</th>
                   <td>{formatBytes(totalBytes)}</td>
                 </tr>
                 <tr>
-                  <td>Created</td>
+                  <th scope="row">Created</th>
                   <td>{new Date(stash.created_at).toLocaleString()}</td>
                 </tr>
                 <tr>
-                  <td>Updated</td>
+                  <th scope="row">Updated</th>
                   <td>{new Date(stash.updated_at).toLocaleString()}</td>
                 </tr>
                 {stash.tags.length > 0 && (
                   <tr>
-                    <td>Tags</td>
+                    <th scope="row">Tags</th>
                     <td>{stash.tags.join(', ')}</td>
                   </tr>
                 )}
@@ -1372,7 +1372,7 @@ export default function StashViewer({
                     const copyKey = `meta-${key}`;
                     return (
                       <tr key={key}>
-                        <td>{key}</td>
+                        <th scope="row">{key}</th>
                         <td className="metadata-value-cell">
                           <code>{display}</code>
                           <button

--- a/src/components/api/icons.tsx
+++ b/src/components/api/icons.tsx
@@ -1,6 +1,7 @@
 export function BookIcon() {
   return (
     <svg
+      aria-hidden="true"
       width="24"
       height="24"
       viewBox="0 0 24 24"
@@ -18,6 +19,7 @@ export function BookIcon() {
 export function KeyIcon() {
   return (
     <svg
+      aria-hidden="true"
       width="20"
       height="20"
       viewBox="0 0 24 24"
@@ -38,6 +40,7 @@ export function KeyIcon() {
 export function ServerIcon() {
   return (
     <svg
+      aria-hidden="true"
       width="20"
       height="20"
       viewBox="0 0 24 24"
@@ -58,6 +61,7 @@ export function ServerIcon() {
 export function WifiIcon() {
   return (
     <svg
+      aria-hidden="true"
       width="20"
       height="20"
       viewBox="0 0 24 24"
@@ -81,7 +85,7 @@ export { CopyIcon } from '../shared/icons';
 
 export function PlusIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+    <svg aria-hidden="true" width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
       <path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2Z" />
     </svg>
   );
@@ -90,6 +94,7 @@ export function PlusIcon() {
 export function TrashIcon() {
   return (
     <svg
+      aria-hidden="true"
       width="14"
       height="14"
       viewBox="0 0 24 24"
@@ -109,6 +114,7 @@ export function TrashIcon() {
 export function WarningIcon() {
   return (
     <svg
+      aria-hidden="true"
       width="16"
       height="16"
       viewBox="0 0 24 24"
@@ -128,6 +134,7 @@ export function WarningIcon() {
 export function ChevronIcon({ expanded }: { expanded: boolean }) {
   return (
     <svg
+      aria-hidden="true"
       width="14"
       height="14"
       viewBox="0 0 24 24"
@@ -149,6 +156,7 @@ export function ChevronIcon({ expanded }: { expanded: boolean }) {
 export function CheckIcon() {
   return (
     <svg
+      aria-hidden="true"
       width="14"
       height="14"
       viewBox="0 0 24 24"

--- a/src/components/settings/BackupActivityCard.tsx
+++ b/src/components/settings/BackupActivityCard.tsx
@@ -77,8 +77,9 @@ export default function BackupActivityCard({ onSyncRan, onUnhealthyChange }: Pro
 
   if (loading) {
     return (
-      <div className="settings-card">
+      <div className="settings-card" role="status" aria-live="polite">
         <Spinner />
+        <span className="sr-only">Loading sync activity…</span>
       </div>
     );
   }

--- a/src/components/settings/BackupActivityCard.tsx
+++ b/src/components/settings/BackupActivityCard.tsx
@@ -165,10 +165,10 @@ export default function BackupActivityCard({ onSyncRan, onUnhealthyChange }: Pro
           <table className="backup-table">
             <thead>
               <tr>
-                <th>Stash</th>
-                <th>State</th>
-                <th>Last sync</th>
-                <th>Commit</th>
+                <th scope="col">Stash</th>
+                <th scope="col">State</th>
+                <th scope="col">Last sync</th>
+                <th scope="col">Commit</th>
               </tr>
             </thead>
             <tbody>

--- a/src/components/settings/BackupLogCard.tsx
+++ b/src/components/settings/BackupLogCard.tsx
@@ -20,8 +20,13 @@ export default function BackupLogCard({ repoFullName, refreshToken }: Props) {
   const [log, setLog] = useState<BackupLogEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadFailed, setLoadFailed] = useState(false);
+  // Separate from `loading`: the initial load swaps the whole card for a
+  // spinner, whereas a manual refresh keeps the table on screen and only
+  // needs to mark the button busy.
+  const [refreshing, setRefreshing] = useState(false);
 
   const refresh = useCallback(async () => {
+    setRefreshing(true);
     try {
       const data = await api.getBackupLog({ limit: 50 });
       setLog(data.entries);
@@ -31,6 +36,7 @@ export default function BackupLogCard({ repoFullName, refreshToken }: Props) {
       setLoadFailed(true);
     } finally {
       setLoading(false);
+      setRefreshing(false);
     }
   }, []);
 
@@ -60,8 +66,13 @@ export default function BackupLogCard({ repoFullName, refreshToken }: Props) {
       )}
 
       <div className="settings-option-group">
-        <button className="btn btn-secondary btn-sm" onClick={refresh}>
-          Refresh
+        <button
+          className="btn btn-secondary btn-sm"
+          onClick={refresh}
+          disabled={refreshing}
+          aria-busy={refreshing}
+        >
+          {refreshing ? 'Refreshing…' : 'Refresh'}
         </button>
       </div>
 

--- a/src/components/settings/BackupLogCard.tsx
+++ b/src/components/settings/BackupLogCard.tsx
@@ -40,8 +40,9 @@ export default function BackupLogCard({ repoFullName, refreshToken }: Props) {
 
   if (loading) {
     return (
-      <div className="settings-card">
+      <div className="settings-card" role="status" aria-live="polite">
         <Spinner />
+        <span className="sr-only">Loading sync log…</span>
       </div>
     );
   }

--- a/src/components/settings/BackupLogCard.tsx
+++ b/src/components/settings/BackupLogCard.tsx
@@ -71,10 +71,10 @@ export default function BackupLogCard({ repoFullName, refreshToken }: Props) {
           <table className="backup-table">
             <thead>
               <tr>
-                <th>Time</th>
-                <th>Trigger</th>
-                <th>Status</th>
-                <th>Details</th>
+                <th scope="col">Time</th>
+                <th scope="col">Trigger</th>
+                <th scope="col">Status</th>
+                <th scope="col">Details</th>
               </tr>
             </thead>
             <tbody>

--- a/src/components/settings/BackupSection.tsx
+++ b/src/components/settings/BackupSection.tsx
@@ -124,8 +124,9 @@ export default function BackupSection() {
       )}
 
       {!loadError && !response && (
-        <div className="settings-card">
+        <div className="settings-card" role="status" aria-live="polite">
           <Spinner />
+          <span className="sr-only">Loading backup settings…</span>
         </div>
       )}
 

--- a/src/components/shared/Spinner.tsx
+++ b/src/components/shared/Spinner.tsx
@@ -1,6 +1,13 @@
 export default function Spinner({ size = 16 }: { size?: number }) {
   return (
-    <svg className="api-spinner" width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <svg
+      aria-hidden="true"
+      className="api-spinner"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+    >
       <circle
         style={{ opacity: 0.25 }}
         cx="12"

--- a/src/components/shared/icons.tsx
+++ b/src/components/shared/icons.tsx
@@ -12,6 +12,7 @@ interface IconProps {
 export function CopyIcon({ size = 12 }: IconProps) {
   return (
     <svg
+      aria-hidden="true"
       width={size}
       height={size}
       viewBox="0 0 24 24"
@@ -30,7 +31,7 @@ export function CopyIcon({ size = 12 }: IconProps) {
 /** Octicon-style checkmark icon. */
 export function CheckIcon({ size = 12 }: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
+    <svg aria-hidden="true" width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
       <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z" />
     </svg>
   );
@@ -39,7 +40,7 @@ export function CheckIcon({ size = 12 }: IconProps) {
 /** Octicon-style X/cross icon for error states. */
 export function XIcon({ size = 12 }: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
+    <svg aria-hidden="true" width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
       <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
     </svg>
   );

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2340,16 +2340,20 @@ body {
   border-collapse: collapse;
 }
 
-.metadata-table td {
+/* The label column is a <th scope="row">, so every cell rule has to match
+   both element types — a bare `td` selector would drop the padding/border
+   off the labels and let the <th> defaults (bold, centered) through. */
+.metadata-table :is(td, th) {
   padding: 8px 12px;
   border-bottom: 1px solid var(--border-color);
   font-size: 13px;
 }
 
-.metadata-table td:first-child {
+.metadata-table :is(td, th):first-child {
   color: var(--text-secondary);
   width: 120px;
   font-weight: 500;
+  text-align: left;
 }
 
 .metadata-table code {


### PR DESCRIPTION
Five UX best-practice fixes — four accessibility, one interaction. All additive, no behaviour change on the happy path, no visual change.

| # | Commit | Category | Effort | Recommendation |
| - | ------ | -------- | ------ | -------------- |
| 1 | `ux(a11y): associate backup table headers via scope="col"` | a11y | S | auto-fix |
| 2 | `ux(a11y): make metadata row labels real row headers` | a11y | M | auto-fix |
| 3 | `ux(a11y): announce the three bare backup loading cards` | a11y | M | auto-fix |
| 4 | `ux(a11y): hide decorative shared icons from assistive tech` | a11y | S | auto-fix |
| 5 | `ux(interaction): give the sync-log Refresh button a busy state` | interaction | S | auto-fix |

### What changed, briefly

1. **Backup tables had no header association.** Both `<thead>` rows were plain `<th>` cells without `scope`, so in table-navigation mode a screen reader read data cells bare — "Pending", "manual", a lone timestamp — without the column name that gives them meaning. Added `scope="col"` to the eight header cells (WCAG 1.3.1 / H63).

2. **The metadata tables had no header cells at all.** Both tables in the stash viewer used `<td>` for the label column, so an ID, a byte count or a timestamp was announced with nothing naming the field — and the custom-metadata table lost its key entirely when navigating by cell. Promoted the label cells to `<th scope="row">` and widened the two `.metadata-table` cell rules to `:is(td, th)`, pinning `text-align: left` so the `<th>` user-agent defaults (bold, centered) are cancelled. Rendering is unchanged.

3. **Three loading states were silent.** The GitHub-backup section, sync activity card and sync log card each rendered their loading state as a lone `<Spinner />` — no text, no role. An SVG with no accessible name is nothing to a screen reader, so the card read as an empty box. Brought them in line with the rest of the app (`role="status"` + `aria-live="polite"` + an `.sr-only` label).

4. **Shared icons announced as nameless graphics.** The three shared icon modules render 13 bare `<svg>` roots with no `aria-hidden`, even though every consumer already supplies the accessible name on the wrapping button or pairs the glyph with visible text. Fixing this at the shared modules covers every call site at once.

5. **"Refresh" in the sync log looked like a no-op.** `loading` is only ever true for the initial mount, so clicking Refresh left the button idle and the table in place — a run returning identical entries was indistinguishable from a click that never registered, and each retry queued another request. The manual refetch is now tracked separately, with `disabled` + `aria-busy` and a "Refreshing…" label while in flight.

### Screens affected

Settings → GitHub Backup (target/activity/sync-log cards), stash detail → Metadata tab, and — via the shared icon modules — copy buttons across the stash viewer, version history, the REST/MCP/Tokens API tabs and every spinner usage.

### Verification

`npm ci` → `npm run format:check` → `npx tsc --noEmit` → `npm test` (388 passed, 5 skipped, 35 files) → `npm run build`. All green.

Closes #417


---
_Generated by [Claude Code](https://claude.ai/code/session_01L88b39wHKPkDvwjKTZQc2f)_