### PR TITLE
chore: repo quality maintenance (Next.js 16 / TS / MCP)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@
 # two uncommented lines below only restate the built-in defaults. TRUST_PROXY is
 # the one conditional: required once the app sits behind a reverse proxy.
 #
+# Docker Compose note: a copy of this file at `.env` is read for `${...}`
+# interpolation inside docker-compose.yml, NOT injected into the container. A
+# variable only reaches the app if the service lists it under `environment:` or
+# sets `env_file: .env` — see docs/deployment.md → Docker Compose.
+#
 # Server port (optional, default: 3000)
 PORT=3000
 # Bind address of the production server (optional, default: 0.0.0.0).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,6 +12,16 @@ Open http://localhost:3000.
 
 The `docker-compose.yml` uses a named volume (`clawstash-data`) for database persistence.
 
+> **`.env` is not handed to the container automatically.** Compose reads it for `${...}` interpolation inside `docker-compose.yml` — that is how `${PORT:-3000}` picks the published host port — but only the keys listed under the service's `environment:` block actually reach the app. The committed file forwards `NODE_ENV`, `PORT` and `DATABASE_PATH` only, so `ADMIN_PASSWORD` (and `ADMIN_SESSION_HOURS`, `TRUST_PROXY`, `CLAWSTASH_ENCRYPTION_KEY`) stay unset — the instance comes up in open mode. Add them to the service, or point it at the file:
+>
+> ```yaml
+> services:
+>   clawstash:
+>     env_file: .env # everything in .env, or:
+>     environment:
+>       - ADMIN_PASSWORD=your-secret-password
+> ```
+
 ### Using the GHCR Image
 
 To use the pre-built image instead of building locally, edit `docker-compose.yml`:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -127,6 +127,22 @@ Copy `.env.example` and adjust as needed:
 cp .env.example .env
 ```
 
+### Build-time variables (Docker build only)
+
+Two more variables are read at **build** time and never at runtime. The `prebuild` script (`scripts/generate-build-info.js`) bakes them into `build-info.json`, which `/api/version` then serves as the running build's identity.
+
+- `BUILD_COMMIT_SHA` — commit the build came from; truncated to a 7-char short hash on display. Falls back to `git rev-parse --short HEAD` of the working tree.
+- `BUILD_BRANCH` — branch name reported by the running container. Falls back to `git rev-parse --abbrev-ref HEAD` of the working tree.
+
+Both are declared as `ARG` in the `Dockerfile`, and `docker-publish.yml` passes them from `github.sha` / `github.ref_name`. An image has no `.git` directory (`.dockerignore` excludes it), so the git fallback yields empty strings — a locally built image reports a blank branch/commit on `/api/version` unless you pass them explicitly:
+
+```bash
+docker build \
+  --build-arg BUILD_COMMIT_SHA="$(git rev-parse HEAD)" \
+  --build-arg BUILD_BRANCH="$(git rev-parse --abbrev-ref HEAD)" \
+  -t clawstash .
+```
+
 ## Data & Backup
 
 - Database: single SQLite file at `DATABASE_PATH` (default `./data/clawstash.db`)


### PR DESCRIPTION
## Summary

Repo-quality maintenance sweep: closes two documentation gaps around the deployment/config artifacts. Docs and example artifacts only — no runtime config, no source behaviour, no secrets. `docker-compose.yml` is an active runtime artifact and was deliberately left untouched; destructive edits are permitted only in `BACKLOG.md` and none were made.

Closes #448

## Changes

| #   | Pass                       | Datei                                | Befund                                                                                                                                                                                                                                                                                             | Aufwand | Empfehlung |
| --- | -------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ---------- |
| 1   | C — Defaults & Config-Doku | `docs/deployment.md`                 | `BUILD_COMMIT_SHA` / `BUILD_BRANCH` are `Dockerfile` `ARG`s set by `docker-publish.yml` and documented in `.env.example` + `agent_docs/env-vars.md`, but were missing from the user-facing deploy guide. `.dockerignore` excludes `.git`, so the git fallback in `scripts/generate-build-info.js` yields empty strings and a self-built image serves a blank branch/commit on `/api/version`. Added a "Build-time variables (Docker build only)" subsection with both vars, their fallbacks and a `docker build --build-arg …` snippet. | S       | auto-fix   |
| 2   | C — Defaults & Config-Doku | `docs/deployment.md`, `.env.example` | The Compose quickstart says `cp .env.example .env` + "Edit .env to set ADMIN_PASSWORD", but `docker-compose.yml` neither lists it under `environment:` nor sets `env_file:`. Compose reads `.env` for `${…}` interpolation only (that is what `${PORT:-3000}` consumes), so the password never reaches the container and the instance silently comes up in **open mode**. Added the caveat plus both remedies, and a matching note in the `.env.example` header. | M       | auto-fix   |

## Artefakt-Status

| Artefakt                                      | Vorhanden | Vollständig                                                                                                        |
| --------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------ |
| `.env.example`                                | yes       | yes — all 10 runtime + build-time keys, each with purpose, optional/required and value format                       |
| Config-Example (`*.example.{json,yaml,toml}`) | n/a       | n/a — env-vars are the whole config surface; no file-based app config exists                                        |
| README onboarding                             | yes       | yes — prerequisites, install, `cp .env.example .env`, dev/build/start/test/format/mcp, local CI chain               |
| Referenzierte Docs                            | yes       | yes — every linked `.md` resolves, no stubs                                                                          |
| `BACKLOG.md`                                  | yes       | yes — 18 open entries, all re-verified as genuinely open                                                             |

Clean parity checks (no change needed): ENV code→example (9 direct + 2 indirect keys; only the Next.js-internal `NEXT_RUNTIME` is excluded, no orphans), ENV docs consistent across `.env.example` / `agent_docs/env-vars.md` / `docs/deployment.md` / `CLAUDE.md`, 15 MCP tools ↔ README ↔ `docs/mcp.md`, 35 REST routes ↔ `docs/api-reference.md`, and npm-script parity.

## Backlog-Aufarbeitung

**No changes**, no issues extracted. `BACKLOG.md` was swept by the dedicated backlog routine earlier the same day (#447); all 18 open entries were re-verified against the working tree and none is verifiably done — e.g. #93 (`src/server/openapi.ts` still lacks the `/versions*` and `/api/admin/*` paths), #105 (`@asteasolutions/zod-to-openapi` absent), #102/#103 (no `src/components/graph/`), #57 / #92 (symbols absent), #110 (`db.ts:204` still positional), #119 (`next`'s bundled postcss still 8.4.31). Net removal 0 % (limit 60 %).

Extraction was skipped by rule: F.2 reserves it for security / data-loss / user-impact bugs or explicit priority markers, and the open set is entirely P2/P3 Code-Smell, UX, A11y plus one Dependency entry (that one belongs to the dependency routine).

## Testing

- `npx prettier --check .` — clean across the repo (mirrors the CI `format:check` gate).
- Diff verified **purely additive**: 2 files, 31 insertions, 0 deletions; every changed path matches the allowed write targets (`*.md`, `.env.example`).
- Secret heuristics (`sk-` / `ghp_` / `cs_` / `csa_` / JWT / long-hex) run over the added lines — clean; no real secret value was written, invented or guessed, and missing keys were sourced from a code scan rather than from any real env file.
- `tsc --noEmit` / `vitest` not run: no source file is touched by this PR (docs + example only), and both gates are unaffected.

## Checklist

- [x] Formatting passes (`npm run format:check` — verified via `npx prettier --check .`)
- [x] Code compiles without errors (`npx tsc --noEmit`) — n/a, no source changes
- [x] Tests pass (`npm test`) — n/a, no source changes
- [x] Build succeeds (`npm run build`) — n/a, no source changes
- [x] Changes are documented (if applicable) — the change *is* documentation


---
_Generated by [Claude Code](https://claude.ai/code/session_01PW4HA1bqk5AxSVx4qoSfB9)_