### PR TITLE
security: hardening sweep (Next.js 16 App Router + MCP)

### DIFF
--- a/src/languages.ts
+++ b/src/languages.ts
@@ -180,6 +180,21 @@ const languageNameToPrism: Record<string, string> = {
 };
 
 /**
+ * Own-property lookup on a plain string map.
+ *
+ * `language` and `filename` are user-controlled (stored per file, free text
+ * on the write path), so a bare `map[key]` is a prototype-chain lookup with
+ * an attacker-chosen key: `map['constructor']`, `map['toString']` and
+ * `map['__proto__']` all resolve to truthy `Object.prototype` members and
+ * would be handed on as if they were a real grammar name. Restricting every
+ * lookup to own properties keeps the maps closed sets — the value returned
+ * is always one the module actually declares, never something inherited.
+ */
+function lookupOwn(map: Record<string, string>, key: string): string | undefined {
+  return Object.prototype.hasOwnProperty.call(map, key) ? map[key] : undefined;
+}
+
+/**
  * Detect PrismJS language from a filename.
  */
 export function detectLanguageFromFilename(filename: string): string {
@@ -190,7 +205,7 @@ export function detectLanguageFromFilename(filename: string): string {
   if (lower === 'makefile' || lower === 'gnumakefile') return 'makefile';
 
   const ext = lower.split('.').pop() || '';
-  return extensionToLanguage[ext] || 'text';
+  return lookupOwn(extensionToLanguage, ext) || 'text';
 }
 
 /**
@@ -199,12 +214,12 @@ export function detectLanguageFromFilename(filename: string): string {
 export function resolvePrismLanguage(language: string, filename?: string): string {
   if (language) {
     const lower = language.toLowerCase();
-    const mapped = languageNameToPrism[lower];
+    const mapped = lookupOwn(languageNameToPrism, lower);
     if (mapped) return mapped;
     // The editor's language field is free text — users often type
     // extension-style shorthands ("js", "py", "yml", "md"), so fall back to
     // the extension map before ignoring the explicit language entirely.
-    const fromExtension = extensionToLanguage[lower];
+    const fromExtension = lookupOwn(extensionToLanguage, lower);
     if (fromExtension) return fromExtension;
   }
   if (filename) {
@@ -218,7 +233,15 @@ export function resolvePrismLanguage(language: string, filename?: string): strin
  * Returns HTML string with syntax tokens.
  */
 export function highlightCode(code: string, language: string): string {
-  const prismLang = Prism.languages[language];
+  // Own-property check for the same reason as `lookupOwn` above: `language`
+  // is user-controlled, and `Prism.languages['constructor']` is a truthy
+  // inherited function that would be passed to `Prism.highlight` as a
+  // "grammar". Prism escapes its output either way, so this is not a live
+  // XSS — but an inherited value must never reach the highlighter, and the
+  // escaping fallback below is the correct outcome for any unknown language.
+  const prismLang = Object.prototype.hasOwnProperty.call(Prism.languages, language)
+    ? Prism.languages[language]
+    : undefined;
   if (!prismLang) {
     // Fallback: escape HTML entities for plain text
     return escapeHtml(code);

--- a/src/server/backup/device-poll.ts
+++ b/src/server/backup/device-poll.ts
@@ -1,4 +1,5 @@
 import type { DeviceSession } from './device-sessions';
+import { redactSecrets } from './backup-crypto';
 
 /**
  * Testable core of the device-flow poll route (refs #108, #111).
@@ -83,9 +84,16 @@ export async function processDevicePoll(
     try {
       ({ login } = await deps.getAuthenticatedUser(result.token));
     } catch (lookupErr) {
+      // This lookup is the one call in the flow that carries the freshly
+      // exchanged access token, so its failure message is routed through
+      // redactSecrets before it reaches stdout — the same treatment
+      // /api/backup/token gives its GitHub errors. Matches the module-wide
+      // rule that a GitHub secret never lands in a log line.
       console.warn(
         '[backup] token stored but account lookup failed:',
-        lookupErr instanceof Error ? lookupErr.message : lookupErr,
+        redactSecrets(lookupErr instanceof Error ? lookupErr.message : String(lookupErr), [
+          result.token,
+        ]),
       );
     }
     deps.storeToken(result.token, login);
@@ -94,8 +102,13 @@ export async function processDevicePoll(
     return { status: 'connected', login };
   } catch (err) {
     // Transient upstream/network failure: keep the session alive and let
-    // the browser retry until the device code expires.
-    console.warn('[backup] device poll failed:', err instanceof Error ? err.message : err);
+    // the browser retry until the device code expires. The failing call is
+    // the device-code exchange, so redact the device code (the secret half
+    // of the flow) plus anything token-shaped before logging.
+    console.warn(
+      '[backup] device poll failed:',
+      redactSecrets(err instanceof Error ? err.message : String(err), [session.deviceCode]),
+    );
     return { status: 'pending' };
   }
 }

--- a/src/server/tool-defs.ts
+++ b/src/server/tool-defs.ts
@@ -227,8 +227,13 @@ Important:
 - To update only name/description, omit files/tags/metadata.`,
     schema: z.object({
       id: z.string().describe('The stash ID to update'),
-      name: z.string().optional().describe('New name/title'),
-      description: z.string().optional().describe('New description'),
+      // Same caps as create_stash and the REST `UpdateStashSchema`. Without
+      // them this tool was the one write path with no bound on name /
+      // description size, so an MCP caller could persist an arbitrarily large
+      // value that every other surface rejects (and that then flows into
+      // listings, FTS indexing, exports and the GitHub backup).
+      name: z.string().max(MAX_NAME_LENGTH).optional().describe('New name/title'),
+      description: z.string().max(MAX_DESCRIPTION_LENGTH).optional().describe('New description'),
       files: z
         .array(FileInputSchema)
         .max(MAX_FILES)

--- a/src/server/tool-defs.ts
+++ b/src/server/tool-defs.ts
@@ -20,6 +20,7 @@ import {
   MAX_TAGS,
   maxObjectDepth,
   hasUniqueFilenames,
+  isValidFilename,
   DUPLICATE_FILENAME_MESSAGE,
 } from './validation';
 
@@ -29,14 +30,20 @@ import {
 // ---------------------------------------------------------------------------
 
 export const FileInputSchema = z.object({
+  // Uses the SHARED `isValidFilename` guard rather than an inline check so the
+  // MCP write path cannot drift from the REST one (`FileSchema` in
+  // validation.ts) or from the read-side raw-file route. The previous inline
+  // predicate only rejected `/`, `\`, `..` and NUL, so an MCP caller could
+  // store a filename containing other C0/C1 control characters (CR/LF, ESC, …)
+  // that every other surface rejects. Those bytes are reflected into the
+  // `Content-Disposition` header by the raw-file route and into git paths by
+  // the GitHub backup, so keeping the guards symmetric closes the drift at the
+  // one boundary that was still permissive.
   filename: z
     .string()
     .min(1)
     .max(MAX_FILENAME_LENGTH)
-    .refine(
-      (f) => !/[/\\]/.test(f) && !f.includes('..') && !f.includes('\0'),
-      'Filename contains invalid characters',
-    )
+    .refine(isValidFilename, 'Filename contains invalid characters')
     .describe(
       'Filename with extension (e.g. "main.py", "config.json"). Extension is used for language detection.',
     ),


### PR DESCRIPTION
## Summary

Autonomous security hardening sweep of the externally reachable web layer (REST route handlers, the `/mcp` endpoint, middleware, and the render/XSS surface).

Only mechanical, non-breaking fixes are included. Everything touching auth/authz logic, retention semantics or dependency versions is flagged in #432 instead of being changed here.

Three of the four fixes close **drift between the REST and MCP trust boundaries** — MCP was the more permissive surface in each case.

## Changes

| # | Kategorie | Severity | Datei | Fix |
| --- | --- | --- | --- | --- |
| 1 | H — Input validation drift (path/header injection defense-in-depth) | Medium | `src/server/tool-defs.ts` | MCP `FileInputSchema.filename` now uses the shared `isValidFilename` guard. The previous inline predicate rejected only `/`, `\`, `..` and NUL, so the MCP write path accepted C0/C1 control characters (incl. CR/LF) that REST and the raw-file route both reject. Stored filenames are reflected into `Content-Disposition` and into git paths by the GitHub backup. |
| 2 | A/I — Trust-boundary drift, unbounded payload | Medium | `src/server/tool-defs.ts` | MCP `update_stash` declared `name`/`description` as plain `z.string()`, making it the only write path with no size bound. Now capped at `MAX_NAME_LENGTH` / `MAX_DESCRIPTION_LENGTH`, matching `create_stash` and the REST `UpdateStashSchema`. |
| 3 | C — Prototype-chain lookup with attacker-controlled key | Low | `src/languages.ts` | `extensionToLanguage`, `languageNameToPrism` and `Prism.languages` were indexed with the user-controlled file language/filename, so `constructor` / `toString` / `__proto__` resolved to truthy `Object.prototype` members. All three lookups are now `hasOwnProperty`-guarded. Verified this was **not** a live XSS — Prism escapes its output for every such value — but an inherited value must never reach the highlighter, and the escaping fallback is the correct result for an unknown language. |
| 4 | F — Secret in log output | Low | `src/server/backup/device-poll.ts` | Both `console.warn` calls logged raw upstream error text. One wraps the only call carrying the freshly exchanged access token, the other wraps the device-code exchange. Both now go through `redactSecrets`, matching `/api/backup/token` and `backup-service`. |

All four are strictly tightening and symmetric with behaviour that already exists on another surface — no legitimate caller is affected.

## Testing

Full verification chain, green on the final commit:

- `npm ci`
- `npm run format:check` — passed
- `npx tsc --noEmit` — passed
- `npm test` — 415 passed, 5 skipped (40 files)
- `npm run build` — passed

## Checklist

- [x] Formatting passes (`npm run format:check`)
- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Changes are documented (if applicable) — rationale is inline at each call site; no user-facing docs affected

Refs #432

The issue also records 7 `security-flag` items (incl. one **High**: the `mcp` scope grants write/delete because no MCP tool re-checks a scope, and dependency CVEs) plus 3 deferred Low findings. None of those are addressed here — they need an owner decision or a dependency bump.


---
_Generated by [Claude Code](https://claude.ai/code/session_015j32RLAFK9ebyPz3sZoXoR)_