### PR TITLE
chore: quality & housekeeping sweep (Next.js)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,16 +12,6 @@ updates:
       # electron major: needs manual migration
       - dependency-name: 'electron'
         update-types: ['version-update:semver-major']
-  - package-ecosystem: 'npm'
-    directory: '/server'
-    schedule:
-      interval: 'weekly'
-    open-pull-requests-limit: 10
-    ignore:
-      - dependency-name: 'eslint'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'electron'
-        update-types: ['version-update:semver-major']
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:

--- a/agent_docs/project-structure.md
+++ b/agent_docs/project-structure.md
@@ -7,9 +7,13 @@ clawstash/
 ├── package.json                # Dependencies and scripts
 ├── tsconfig.json               # TypeScript config (strict, ES2022, Next.js plugin, @/* path alias)
 ├── next.config.ts              # Next.js config (standalone output, better-sqlite3 external)
+├── vitest.config.ts            # Vitest config (node env, @/* alias, src/**/*.{test,spec}.{ts,tsx})
 ├── Dockerfile                  # Multi-stage Docker build (Node 26-slim, Next.js standalone)
 ├── docker-compose.yml          # Docker Compose deployment
+├── docker-entrypoint.sh        # Container entrypoint: chown data dir as root, drop to `node` via setpriv
 ├── .env.example                # Environment variables template
+├── .prettierignore             # Prettier excludes (`.claude/` is excluded on purpose -- see MEMORY.md)
+├── test-data.http              # Manual REST scratch file: 20 sample stashes against localhost:3000
 ├── BACKLOG.md                  # Deferred review findings tracker
 ├── MEMORY.md                   # Session-spanning project knowledge (long-term)
 ├── SCRATCHPAD.md               # Temporary working context (short-term)
@@ -18,6 +22,16 @@ clawstash/
 │   ├── backlog_process.md      # Backlog tracking rules and format
 │   ├── memory_process.md       # Memory tracking rules and format
 │   ├── refactoring_guidelines.md  # Refactoring principles and rules
+│   ├── coding-conventions.md   # Full coding conventions (CLAUDE.md keeps the short list)
+│   ├── development-notes.md    # Runtime quirks, Docker/CI notes, refactoring candidates
+│   ├── key-patterns.md         # Full pattern reference (CLAUDE.md keeps the top 5)
+│   ├── env-vars.md             # Full environment-variable reference + secrets locations
+│   ├── context_budget.md       # Char budgets for CLAUDE/MEMORY/SCRATCHPAD + offload ladder
+│   ├── adr_template.md         # ADR format and triggers
+│   ├── ci_formatting_guard.md  # Optional husky + lint-staged pre-commit formatting guard
+│   ├── hooks_catalog.md        # Claude Code hook catalog (Tier-1 hooks in .claude/settings.json)
+│   ├── mcp_catalog.md          # Project-intended and common MCP servers
+│   ├── gitnexus.md             # GitNexus read-only policy (verbatim), CLI reference, skill map
 │   ├── diagram_prompt.md       # Architecture diagram generation instructions
 │   └── project-structure.md    # This file
 ├── docs/                       # User-facing documentation (split from README)
@@ -45,6 +59,7 @@ clawstash/
 ├── public/                     # Next.js static assets
 ├── src/
 │   ├── middleware.ts            # Next.js middleware (CORS, security headers)
+│   ├── instrumentation.ts       # Next.js boot hook: starts the GitHub backup scheduler (nodejs runtime only)
 │   ├── app/                    # Next.js App Router
 │   │   ├── layout.tsx          # Root layout with metadata + global CSS
 │   │   ├── page.tsx            # Client component wrapper for <App />
@@ -54,6 +69,7 @@ clawstash/
 │   │   │   └── route.ts        # MCP Streamable HTTP endpoint (POST/GET/DELETE)
 │   │   └── api/                # API Route Handlers
 │   │       ├── _helpers.ts     # Shared utilities (checkScope, checkAdmin, getBaseUrl)
