### PR TITLE
feat: comfort sweep (Next.js)

### DIFF
--- a/docs/ARCHITECTURE.mmd
+++ b/docs/ARCHITECTURE.mmd
@@ -16,7 +16,7 @@ flowchart TD
             StashEditor("StashEditor (Create/Edit)")
             GraphViewer("GraphViewer (Tag Graph Canvas)")
             Settings("Settings (Admin Area)")
-            SearchOverlay("SearchOverlay (Alt+K)")
+            SearchOverlay("SearchOverlay (Ctrl/Cmd+K)")
         end
 
         subgraph "API Route Handlers"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -768,6 +768,24 @@ export default function App() {
     setLoadedPages(1);
   };
 
+  /**
+   * "Show all N" from the quick-search overlay: run the same query as the
+   * dashboard's own search and go there. The overlay counts matches without a
+   * tag filter, so an active tag filter is cleared — leaving it on would land
+   * the user on a handful of rows right after promising N matches.
+   * `showArchived` is left alone: it only ever widens the result set, and it
+   * is a persisted, deliberate preference.
+   */
+  const handleSearchAll = (query: string) => {
+    if (!confirmDiscardUnsaved()) return;
+    handleSearchChange(query);
+    setFilterTag('');
+    setSelectedStash(null);
+    setView('home');
+    pushUrl('/');
+    setSidebarOpen(false);
+  };
+
   const handleFilterTag = (tag: string) => {
     const newTag = tag === filterTagRef.current ? '' : tag;
     setFilterTag(newTag);
@@ -1040,6 +1058,7 @@ export default function App() {
         open={searchOpen}
         onClose={() => setSearchOpen(false)}
         onSelectStash={handleSelectStash}
+        onSearchAll={handleSearchAll}
       />
       <KeyboardShortcutsHelp open={shortcutsHelpOpen} onClose={() => setShortcutsHelpOpen(false)} />
       {successToast && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,18 +159,29 @@ export default function App() {
 
   // Mirror auth state for the dependency-free hotkey handlers. Without this
   // guard, hotkeys fire on the login screen — 'n' mutates view state + URL,
-  // 'a' toggles + persists showArchived, ?/Alt+K open modals — all pre-auth.
+  // 'a' toggles + persists showArchived, ? / quick-search open modals — all pre-auth.
   const isAuthedRef = useRef(false);
   useEffect(() => {
     isAuthedRef.current =
       adminSession !== null && (adminSession.authenticated || !adminSession.authRequired);
   }, [adminSession]);
 
-  // Global Alt+K shortcut for quick search
+  // Global quick-search shortcut. Ctrl+K / Cmd+K is the accelerator every
+  // comparable tool uses (GitHub, Linear, Slack, VS Code), so it is what users
+  // reach for first; Alt+K stays as the original binding. Both are handled
+  // here rather than in the hotkey effect below, which deliberately ignores
+  // every modified keystroke.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.altKey && e.key.toLowerCase() === 'k') {
+      if (e.key.toLowerCase() !== 'k') return;
+      // Ctrl+K and Cmd+K only when they are the ONLY modifier — Ctrl+Shift+K
+      // and friends belong to the browser (and to any future binding).
+      const accelerator =
+        (e.altKey && !e.ctrlKey && !e.metaKey) || ((e.ctrlKey || e.metaKey) && !e.altKey);
+      if (accelerator && !e.shiftKey) {
         if (!isAuthedRef.current) return;
+        // Ctrl+K focuses the browser's search bar in Firefox/Chrome, so this
+        // has to be claimed explicitly.
         e.preventDefault();
         // No-op while the shortcuts help dialog is open — toggling search on
         // top would stack both modals (double-Escape needed to get out).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -965,6 +965,8 @@ export default function App() {
               onBack={handleGoHome}
               onAnalyzeStash={handleAnalyzeStash}
               onFilterTag={handleViewerFilterTag}
+              isFavorite={favoriteIds.has(selectedStash.id)}
+              onToggleFavorite={handleToggleFavorite}
               onStashUpdated={(stash) => {
                 setSelectedStash(stash);
                 loadStashes();

--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
+import { useQuickSearchHint } from '../hooks/useQuickSearchHint';
 
 interface Props {
   open: boolean;
@@ -12,7 +13,12 @@ interface ShortcutGroup {
   shortcuts: { keys: string[]; description: string }[];
 }
 
-const SHORTCUT_GROUPS: ShortcutGroup[] = [
+/**
+ * Groups that do not depend on the platform. The Search group is built at
+ * render time because its primary accelerator is labelled per platform
+ * ("⌘K" vs "Ctrl+K").
+ */
+const STATIC_SHORTCUT_GROUPS: ShortcutGroup[] = [
   {
     label: 'Navigation',
     shortcuts: [
@@ -21,13 +27,6 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: ['a'], description: 'Toggle archived stashes on the dashboard' },
       { keys: ['Esc'], description: 'Back to dashboard / close overlay' },
       { keys: ['?'], description: 'Show / hide keyboard shortcuts' },
-    ],
-  },
-  {
-    label: 'Search',
-    shortcuts: [
-      { keys: ['Alt', 'K'], description: 'Open quick search' },
-      { keys: ['/'], description: 'Focus sidebar search' },
     ],
   },
   {
@@ -45,9 +44,27 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
   },
 ];
 
+/**
+ * Insert the Search group after Navigation, with the platform's own quick-search
+ * accelerator first and the original Alt+K binding listed as the alternative.
+ */
+function buildShortcutGroups(quickSearchKey: string): ShortcutGroup[] {
+  const search: ShortcutGroup = {
+    label: 'Search',
+    shortcuts: [
+      { keys: [quickSearchKey], description: 'Open quick search' },
+      { keys: ['Alt', 'K'], description: 'Open quick search (alternative)' },
+      { keys: ['/'], description: 'Focus sidebar search' },
+    ],
+  };
+  return [STATIC_SHORTCUT_GROUPS[0], search, ...STATIC_SHORTCUT_GROUPS.slice(1)];
+}
+
 export default function KeyboardShortcutsHelp({ open, onClose }: Props) {
   const closeBtnRef = useRef<HTMLButtonElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
+  const quickSearchKey = useQuickSearchHint();
+  const groups = buildShortcutGroups(quickSearchKey);
 
   // Close on Escape
   useEffect(() => {
@@ -111,7 +128,7 @@ export default function KeyboardShortcutsHelp({ open, onClose }: Props) {
           </button>
         </div>
         <div className="shortcuts-help-body">
-          {SHORTCUT_GROUPS.map((group) => (
+          {groups.map((group) => (
             <div key={group.label} className="shortcuts-group">
               <div className="shortcuts-group-label">{group.label}</div>
               <table className="shortcuts-table">

--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -13,9 +13,16 @@ interface Props {
   open: boolean;
   onClose: () => void;
   onSelectStash: (id: string) => void;
+  /**
+   * Hand the current query to the dashboard's own search. The overlay caps its
+   * result list, so a query matching more stashes than fit used to dead-end at
+   * "refine to narrow" — the dashboard is capped too, but offers "Load more"
+   * up to the full total.
+   */
+  onSearchAll: (query: string) => void;
 }
 
-export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
+export default function SearchOverlay({ open, onClose, onSelectStash, onSearchAll }: Props) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<StashListItem[]>([]);
   // Full server-side match count. The result list is capped (see the `limit`
@@ -173,6 +180,15 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
     onClose();
   };
 
+  // Escape hatch for a capped result list: push the query into the dashboard
+  // search, which pages up to the full match count, and close the overlay.
+  const handleShowAll = () => {
+    const q = query.trim();
+    if (!q) return;
+    onSearchAll(q);
+    onClose();
+  };
+
   // Arrow/Enter navigation targets whichever list is on screen: search results
   // when a query is present, otherwise the "Recently viewed" shortcuts. Both
   // item shapes expose an `id`, so selection is uniform.
@@ -303,10 +319,25 @@ export default function SearchOverlay({ open, onClose, onSelectStash }: Props) {
                 status row nested inside made assistive tech announce it as
                 one of the results. Keeping it above also stops the count from
                 scrolling out of view with the list. */}
-            <div className="search-overlay-results-count" aria-live="polite" role="status">
-              {total > results.length
-                ? `Showing first ${results.length} of ${total} matches — refine to narrow`
-                : `${results.length} result${results.length !== 1 ? 's' : ''}`}
+            {/* The row is a plain flex container; only the text carries the
+                live region. An interactive control inside `aria-live` would be
+                re-announced on every keystroke that changes the count. */}
+            <div className="search-overlay-results-count">
+              <span aria-live="polite" role="status">
+                {total > results.length
+                  ? `Showing first ${results.length} of ${total} matches`
+                  : `${results.length} result${results.length !== 1 ? 's' : ''}`}
+              </span>
+              {total > results.length && (
+                <button
+                  type="button"
+                  className="search-overlay-show-all"
+                  onClick={handleShowAll}
+                  title={`Search the dashboard for "${query.trim()}" to page through all ${total} matches`}
+                >
+                  Show all {total}
+                </button>
+              )}
             </div>
             <div
               className="search-overlay-results"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback } from 'react';
 import { useClickOutside } from '../hooks/useClickOutside';
+import { useQuickSearchHint } from '../hooks/useQuickSearchHint';
 import type { JSX } from 'react';
 import type { StashListItem, SettingsSection, TagInfo } from '../types';
 import { formatDate } from '../utils/format';
@@ -186,6 +187,9 @@ export default function Sidebar({
   const [tagDropdownOpen, setTagDropdownOpen] = useState(false);
   const [tagSearch, setTagSearch] = useState('');
   const tagFilterRef = useRef<HTMLDivElement>(null);
+  // "⌘K" on Apple platforms, "Ctrl+K" elsewhere. Alt+K still works and stays
+  // in the tooltip, but the hint shows the accelerator users reach for.
+  const quickSearchKey = useQuickSearchHint();
 
   const closeTagDropdown = useCallback(() => {
     setTagDropdownOpen(false);
@@ -302,7 +306,7 @@ export default function Sidebar({
                   }
                 }}
                 className="search-input"
-                title="Search by name, filename, or content — / to focus, Esc to clear, Alt+K for quick search"
+                title={`Search by name, filename, or content — / to focus, Esc to clear, ${quickSearchKey} (or Alt+K) for quick search`}
                 aria-label="Search stashes"
               />
               {search ? (
@@ -318,8 +322,11 @@ export default function Sidebar({
                   </svg>
                 </button>
               ) : (
-                <kbd className="search-input-kbd" title="Alt+K for quick search overlay">
-                  Alt+K
+                <kbd
+                  className="search-input-kbd"
+                  title={`${quickSearchKey} (or Alt+K) for the quick search overlay`}
+                >
+                  {quickSearchKey}
                 </kbd>
               )}
             </div>

--- a/src/components/StashCard.tsx
+++ b/src/components/StashCard.tsx
@@ -3,6 +3,7 @@ import type { StashListItem, LayoutMode } from '../types';
 import { renderDescriptionMarkdown } from '../utils/markdown';
 import { formatBytes } from '../utils/format';
 import RelativeTime from './shared/RelativeTime';
+import { StarIcon } from './shared/icons';
 
 interface Props {
   stash: StashListItem;
@@ -84,24 +85,7 @@ export default function StashCard({
           title={isFavorite ? 'Unpin from top' : 'Pin to top'}
           data-testid="favorite-toggle"
         >
-          {isFavorite ? (
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-              <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
-            </svg>
-          ) : (
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 16 16"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M8 1.25 9.882 5.065l4.21.612-3.046 2.97.719 4.192L8 10.86l-3.765 1.98.72-4.194L1.908 5.677l4.21-.612L8 1.25Z" />
-            </svg>
-          )}
+          <StarIcon filled={isFavorite} />
         </button>
       </div>
 

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -10,7 +10,7 @@ import {
 } from '../languages';
 import RelativeTime from './shared/RelativeTime';
 import { useClipboard, useClipboardWithKey } from '../hooks/useClipboard';
-import { CopyIcon, CheckIcon, XIcon } from './shared/icons';
+import { CopyIcon, CheckIcon, XIcon, StarIcon } from './shared/icons';
 import VersionHistory from './VersionHistory';
 import { Marked } from 'marked';
 import { renderDescriptionMarkdown, isUnsafeUrl, sanitizeHtml } from '../utils/markdown';
@@ -40,6 +40,14 @@ interface Props {
    * handler they looked interactive but did nothing.
    */
   onFilterTag: (tag: string) => void;
+  /**
+   * Whether this stash is pinned to the top of the dashboard. Favoriting was
+   * previously reachable only from the dashboard card, so the moment a stash
+   * turns out to be worth keeping — while reading it — the user had to go
+   * back and hunt for its card. Same localStorage-backed state as the card.
+   */
+  isFavorite: boolean;
+  onToggleFavorite: (id: string) => void;
   onStashUpdated?: (stash: Stash) => void;
   // Fired specifically when a previous version is restored from the history
   // tab, so the shell can surface a success toast. Restoring previously gave
@@ -429,6 +437,8 @@ export default function StashViewer({
   onBack,
   onAnalyzeStash,
   onFilterTag,
+  isFavorite,
+  onToggleFavorite,
   onStashUpdated,
   onVersionRestored,
 }: Props) {
@@ -842,6 +852,19 @@ export default function StashViewer({
               labelCopied=""
               labelFailed=""
             />
+          </button>
+          {/* Mirrors the dashboard card's star: same state, same wording, so
+              a stash can be pinned while it is being read. */}
+          <button
+            type="button"
+            className={`stash-card-favorite-btn viewer-favorite-btn${isFavorite ? ' is-favorite' : ''}`}
+            onClick={() => onToggleFavorite(stash.id)}
+            aria-pressed={isFavorite}
+            aria-label={isFavorite ? `Unpin "${title}" from top` : `Pin "${title}" to top`}
+            title={isFavorite ? 'Unpin from top' : 'Pin to top'}
+            data-testid="viewer-favorite-toggle"
+          >
+            <StarIcon filled={isFavorite} />
           </button>
         </h2>
         <div className="viewer-actions">

--- a/src/components/__tests__/SearchOverlay.showall.test.tsx
+++ b/src/components/__tests__/SearchOverlay.showall.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import SearchOverlay from '../SearchOverlay';
+import type { StashListItem } from '../../types';
+
+const listStashes = vi.fn();
+vi.mock('../../api', () => ({
+  api: {
+    listStashes: (...args: unknown[]) => listStashes(...args),
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  listStashes.mockReset();
+});
+
+function stash(n: number): StashListItem {
+  return {
+    id: `id-${n}`,
+    name: `Stash ${n}`,
+    description: '',
+    tags: [],
+    version: 1,
+    archived: false,
+    backup_enabled: true,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    total_size: 1,
+    files: [],
+  };
+}
+
+/** Render the overlay and run a query that the server reports as capped. */
+async function renderCapped(total: number, query = '  config  ') {
+  const onSearchAll = vi.fn();
+  const onClose = vi.fn();
+  const results = Array.from({ length: 12 }, (_, i) => stash(i));
+  listStashes.mockResolvedValue({ stashes: results, total });
+
+  render(
+    <SearchOverlay open onClose={onClose} onSelectStash={vi.fn()} onSearchAll={onSearchAll} />,
+  );
+  fireEvent.change(screen.getByLabelText('Search stashes'), { target: { value: query } });
+  await waitFor(() => expect(screen.getAllByRole('option').length).toBe(12));
+  return { onSearchAll, onClose };
+}
+
+describe('SearchOverlay "Show all" escape hatch', () => {
+  it('offers the full result set when the list is capped', async () => {
+    await renderCapped(84);
+    expect(screen.getByRole('button', { name: /show all 84/i })).toBeTruthy();
+    expect(screen.getByText(/Showing first 12 of 84 matches/)).toBeTruthy();
+  });
+
+  it('hands the trimmed query to the dashboard and closes', async () => {
+    const { onSearchAll, onClose } = await renderCapped(84);
+    fireEvent.click(screen.getByRole('button', { name: /show all 84/i }));
+    expect(onSearchAll).toHaveBeenCalledWith('config');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('stays hidden when every match is already on screen', async () => {
+    await renderCapped(12);
+    expect(screen.queryByRole('button', { name: /show all/i })).toBeNull();
+    expect(screen.getByText('12 results')).toBeTruthy();
+  });
+
+  it('keeps the interactive control out of the live region', async () => {
+    await renderCapped(84);
+    // An `aria-live` region containing a button is re-announced on every
+    // keystroke that changes the count — the button is a sibling of the text.
+    const live = document.querySelector('.search-overlay-results-count [aria-live]')!;
+    expect(live).toBeTruthy();
+    expect(live.querySelector('button')).toBeNull();
+    expect(document.querySelector('.search-overlay-show-all')).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/StashViewer.favorite.test.tsx
+++ b/src/components/__tests__/StashViewer.favorite.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import StashViewer from '../StashViewer';
+import type { Stash } from '../../types';
+
+afterEach(cleanup);
+
+const STASH: Stash = {
+  id: 'abc',
+  name: 'My stash',
+  description: '',
+  tags: [],
+  metadata: {},
+  version: 1,
+  archived: false,
+  backup_enabled: true,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  files: [
+    {
+      id: 'f1',
+      stash_id: 'abc',
+      filename: 'a.txt',
+      content: 'hello',
+      language: 'text',
+      sort_order: 0,
+    },
+  ],
+};
+
+function renderViewer(isFavorite: boolean, onToggleFavorite = vi.fn()) {
+  const view = render(
+    <StashViewer
+      stash={STASH}
+      onEdit={vi.fn()}
+      onDelete={vi.fn()}
+      onArchive={vi.fn()}
+      onBack={vi.fn()}
+      onAnalyzeStash={vi.fn()}
+      onFilterTag={vi.fn()}
+      isFavorite={isFavorite}
+      onToggleFavorite={onToggleFavorite}
+    />,
+  );
+  return { ...view, onToggleFavorite };
+}
+
+describe('StashViewer favorite toggle', () => {
+  it('renders the toggle in the unpinned state', () => {
+    const { container } = renderViewer(false);
+    const btn = container.querySelector('[data-testid="viewer-favorite-toggle"]')!;
+    expect(btn).toBeTruthy();
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+    expect(btn.className).not.toContain('is-favorite');
+    expect(btn.getAttribute('aria-label')).toBe('Pin "My stash" to top');
+  });
+
+  it('reflects the pinned state', () => {
+    const { container } = renderViewer(true);
+    const btn = container.querySelector('[data-testid="viewer-favorite-toggle"]')!;
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+    expect(btn.className).toContain('is-favorite');
+    expect(btn.getAttribute('aria-label')).toBe('Unpin "My stash" from top');
+  });
+
+  it('reports the stash id so the shell can persist the change', () => {
+    const { container, onToggleFavorite } = renderViewer(false);
+    const btn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="viewer-favorite-toggle"]',
+    )!;
+    btn.click();
+    expect(onToggleFavorite).toHaveBeenCalledWith('abc');
+  });
+});

--- a/src/components/shared/icons.tsx
+++ b/src/components/shared/icons.tsx
@@ -37,6 +37,41 @@ export function CheckIcon({ size = 12 }: IconProps) {
   );
 }
 
+interface StarIconProps extends IconProps {
+  /** Solid star when the item is a favorite, outline when it is not. */
+  filled: boolean;
+}
+
+/**
+ * Octicon-style star icon for the favorite ("pin to top") toggle.
+ *
+ * Shared by `StashCard` and `StashViewer` so the same stash renders the same
+ * glyph on the dashboard and in the viewer.
+ */
+export function StarIcon({ filled, size = 14 }: StarIconProps) {
+  if (filled) {
+    return (
+      <svg aria-hidden="true" width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
+        <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+      </svg>
+    );
+  }
+  return (
+    <svg
+      aria-hidden="true"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+    >
+      <path d="M8 1.25 9.882 5.065l4.21.612-3.046 2.97.719 4.192L8 10.86l-3.765 1.98.72-4.194L1.908 5.677l4.21-.612L8 1.25Z" />
+    </svg>
+  );
+}
+
 /** Octicon-style X/cross icon for error states. */
 export function XIcon({ size = 12 }: IconProps) {
   return (

--- a/src/hooks/useQuickSearchHint.ts
+++ b/src/hooks/useQuickSearchHint.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+import { QUICK_SEARCH_HINT_DEFAULT, quickSearchHint } from '../utils/platform';
+
+/**
+ * The quick-search accelerator label for the current platform.
+ *
+ * Resolved after mount on purpose: `navigator` does not exist during the
+ * server render, so reading it inline would make the server and the first
+ * client render disagree and trip React's hydration check. Starts at the
+ * non-Mac label and refines to "⌘K" on Apple platforms.
+ */
+export function useQuickSearchHint(): string {
+  const [hint, setHint] = useState(QUICK_SEARCH_HINT_DEFAULT);
+  useEffect(() => {
+    setHint(quickSearchHint());
+  }, []);
+  return hint;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -914,11 +914,41 @@ body {
 }
 
 .search-overlay-results-count {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   padding: 4px 16px 2px;
   font-size: 11px;
   color: var(--text-muted);
   border-bottom: 1px solid var(--border-color);
   margin-bottom: 2px;
+}
+
+/* "Show all N" — the way out of a capped result list, into the dashboard
+   search which pages up to the full total. */
+.search-overlay-show-all {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--accent-blue);
+  font-size: 11px;
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    color 0.12s,
+    background 0.12s;
+}
+
+.search-overlay-show-all:hover {
+  background: rgba(88, 166, 255, 0.12);
+}
+
+.search-overlay-show-all:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 1px;
 }
 
 .search-overlay-item {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1832,6 +1832,14 @@ body {
   color: var(--text-secondary);
 }
 
+/* Favorite toggle in the viewer title. Inherits look + interaction states from
+   `.stash-card-favorite-btn`; unlike the copy button next to it, it is never
+   hover-revealed — a pinned star has to be readable at a glance. */
+.viewer-favorite-btn {
+  margin-left: 2px;
+  vertical-align: middle;
+}
+
 .viewer-archived-badge {
   display: inline-block;
   margin-left: 8px;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -214,7 +214,7 @@ body {
   pointer-events: none;
 }
 
-/* Inline clear button that replaces the Alt+K hint when the field has a
+/* Inline clear button that replaces the quick-search hint when the field has a
    value — saves users a sidebar-tag-toggle round-trip just to reset search. */
 .search-input-clear {
   position: absolute;
@@ -776,7 +776,7 @@ body {
   justify-content: center;
 }
 
-/* === Search Overlay (Alt+K) === */
+/* === Search Overlay (Ctrl+K / Cmd+K, Alt+K) === */
 .search-overlay-backdrop {
   position: fixed;
   inset: 0;

--- a/src/utils/__tests__/platform.test.ts
+++ b/src/utils/__tests__/platform.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { QUICK_SEARCH_HINT_DEFAULT, QUICK_SEARCH_HINT_MAC, quickSearchHint } from '../platform';
+
+describe('quickSearchHint', () => {
+  it('labels the accelerator with the command key on Apple platforms', () => {
+    expect(quickSearchHint(true)).toBe(QUICK_SEARCH_HINT_MAC);
+  });
+
+  it('labels the accelerator with Ctrl elsewhere', () => {
+    expect(quickSearchHint(false)).toBe(QUICK_SEARCH_HINT_DEFAULT);
+  });
+
+  it('defaults to the non-Mac label when there is no navigator (SSR)', () => {
+    // The module is imported in a node environment, so `navigator` detection
+    // must not throw and must not produce a Mac label on the server — a
+    // mismatch with the first client render would trip hydration.
+    expect(quickSearchHint()).toBe(QUICK_SEARCH_HINT_DEFAULT);
+  });
+});

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,36 @@
+/**
+ * Platform detection for keyboard-shortcut labels.
+ *
+ * Pure and SSR-safe: everything here returns the non-Mac answer when there is
+ * no `navigator`, so a server render and the first client render agree. The
+ * mounted-only refinement lives in `hooks/useQuickSearchHint.ts`.
+ */
+
+/** Modifier label for the quick-search accelerator on non-Apple platforms. */
+export const QUICK_SEARCH_HINT_DEFAULT = 'Ctrl+K';
+
+/** Modifier label for the quick-search accelerator on Apple platforms. */
+export const QUICK_SEARCH_HINT_MAC = '⌘K';
+
+/**
+ * True on macOS / iPadOS / iOS, where the command key carries the accelerator.
+ *
+ * `navigator.platform` is deprecated but still the most reliable signal, so it
+ * is consulted after the modern `userAgentData.platform` hint and before the
+ * user-agent string. Returns false during SSR.
+ */
+export function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
+  const source = uaData?.platform || navigator.platform || navigator.userAgent || '';
+  return /mac|iphone|ipad|ipod/i.test(source);
+}
+
+/**
+ * Label for the quick-search accelerator — "⌘K" on Apple platforms, "Ctrl+K"
+ * elsewhere. The platform is injectable so the label is testable without
+ * stubbing `navigator`.
+ */
+export function quickSearchHint(mac: boolean = isMacPlatform()): string {
+  return mac ? QUICK_SEARCH_HINT_MAC : QUICK_SEARCH_HINT_DEFAULT;
+}


### PR DESCRIPTION
Three small comfort features, one commit each. All additive — no dependency changes, no refactoring, no data migration.

| # | Feature | Nutzen für User | Aufwand | Empfehlung |
|---|---|---|---|---|
| 1 | Favorite toggle in the stash viewer header | Pinning was reachable only from the dashboard card — the moment a stash proves worth keeping, while reading it, you had to navigate back and hunt for its card. Now it is one click in the title row, backed by the same localStorage state. | S | auto-build |
| 2 | `Ctrl+K` / `Cmd+K` opens quick search | Quick search was bound to `Alt+K` only, but `Ctrl/Cmd+K` is the accelerator every comparable tool uses — and on macOS `Alt+K` is the key that *types a character*. Both bindings work; the hint and the shortcuts dialog label the accelerator per platform. | S | auto-build |
| 3 | "Show all N" escape hatch from capped quick-search results | The overlay capped its list at 12 and said "Showing first 12 of 84 matches — refine to narrow", with no way to reach the other 72. The count row now hands the query to the dashboard search, which pages up to the full total. | S | auto-build |

### Details worth reviewing

- **#2** claims the keystroke only when Ctrl/Cmd *or* Alt is the sole modifier and Shift is not held, so `Ctrl+Shift+K` and friends stay with the browser. `preventDefault` is required because `Ctrl+K` otherwise focuses the browser search bar in Firefox/Chrome. The platform label resolves *after mount* (`useQuickSearchHint`) so the server render and the first client render agree — reading `navigator` inline would trip hydration.
- **#3** clears an active tag filter on the way to the dashboard: the overlay counts matches *without* a tag filter, so leaving one on would land the user on a handful of rows straight after promising N. `showArchived` is left alone — it only ever widens the set and is a persisted preference.
- **#3** also moved the `aria-live` region onto the count text span alone, since an interactive control inside a live region is re-announced on every keystroke that changes the count.
- **#1** deduplicated the card's two inline star SVGs into a shared `StarIcon`, so the dashboard and the viewer render the same glyph.

### Verification

Full local chain, all green:

- `npm run format:check` — clean
- `npx tsc --noEmit` — clean
- `npm test` — 440 passed, 5 skipped (44 files), incl. 10 new regression tests
- `npm run build` — compiled successfully (the 2 Turbopack warnings are pre-existing: middleware→proxy deprecation and the `next.config.ts` NFT trace)

Closes #444

<!-- screenshot: optional -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01DX5Qt6ju68WnNmDregFfxE)_