### PR TITLE
refine: ux sweep (Next.js)

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -390,18 +390,27 @@ function StorageSection() {
   const [importing, setImporting] = useState(false);
   const [importResult, setImportResult] = useState<string | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
+  // True after a failed stats/tags load. Without it the section fell through to
+  // "No storage data available." — the same misleading empty state the
+  // dashboard already replaced with an error + retry (see Dashboard loadError).
+  const [loadFailed, setLoadFailed] = useState(false);
+  // Bumped by the Retry button to re-run the load effect.
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
     async function load() {
+      setLoading(true);
       try {
         const [statsData, tagsData] = await Promise.all([api.getStats(), api.getTags()]);
         if (!cancelled) {
           setStats(statsData);
           setTags(tagsData);
+          setLoadFailed(false);
         }
       } catch (err) {
         console.error('Failed to load storage stats:', err);
+        if (!cancelled) setLoadFailed(true);
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -410,7 +419,7 @@ function StorageSection() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [reloadKey]);
 
   // Tracks whether the storage section is still mounted, so async ops launched
   // from event handlers don't trigger setState-after-unmount warnings if the
@@ -630,7 +639,24 @@ function StorageSection() {
         )}
       </div>
 
-      {!stats && (
+      {!stats && loadFailed && (
+        // Honest failure state: "No storage data available." reads like an
+        // empty database, so a failed fetch used to look like a valid result.
+        <div className="settings-card">
+          <div role="alert" className="settings-import-error">
+            Failed to load storage statistics. Check your connection and try again.
+          </div>
+          <div className="settings-export-import-actions">
+            {/* No own busy label: the retry flips `loading`, and the early
+                return above swaps the whole section for the load spinner. */}
+            <button className="settings-option-btn" onClick={() => setReloadKey((k) => k + 1)}>
+              Retry
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!stats && !loadFailed && (
         <div className="settings-card">
           <p className="api-hint">No storage data available.</p>
         </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { useClickOutside } from '../hooks/useClickOutside';
 import type { JSX } from 'react';
 import type { StashListItem, SettingsSection, TagInfo } from '../types';
 import { formatDate } from '../utils/format';
+import { splitHighlight } from '../utils/highlight';
 
 interface Props {
   stashes: StashListItem[];
@@ -195,6 +196,29 @@ export default function Sidebar({
   const filteredTags = tagSearch
     ? tags.filter((t) => t.tag.toLowerCase().includes(tagSearch.toLowerCase()))
     : tags;
+
+  /**
+   * Wrap the parts of `text` matching the active stash search in <mark>, so a
+   * filtered list row shows *why* it matched — the quick-search overlay has
+   * done this since it shipped, while the sidebar (driven by the very same
+   * search term) rendered plain text.
+   *
+   * Segments render as React text nodes, so this stays XSS-safe. With no
+   * active search the helper short-circuits to the raw string, which keeps the
+   * common unfiltered render allocation-free.
+   */
+  const renderHighlighted = (text: string) => {
+    if (!search.trim()) return text;
+    return splitHighlight(text, search).map((seg, i) =>
+      seg.match ? (
+        <mark key={i} className="sidebar-item-mark">
+          {seg.text}
+        </mark>
+      ) : (
+        seg.text
+      ),
+    );
+  };
 
   return (
     <aside className={`sidebar${isOpen ? ' sidebar-open' : ''}`}>
@@ -495,11 +519,13 @@ export default function Sidebar({
                 title={`${stash.name || stash.files[0]?.filename || 'Untitled'} — ${stash.files.length} file${stash.files.length !== 1 ? 's' : ''}`}
               >
                 <div className="sidebar-item-title">
-                  {stash.name || stash.files[0]?.filename || 'Untitled'}
+                  {renderHighlighted(stash.name || stash.files[0]?.filename || 'Untitled')}
                   {stash.archived && <span className="sidebar-item-archived-badge">Archived</span>}
                 </div>
                 <div className="sidebar-item-meta">
-                  <span className="sidebar-item-filename">{stash.files[0]?.filename}</span>
+                  <span className="sidebar-item-filename">
+                    {stash.files[0]?.filename && renderHighlighted(stash.files[0].filename)}
+                  </span>
                 </div>
                 <div className="sidebar-item-footer">
                   <span className="sidebar-item-date">{formatDate(stash.updated_at)}</span>

--- a/src/components/VersionHistory.tsx
+++ b/src/components/VersionHistory.tsx
@@ -22,7 +22,11 @@ export default function VersionHistory({ stashId, currentVersion, onRestore }: P
   const [loading, setLoading] = useState(true);
   const [subView, setSubView] = useState<SubView>('list');
   const [selectedVersion, setSelectedVersion] = useState<StashVersion | null>(null);
-  const [detailLoading, setDetailLoading] = useState(false);
+  // Version number whose detail fetch is in flight, or null. Every View button
+  // was disabled while loading with no indication of WHICH row was opening —
+  // on a slow fetch the click read as "nothing happened".
+  const [loadingVersion, setLoadingVersion] = useState<number | null>(null);
+  const detailLoading = loadingVersion !== null;
   const [restoring, setRestoring] = useState(false);
   const [confirmRestore, setConfirmRestore] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -68,7 +72,7 @@ export default function VersionHistory({ stashId, currentVersion, onRestore }: P
   }, [stashId, currentVersion]);
 
   const handleViewVersion = async (version: number) => {
-    setDetailLoading(true);
+    setLoadingVersion(version);
     try {
       const data = await api.getVersion(stashId, version);
       setSelectedVersion(data);
@@ -77,7 +81,7 @@ export default function VersionHistory({ stashId, currentVersion, onRestore }: P
     } catch {
       setError('Failed to load version details');
     } finally {
-      setDetailLoading(false);
+      setLoadingVersion(null);
     }
   };
 
@@ -440,8 +444,15 @@ export default function VersionHistory({ stashId, currentVersion, onRestore }: P
                   className="btn btn-sm btn-ghost"
                   onClick={() => handleViewVersion(v.version)}
                   disabled={detailLoading}
+                  aria-busy={loadingVersion === v.version || undefined}
                 >
-                  View
+                  {loadingVersion === v.version ? (
+                    <>
+                      <Spinner size={12} /> Opening...
+                    </>
+                  ) : (
+                    'View'
+                  )}
                 </button>
                 {!isCurrent && (
                   <button

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -966,7 +966,10 @@ body {
   margin-bottom: 4px;
 }
 
-.search-overlay-mark {
+/* Shared search-match highlight: quick-search results and the sidebar stash
+   list are driven by the same query, so they share one visual language. */
+.search-overlay-mark,
+.sidebar-item-mark {
   /* Accent-orange tint keeps the match visible on the dark surface without the
      browser default black-on-yellow. `color: inherit` preserves item colors. */
   background: rgba(210, 153, 34, 0.28);


### PR DESCRIPTION
## Summary

UX-refine sweep: three existing user-facing features sharpened for comfort and clarity. No new features, no refactors, no dependency changes. One commit per refinement.

| # | Feature | Kategorie | UX gap → improvement | Aufwand |
| - | ------- | --------- | -------------------- | ------- |
| 1 | Sidebar stash search + list | Komfort | The filtered list rendered plain text, so nothing showed *which* part matched — while the quick-search overlay, driven by the same term, has always marked its matches. Now `<mark>`s matches in the item title and filename via the existing `splitHighlight` util, sharing the overlay's highlight tint. | S |
| 2 | Settings → Storage | Qualität | A failed stats/tags fetch was swallowed into `console.error` and fell through to "No storage data available." — reads like an empty database, with no way to recover but a page reload. Now an explicit error card + Retry, mirroring the dashboard's existing `loadError` pattern. | S |
| 3 | Stash viewer → History tab | Qualität | Clicking **View** disabled every View button with no other feedback, so a slow version fetch read as "nothing happened". Now a spinner + "Opening..." (plus `aria-busy`) on the clicked row, matching the Compare button's existing "Comparing..." affordance. | S |

## Changes

- `refine(sidebar): stash list – highlight the active search term` — `src/components/Sidebar.tsx`, `src/styles/app.css` (one extra selector on the existing `.search-overlay-mark` rule, no new visual language). Short-circuits to the raw string with no active search, so the unfiltered render is unchanged.
- `refine(settings): storage section – honest error state with retry` — `src/components/Settings.tsx`. The genuine success-but-empty case keeps its original message; Export/Import stays reachable either way.
- `refine(versions): version list – per-row loading state on View` — `src/components/VersionHistory.tsx`. Non-active rows stay disabled exactly as before.

All changes are feature-local and additive; no existing behaviour, keybinding or default was changed.

## Testing

Full local pipeline, all green:

- `npm ci`
- `npm run format:check` — clean
- `npx tsc --noEmit` — clean
- `npm run build` — succeeds
- `npm test` — 401 passed, 5 skipped (38 files)

No ESLint is configured in this repo. `splitHighlight` (the util reused by refinement 1) is already covered by `src/utils/__tests__/highlight.test.ts`.

## Checklist

- [x] Formatting passes (`npm run format:check`)
- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Changes are documented (if applicable) — no user-facing hotkey, config key or env var added, so no doc update was needed; the deferred ideas are recorded in the issue

Closes #424


---
_Generated by [Claude Code](https://claude.ai/code/session_01TZ4PCgy393Au8BBYZHZ5Ec)_