+│   │       ├── __tests__/      # API helper unit tests (vitest: get-base-url)
 │   │       ├── health/route.ts # GET health check (no auth, DB status + stats)
 │   │       ├── stashes/
 │   │       │   ├── route.ts            # GET (list), POST (create)
@@ -132,6 +148,7 @@ clawstash/
 │   │   │   ├── backup-crypto.ts    # AES-256-GCM encryption for stored GitHub token
 │   │   │   ├── backup-scheduler.ts # BackupScheduler: mutation-debounce + interval sync
 │   │   │   ├── backup-service.ts   # BackupService: Git Data API sync engine
+│   │   │   ├── device-poll.ts      # Pure device-flow poll-response handling (unit-tested)
 │   │   │   ├── device-sessions.ts  # OAuth device-flow session management (in-memory)
 │   │   │   ├── github-client.ts    # GitHubClient: REST calls (repos, branches, Git Data API)
 │   │   │   └── __tests__/          # Backup unit tests (vitest)
@@ -142,11 +159,16 @@ clawstash/
 │   ├── languages.ts            # PrismJS language detection, mapping, highlighting
 │   ├── hooks/
 │   │   ├── useClipboard.ts     # useClipboard + useClipboardWithKey hooks
-│   │   └── useClickOutside.ts  # Click-outside detection hook (used by Sidebar, TagCombobox, MetadataEditor)
+│   │   ├── useClickOutside.ts  # Click-outside detection hook (used by Sidebar, TagCombobox, MetadataEditor)
+│   │   ├── useBodyScrollLock.ts # Lock background scrolling while a modal/overlay is open
+│   │   ├── useFocusTrap.ts     # Keep Tab focus inside an open dialog and restore it on close
+│   │   └── __tests__/          # Hook unit tests (vitest + @testing-library/react)
 │   ├── utils/
 │   │   ├── archived.ts         # localStorage persistence for the "show archived" dashboard toggle
 │   │   ├── clipboard.ts        # Copy-to-clipboard with fallback for non-HTTPS
 │   │   ├── constants.ts        # Shared client/server constants
+│   │   ├── contrast.ts         # Pick a readable label colour for text drawn onto canvas node shapes
+│   │   ├── dpr.ts              # Watch `devicePixelRatio` changes so canvas bitmaps stay crisp
 │   │   ├── favorites.ts        # Favorite-stash localStorage helpers
 │   │   ├── format.ts           # Date formatting (formatDate, formatDateTime, formatRelativeTime)
 │   │   ├── highlight.ts        # Split text into matched/unmatched segments to <mark> search terms
@@ -154,6 +176,7 @@ clawstash/
 │   │   ├── markdown.ts         # Markdown rendering for descriptions (Marked + sanitization)
 │   │   ├── mermaid.ts          # Lazy-loaded Mermaid renderer (shared util for .mmd files + inline ```mermaid blocks)
 │   │   ├── mermaid-hydrate.ts  # Hydrate inline ```mermaid placeholders inside rendered Markdown HTML
+│   │   ├── mermaid-zoom.ts     # Per-diagram zoom persistence in localStorage (LRU-capped)
 │   │   ├── recent-views.ts     # Recently-viewed stashes MRU list (localStorage) for the search overlay
 │   │   ├── sort.ts             # Dashboard sort-order state + pure sort helper
 │   │   ├── stash-url.ts        # Build a shareable deep-link URL for a stash
@@ -172,7 +195,7 @@ clawstash/
 │   │   ├── VersionHistory.tsx  # Version history list, Confluence-style inline comparison radios, restore button
 │   │   ├── VersionDiff.tsx     # GitHub-style diff view (green/red) using jsdiff
 │   │   ├── version-diff-utils.ts # Pure diff utilities extracted from VersionDiff (unit-tested)
-│   │   ├── __tests__/          # Component unit tests (vitest: version-diff-utils)
+│   │   ├── __tests__/          # Component unit tests (vitest: version-diff-utils, MarkdownBody, StashCard)
 │   │   ├── SearchOverlay.tsx   # Alt+K quick search overlay with keyboard navigation
 │   │   ├── LoginScreen.tsx     # Password login gate
 │   │   ├── MermaidDiagram.tsx  # React wrapper around renderMermaid() for .mmd files
@@ -194,14 +217,18 @@ clawstash/
 │   │   │   ├── RestTab.tsx     # REST API docs, Swagger explorer, examples
 │   │   │   ├── McpTab.tsx      # MCP Server config, tools, examples
 │   │   │   ├── SwaggerViewer.tsx # Swagger UI lazy-loader
+│   │   │   ├── CodeExample.tsx # Titled code snippet with a one-click copy button
+│   │   │   ├── SpecPreview.tsx # Spec text preview with spinner + fetch-failure state
 │   │   │   ├── api-data.ts    # Static data: endpoints, tools, scope labels, spec generators
 │   │   │   ├── icons.tsx       # API-specific icons
-│   │   │   └── useCopyToast.ts # Copy toast hook
+│   │   │   ├── useCopyToast.ts # Copy toast hook
+│   │   │   └── __tests__/      # API sub-component unit tests (vitest: api-data)
 │   │   └── editor/             # Stash editor sub-components
 │   │       ├── StashEditor.tsx # Main create/edit form with file management
 │   │       ├── FileCodeEditor.tsx # PrismJS code editor wrapper
 │   │       ├── TagCombobox.tsx # Tag input with autocomplete dropdown
-│   │       └── MetadataEditor.tsx # Key-value editor with suggestions
+│   │       ├── MetadataEditor.tsx # Key-value editor with suggestions
+│   │       └── __tests__/      # Editor unit tests (vitest: FileCodeEditor, metadata-entries)
 │   └── styles/
 │       └── app.css             # Global styles (CSS custom properties)
 └── data/                       # SQLite database directory (gitignored)

--- a/test-data.http
+++ b/test-data.http
@@ -1,5 +1,5 @@
-### Beispieldaten für ClawStash - 20 Stashes mit vollen Metadaten
-### Server muss auf localhost:3000 laufen
+### Sample data for ClawStash - 20 stashes with full metadata
+### The server must be running on localhost:3000
 
 @baseUrl = http://localhost:3000/api/stashes
 
@@ -9,7 +9,7 @@ Content-Type: application/json
 
 {
   "name": "Python String Utils",
-  "description": "Hilfsfunktionen für String-Manipulation in Python",
+  "description": "Helper functions for string manipulation in Python",
   "tags": ["python", "utils", "strings"],
   "metadata": {"project": "toolbox", "priority": "high", "author": "anna"},
   "files": [{"filename": "string_utils.py", "content": "def slugify(text: str) -> str:\n    import re\n    text = text.lower().strip()\n    return re.sub(r'[\\W_]+', '-', text)\n\ndef truncate(text: str, length: int = 100) -> str:\n    return text[:length] + '...' if len(text) > length else text", "language": "python"}]
@@ -21,7 +21,7 @@ Content-Type: application/json
 
 {
   "name": "useLocalStorage Hook",
-  "description": "Custom React Hook für localStorage mit TypeScript",
+  "description": "Custom React hook for localStorage with TypeScript",
   "tags": ["react", "typescript", "hooks"],
   "metadata": {"project": "frontend-lib", "priority": "medium", "author": "max"},
   "files": [{"filename": "useLocalStorage.ts", "content": "import { useState, useEffect } from 'react';\n\nexport function useLocalStorage<T>(key: string, initial: T) {\n  const [value, setValue] = useState<T>(() => {\n    const stored = localStorage.getItem(key);\n    return stored ? JSON.parse(stored) : initial;\n  });\n  useEffect(() => localStorage.setItem(key, JSON.stringify(value)), [key, value]);\n  return [value, setValue] as const;\n}", "language": "typescript"}]
@@ -33,7 +33,7 @@ Content-Type: application/json
 
 {
   "name": "Docker Compose PostgreSQL + Redis",
-  "description": "Standard Docker Compose Setup mit PostgreSQL und Redis",
+  "description": "Standard Docker Compose setup with PostgreSQL and Redis",
   "tags": ["docker", "postgres", "redis", "devops"],
   "metadata": {"project": "infrastructure", "priority": "high", "author": "anna"},
   "files": [{"filename": "docker-compose.yml", "content": "version: '3.8'\nservices:\n  db:\n    image: postgres:16\n    environment:\n      POSTGRES_PASSWORD: secret\n    ports:\n      - '5432:5432'\n    volumes:\n      - pgdata:/var/lib/postgresql/data\n  redis:\n    image: redis:7-alpine\n    ports:\n      - '6379:6379'\nvolumes:\n  pgdata:", "language": "yaml"}]
@@ -45,7 +45,7 @@ Content-Type: application/json
 
 {
   "name": "User Table Migration",
-  "description": "SQL Migration für User-Tabelle mit Rollen",
+  "description": "SQL migration for a user table with roles",
   "tags": ["sql", "postgres", "migration"],
   "metadata": {"project": "backend-api", "priority": "high", "author": "tom"},
   "files": [{"filename": "001_users.sql", "content": "CREATE TABLE users (\n  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n  email VARCHAR(255) UNIQUE NOT NULL,\n  name VARCHAR(100),\n  role VARCHAR(20) DEFAULT 'user',\n  created_at TIMESTAMPTZ DEFAULT NOW()\n);\nCREATE INDEX idx_users_email ON users(email);", "language": "sql"}, {"filename": "002_sessions.sql", "content": "CREATE TABLE sessions (\n  id UUID PRIMARY KEY,\n  user_id UUID REFERENCES users(id),\n  token TEXT NOT NULL,\n  expires_at TIMESTAMPTZ NOT NULL\n);", "language": "sql"}]
@@ -57,7 +57,7 @@ Content-Type: application/json
 
 {
   "name": "Deploy Script",
-  "description": "Automatisiertes Deployment-Script für Production",
+  "description": "Automated deployment script for production",
   "tags": ["bash", "devops", "deployment"],
   "metadata": {"project": "infrastructure", "priority": "critical", "author": "anna"},
   "files": [{"filename": "deploy.sh", "content": "#!/bin/bash\nset -euo pipefail\necho \"Deploying to production...\"\ngit pull origin main\nnpm ci --production\nnpm run build\npm2 restart all\necho \"Deploy complete!\"", "language": "bash"}]
@@ -69,7 +69,7 @@ Content-Type: application/json
 
 {
   "name": "Fetch API Wrapper",
-  "description": "Typsicherer Fetch-Wrapper mit Error Handling",
+  "description": "Type-safe fetch wrapper with error handling",
   "tags": ["typescript", "api", "utils"],
   "metadata": {"project": "frontend-lib", "priority": "high", "author": "max"},
   "files": [{"filename": "api-client.ts", "content": "type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';\n\nasync function request<T>(url: string, method: Method = 'GET', body?: unknown): Promise<T> {\n  const res = await fetch(url, {\n    method,\n    headers: { 'Content-Type': 'application/json' },\n    body: body ? JSON.stringify(body) : undefined,\n  });\n  if (!res.ok) throw new Error(`HTTP ${res.status}`);\n  return res.json();\n}", "language": "typescript"}]
@@ -81,7 +81,7 @@ Content-Type: application/json
 
 {
   "name": "Responsive Dashboard Grid",
-  "description": "CSS Grid Layout für ein responsives Dashboard",
+  "description": "CSS grid layout for a responsive dashboard",
   "tags": ["css", "layout", "responsive"],
   "metadata": {"project": "frontend-lib", "priority": "medium", "author": "lisa"},
   "files": [{"filename": "dashboard.css", "content": ".dashboard {\n  display: grid;\n  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));\n  gap: 1.5rem;\n  padding: 2rem;\n}\n.card {\n  background: var(--surface);\n  border-radius: 12px;\n  padding: 1.5rem;\n  box-shadow: 0 2px 8px rgba(0,0,0,0.1);\n}", "language": "css"}]
@@ -93,7 +93,7 @@ Content-Type: application/json
 
 {
   "name": "FastAPI CRUD Router",
-  "description": "Vollständiger CRUD Router für FastAPI mit Pydantic",
+  "description": "Complete CRUD router for FastAPI with Pydantic",
   "tags": ["python", "fastapi", "api"],
   "metadata": {"project": "backend-api", "priority": "high", "author": "tom"},
   "files": [{"filename": "router.py", "content": "from fastapi import APIRouter, HTTPException\nfrom pydantic import BaseModel\n\nrouter = APIRouter(prefix='/items')\n\nclass Item(BaseModel):\n    name: str\n    price: float\n\nitems: dict[str, Item] = {}\n\n@router.get('/')\ndef list_items():\n    return list(items.values())\n\n@router.post('/', status_code=201)\ndef create_item(item: Item):\n    items[item.name] = item\n    return item", "language": "python"}]
@@ -105,7 +105,7 @@ Content-Type: application/json
 
 {
   "name": "GitHub Actions Node CI",
-  "description": "CI Pipeline für Node.js Projekte mit Tests und Lint",
+  "description": "CI pipeline for Node.js projects with tests and lint",
   "tags": ["devops", "ci", "github-actions"],
   "metadata": {"project": "infrastructure", "priority": "medium", "author": "anna"},
   "files": [{"filename": "ci.yml", "content": "name: CI\non: [push, pull_request]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: npm ci\n      - run: npm run lint\n      - run: npm test", "language": "yaml"}]
@@ -117,7 +117,7 @@ Content-Type: application/json
 
 {
   "name": "Rust Custom Error Type",
-  "description": "Custom Error Type mit thiserror für Rust",
+  "description": "Custom error type with thiserror for Rust",
   "tags": ["rust", "error-handling", "utils"],
   "metadata": {"project": "toolbox", "priority": "medium", "author": "tom"},
   "files": [{"filename": "error.rs", "content": "use thiserror::Error;\n\n#[derive(Error, Debug)]\npub enum AppError {\n    #[error(\"Not found: {0}\")]\n    NotFound(String),\n    #[error(\"Unauthorized\")]\n    Unauthorized,\n    #[error(\"Database error: {0}\")]\n    Database(#[from] sqlx::Error),\n}", "language": "rust"}]
@@ -129,7 +129,7 @@ Content-Type: application/json
 
 {
   "name": "Modal Component",
-  "description": "Wiederverwendbare Modal-Komponente mit Portal",
+  "description": "Reusable modal component using a portal",
   "tags": ["react", "typescript", "components"],
   "metadata": {"project": "frontend-lib", "priority": "medium", "author": "lisa"},
   "files": [{"filename": "Modal.tsx", "content": "import { ReactNode } from 'react';\nimport { createPortal } from 'react-dom';\n\ninterface Props {\n  open: boolean;\n  onClose: () => void;\n  children: ReactNode;\n}\n\nexport function Modal({ open, onClose, children }: Props) {\n  if (!open) return null;\n  return createPortal(\n    <div className=\"modal-overlay\" onClick={onClose}>\n      <div className=\"modal-content\" onClick={e => e.stopPropagation()}>\n        {children}\n      </div>\n    </div>,\n    document.body\n  );\n}", "language": "typescript"}]
@@ -141,7 +141,7 @@ Content-Type: application/json
 
 {
   "name": "Structured Logging Setup",
-  "description": "Strukturiertes Logging mit structlog für Python",
+  "description": "Structured logging with structlog for Python",
   "tags": ["python", "logging", "config"],
   "metadata": {"project": "backend-api", "priority": "low", "author": "anna"},
   "files": [{"filename": "logging_config.py", "content": "import structlog\nimport logging\n\ndef setup_logging(level='INFO'):\n    structlog.configure(\n        processors=[\n            structlog.stdlib.filter_by_level,\n            structlog.stdlib.add_log_level,\n            structlog.processors.TimeStamper(fmt='iso'),\n            structlog.processors.JSONRenderer()\n        ],\n        wrapper_class=structlog.stdlib.BoundLogger,\n        logger_factory=structlog.stdlib.LoggerFactory(),\n    )\n    logging.basicConfig(level=getattr(logging, level))", "language": "python"}]
@@ -153,7 +153,7 @@ Content-Type: application/json
 
 {
   "name": "Nginx Reverse Proxy",
-  "description": "Nginx Konfiguration als Reverse Proxy mit SSL",
+  "description": "Nginx configuration as a reverse proxy with SSL",
   "tags": ["devops", "nginx", "config"],
   "metadata": {"project": "infrastructure", "priority": "high", "author": "tom"},
   "files": [{"filename": "nginx.conf", "content": "server {\n    listen 443 ssl;\n    server_name example.com;\n    ssl_certificate /etc/ssl/cert.pem;\n    ssl_certificate_key /etc/ssl/key.pem;\n\n    location / {\n        proxy_pass http://localhost:3000;\n        proxy_set_header Host $host;\n        proxy_set_header X-Real-IP $remote_addr;\n    }\n\n    location /api {\n        proxy_pass http://localhost:3000;\n    }\n}", "language": "nginx"}]
@@ -165,7 +165,7 @@ Content-Type: application/json
 
 {
   "name": "Go JSON Handler",
-  "description": "HTTP Handler Pattern in Go mit JSON Response",
+  "description": "HTTP handler pattern in Go with a JSON response",
   "tags": ["go", "api", "utils"],
   "metadata": {"project": "toolbox", "priority": "medium", "author": "max"},
   "files": [{"filename": "handler.go", "content": "package main\n\nimport (\n\t\"encoding/json\"\n\t\"net/http\"\n)\n\nfunc jsonResponse(w http.ResponseWriter, data any, status int) {\n\tw.Header().Set(\"Content-Type\", \"application/json\")\n\tw.WriteHeader(status)\n\tjson.NewEncoder(w).Encode(data)\n}\n\nfunc healthHandler(w http.ResponseWriter, r *http.Request) {\n\tjsonResponse(w, map[string]string{\"status\": \"ok\"}, 200)\n}", "language": "go"}]
@@ -177,7 +177,7 @@ Content-Type: application/json
 
 {
   "name": "Jest Test Helpers",
-  "description": "Hilfsfunktionen und Custom Matchers für Jest Tests",
+  "description": "Helper functions and custom matchers for Jest tests",
   "tags": ["typescript", "testing", "utils"],
   "metadata": {"project": "frontend-lib", "priority": "low", "author": "lisa"},
   "files": [{"filename": "test-utils.ts", "content": "import { render, RenderOptions } from '@testing-library/react';\nimport { ReactElement } from 'react';\n\nexport function renderWithProviders(ui: ReactElement, options?: RenderOptions) {\n  return render(ui, { ...options });\n}\n\nexport function mockFetch(data: unknown, status = 200) {\n  global.fetch = jest.fn().mockResolvedValue({\n    ok: status < 400,\n    status,\n    json: async () => data,\n  });\n}", "language": "typescript"}]
@@ -189,7 +189,7 @@ Content-Type: application/json
 
 {
   "name": "K8s Deployment Manifest",
-  "description": "Kubernetes Deployment und Service für eine Web-App",
+  "description": "Kubernetes deployment and service for a web app",
   "tags": ["devops", "kubernetes", "docker"],
   "metadata": {"project": "infrastructure", "priority": "critical", "author": "anna"},
   "files": [{"filename": "deployment.yaml", "content": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web-app\nspec:\n  replicas: 3\n  selector:\n    matchLabels:\n      app: web-app\n  template:\n    metadata:\n      labels:\n        app: web-app\n    spec:\n      containers:\n        - name: app\n          image: myapp:latest\n          ports:\n            - containerPort: 3000", "language": "yaml"}, {"filename": "service.yaml", "content": "apiVersion: v1\nkind: Service\nmetadata:\n  name: web-app-svc\nspec:\n  type: LoadBalancer\n  ports:\n    - port: 80\n      targetPort: 3000\n  selector:\n    app: web-app", "language": "yaml"}]
@@ -201,7 +201,7 @@ Content-Type: application/json
 
 {
   "name": "CSV Data Pipeline",
-  "description": "Einfache ETL-Pipeline für CSV-Daten mit pandas",
+  "description": "Simple ETL pipeline for CSV data with pandas",
   "tags": ["python", "data", "etl"],
   "metadata": {"project": "data-tools", "priority": "high", "author": "tom"},
   "files": [{"filename": "pipeline.py", "content": "import pandas as pd\nfrom pathlib import Path\n\ndef extract(path: str) -> pd.DataFrame:\n    return pd.read_csv(path)\n\ndef transform(df: pd.DataFrame) -> pd.DataFrame:\n    df = df.dropna()\n    df['created'] = pd.to_datetime(df['created'])\n    return df.sort_values('created')\n\ndef load(df: pd.DataFrame, output: str):\n    Path(output).parent.mkdir(parents=True, exist_ok=True)\n    df.to_parquet(output, index=False)", "language": "python"}]
@@ -213,7 +213,7 @@ Content-Type: application/json
 
 {
   "name": "Tailwind + Dark Mode Config",
-  "description": "Tailwind CSS Konfiguration mit Custom Theme und Dark Mode",
+  "description": "Tailwind CSS configuration with a custom theme and dark mode",
   "tags": ["css", "config", "responsive"],
   "metadata": {"project": "frontend-lib", "priority": "low", "author": "lisa"},
   "files": [{"filename": "tailwind.config.js", "content": "/** @type {import('tailwindcss').Config} */\nmodule.exports = {\n  darkMode: 'class',\n  content: ['./src/**/*.{ts,tsx}'],\n  theme: {\n    extend: {\n      colors: {\n        primary: { 500: '#6366f1', 600: '#4f46e5' },\n        surface: { light: '#ffffff', dark: '#1e1e2e' },\n      },\n      fontFamily: { sans: ['Inter', 'sans-serif'] },\n    },\n  },\n  plugins: [],\n};", "language": "javascript"}]
@@ -225,7 +225,7 @@ Content-Type: application/json
 
 {
   "name": "Clap CLI Argument Parser",
-  "description": "CLI Argument Parsing mit clap für Rust",
+  "description": "CLI argument parsing with clap for Rust",
   "tags": ["rust", "cli", "utils"],
   "metadata": {"project": "toolbox", "priority": "medium", "author": "max"},
   "files": [{"filename": "cli.rs", "content": "use clap::Parser;\n\n#[derive(Parser, Debug)]\n#[command(name = \"mytool\", about = \"A useful CLI tool\")]\npub struct Cli {\n    /// Input file path\n    #[arg(short, long)]\n    pub input: String,\n\n    /// Output format\n    #[arg(short, long, default_value = \"json\")]\n    pub format: String,\n\n    /// Verbose output\n    #[arg(short, long)]\n    pub verbose: bool,\n}", "language": "rust"}]
@@ -237,7 +237,7 @@ Content-Type: application/json
 
 {
   "name": "Analytics SQL Queries",
-  "description": "Nützliche SQL Queries für User-Analytics und Reporting",
+  "description": "Useful SQL queries for user analytics and reporting",
   "tags": ["sql", "data", "postgres"],
   "metadata": {"project": "data-tools", "priority": "high", "author": "anna"},
   "files": [{"filename": "analytics.sql", "content": "-- Daily active users\nSELECT DATE(created_at) as day, COUNT(DISTINCT user_id) as dau\nFROM events\nWHERE created_at >= NOW() - INTERVAL '30 days'\nGROUP BY day ORDER BY day;\n\n-- Retention cohort\nSELECT\n  DATE_TRUNC('week', u.created_at) as cohort,\n  COUNT(DISTINCT u.id) as users,\n  COUNT(DISTINCT e.user_id) as retained\nFROM users u\nLEFT JOIN events e ON u.id = e.user_id\n  AND e.created_at >= u.created_at + INTERVAL '7 days'\nGROUP BY cohort ORDER BY cohort;", "language": "sql"}, {"filename": "funnel.sql", "content": "-- Conversion funnel\nWITH steps AS (\n  SELECT user_id,\n    MAX(CASE WHEN event = 'visit' THEN 1 END) as visited,\n    MAX(CASE WHEN event = 'signup' THEN 1 END) as signed_up,\n    MAX(CASE WHEN event = 'purchase' THEN 1 END) as purchased\n  FROM events GROUP BY user_id\n)\nSELECT\n  COUNT(*) as total,\n  SUM(visited) as visits,\n  SUM(signed_up) as signups,\n  SUM(purchased) as purchases\nFROM steps;", "language": "sql"}]


### PR DESCRIPTION
## Summary

Autonomous quality & housekeeping sweep. Three mechanical, behaviour-preserving fixes — two documentation/consistency, one dead config entry. No runtime code is touched.

**No version bumps are included.** `package.json` and `package-lock.json` are unchanged, and no Dependabot PR was touched, reviewed, commented on or closed.

## Changes

| # | Pass | Datei(en) | Befund | Fix | Aufwand | Empfehlung |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | E — Docs | `agent_docs/project-structure.md` | Tree drifted from the repo: 9 source modules (`instrumentation.ts`, `useBodyScrollLock`, `useFocusTrap`, `contrast`, `dpr`, `mermaid-zoom`, `device-poll`, `CodeExample`, `SpecPreview`), 4 `__tests__/` directories and 10 `agent_docs/` files were missing, plus `vitest.config.ts`, `docker-entrypoint.sh`, `.prettierignore`, `test-data.http` | Added the missing entries with one-line descriptions | M | auto-fix |
| 2 | E — Docs | `test-data.http` | German header comments + 20 German sample `description` values contradict the English-only rule in `CLAUDE.md` → Output Languages | Translated comments and description payloads to English; requests, filenames and file contents untouched, all 20 JSON bodies still parse | M | auto-fix |
| 3 | F — Cleanup | `.github/dependabot.yml` | An `npm` update block points at `/server`, a directory that does not exist and (per `git log --all`) never did — Dependabot resolves no manifest for it on every weekly run | Removed the dead block; the `eslint`/`electron` ignores stay | S | auto-fix |

Deferred (not in this PR, tracked in the issue): no linter configured repo-wide (L), and the unreferenced `closeDb()` export in `src/server/singleton.ts` (S).

## Testing

Full local chain per `CLAUDE.md`, green on the final commit:

| Tool | Aktiv | Konfiguriert in | Lief grün |
| --- | --- | --- | --- |
| Prettier (`format:check`) | ja | `.prettierrc.json` + `.prettierignore` + npm script | ja — no drift |
| ESLint / linter | **nein** | — | n/a — none configured |
| TypeScript (`npx tsc --noEmit`) | ja | `tsconfig.json` | ja |
| vitest (`npm test`) | ja | `vitest.config.ts` | ja — 40 files, 415 passed, 5 skipped |
| Next.js build (`npm run build`) | ja | `next.config.ts` | ja |

## Checklist

- [x] Formatting passes (`npm run format:check`)
- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Changes are documented (if applicable)

Closes #439


---
_Generated by [Claude Code](https://claude.ai/code/session_01D9ofyDMpLYgQNfVf5sTsc5)_