### PR TITLE
refactor: best-practice sweep (Next.js 16 App Router + React 19 + TypeScript)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,11 +34,20 @@ jobs:
       - name: Run Type Check
         run: npx tsc --noEmit
 
+      # `npm run` prints script names UNQUOTED, so the previous
+      # `grep -q '"lint"'` / `grep -q '"test"'` guards never matched and both
+      # steps silently no-op'd — the image was published without ever running
+      # the test suite. Probe package.json directly instead.
       - name: Run Linter
-        run: if npm run 2>/dev/null | grep -q '"lint"'; then npm run lint; fi
+        run: |
+          if node -e "process.exit(require('./package.json').scripts?.lint ? 0 : 1)"; then
+            npm run lint
+          else
+            echo "No lint script defined - skipping."
+          fi
 
       - name: Run Tests
-        run: if npm run 2>/dev/null | grep -q '"test"'; then npm run test:run || npm test; fi
+        run: npm run test:run
 
       - name: Build Frontend
         run: npm run build

--- a/src/app/api/admin/export/route.ts
+++ b/src/app/api/admin/export/route.ts
@@ -41,11 +41,24 @@ export async function GET(req: NextRequest) {
     // output avoids a second full-ZIP copy in the `chunks` buffer.
     const archive = archiver('zip', { zlib: { level: 9 } });
 
+    // Set once the consumer is gone (client disconnect / `stream.cancel()`).
+    // Without it the archiver kept zipping the whole DB into a controller that
+    // no longer accepts writes, and `enqueue()` threw out of archiver's `data`
+    // listener on every remaining chunk.
+    let aborted = false;
+
     const stream = new ReadableStream({
       start(controller) {
-        archive.on('data', (chunk: Buffer) => controller.enqueue(chunk));
-        archive.on('end', () => controller.close());
-        archive.on('error', (err: Error) => controller.error(err));
+        archive.on('data', (chunk: Buffer) => {
+          if (aborted) return;
+          controller.enqueue(chunk);
+        });
+        archive.on('end', () => {
+          if (!aborted) controller.close();
+        });
+        archive.on('error', (err: Error) => {
+          if (!aborted) controller.error(err);
+        });
 
         archive.append(JSON.stringify(data.stashes, null, 2), { name: 'stashes.json' });
         archive.append(JSON.stringify(data.stash_files, null, 2), { name: 'stash_files.json' });
@@ -59,6 +72,12 @@ export async function GET(req: NextRequest) {
           name: 'manifest.json',
         });
         archive.finalize();
+      },
+      cancel() {
+        // Stop compressing the rest of the database for a client that already
+        // hung up, and release the archiver's buffers.
+        aborted = true;
+        archive.destroy();
       },
     });
 

--- a/src/app/api/admin/import/route.ts
+++ b/src/app/api/admin/import/route.ts
@@ -5,6 +5,7 @@ import { checkAdmin, getRequestInfo } from '@/app/api/_helpers';
 import { sanitizeLogValue, quoteLogValue } from '@/server/log-sanitize';
 import {
   MAX_IMPORT_SIZE,
+  MAX_IMPORT_UNCOMPRESSED_SIZE,
   ImportStashRowSchema,
   ImportStashFileRowSchema,
   ImportStashVersionRowSchema,
@@ -70,9 +71,22 @@ export async function POST(req: NextRequest) {
     const zip = new AdmZip(buffer);
     const entries = zip.getEntries();
 
+    // Running total of already-inflated bytes. `MAX_IMPORT_SIZE` bounds only
+    // the COMPRESSED upload, so a decompression bomb (a few MB of zeros
+    // inflating to many GB) passes every check above and then OOMs the process
+    // inside `entry.getData()`. Refuse before inflating, using the entry's
+    // declared uncompressed size from the central directory.
+    let inflatedBytes = 0;
+
     const readJson = (name: string): Record<string, unknown>[] => {
       const entry = entries.find((e) => e.entryName === name);
       if (!entry) return [];
+      inflatedBytes += entry.header.size;
+      if (inflatedBytes > MAX_IMPORT_UNCOMPRESSED_SIZE) {
+        throw new Error(
+          `Uncompressed import data exceeds the ${MAX_IMPORT_UNCOMPRESSED_SIZE}-byte limit`,
+        );
+      }
       const parsed: unknown = JSON.parse(entry.getData().toString('utf8'));
       if (!Array.isArray(parsed)) {
         throw new Error(`Expected ${name} to contain a JSON array`);

--- a/src/components/VersionHistory.tsx
+++ b/src/components/VersionHistory.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import type { Stash, StashVersionListItem, StashVersion } from '../types';
 import { api } from '../api';
 import { formatRelativeTime } from '../utils/format';
@@ -159,6 +159,22 @@ export default function VersionHistory({ stashId, currentVersion, onRestore }: P
     }
   };
 
+  // Memoize the Prism-highlighted HTML per file of the opened version, keyed by
+  // filename. Without this, every state-driven re-render of the detail view —
+  // and `useClipboardWithKey` produces two per copy click — re-ran
+  // `highlightCode` over every file in the version. Mirrors the same memo in
+  // StashViewer, which already carries this cost note.
+  const highlightedFiles = useMemo(
+    () =>
+      new Map(
+        (selectedVersion?.files ?? []).map((file) => [
+          file.filename,
+          highlightCode(file.content, resolvePrismLanguage(file.language, file.filename)),
+        ]),
+      ),
+    [selectedVersion],
+  );
+
   if (loading)
     return (
       <div className="loading">
@@ -261,7 +277,6 @@ export default function VersionHistory({ stashId, currentVersion, onRestore }: P
         )}
         <div className="version-detail-files">
           {selectedVersion.files.map((file) => {
-            const lang = resolvePrismLanguage(file.language, file.filename);
             return (
               // Filename is unique per version (enforced by server validation),
               // so it's a stable React key. The previous `key={i}` would
@@ -298,7 +313,11 @@ export default function VersionHistory({ stashId, currentVersion, onRestore }: P
                   </button>
                 </div>
                 <pre className="file-content">
-                  <code dangerouslySetInnerHTML={{ __html: highlightCode(file.content, lang) }} />
+                  <code
+                    dangerouslySetInnerHTML={{
+                      __html: highlightedFiles.get(file.filename) ?? '',
+                    }}
+                  />
                 </pre>
               </div>
             );

--- a/src/server/validation.ts
+++ b/src/server/validation.ts
@@ -20,6 +20,15 @@ export const MAX_FILES = 100;
 export const MAX_FILENAME_LENGTH = 255;
 export const MAX_FILE_CONTENT_LENGTH = 10 * 1024 * 1024; // 10MB per file
 export const MAX_IMPORT_SIZE = 100 * 1024 * 1024; // 100MB for ZIP import
+/**
+ * Cap on the COMBINED uncompressed size of the JSON entries read out of an
+ * import ZIP. `MAX_IMPORT_SIZE` only bounds the compressed upload; a
+ * decompression bomb (a few MB of zeros inflating to many GB) would sail past
+ * it and OOM the process inside `entry.getData()`. 1GB comfortably exceeds any
+ * real export — a full stash DB at the 10MB-per-file / 100-files-per-stash
+ * ceiling still compresses far below the upload limit.
+ */
+export const MAX_IMPORT_UNCOMPRESSED_SIZE = 1024 * 1024 * 1024; // 1GB inflated
 
 /**
  * Compute the maximum nesting depth of a JSON-like value.


### PR DESCRIPTION
## Summary

Best-practice sweep across the Next.js 16 App Router / React 19 / TypeScript surface. Four behaviour-equivalent fixes: one inert CI gate, one decompression-bomb gap, one stream-teardown leak, one missing render memo. No dependency, config or API-shape changes.

## Changes

| #   | Datei                                  | Kategorie   | Fix                                                                                                                                                    | Aufwand | Empfehlung |
| --- | -------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ---------- |
| 1   | `.github/workflows/docker-publish.yml` | Correctness | `grep -q '"test"'` never matched (`npm run` prints script names unquoted), so the Linter **and** Tests steps silently no-op'd — the image was published without the suite ever running. Probe `package.json` for the optional `lint` script; run `npm run test:run` unconditionally. | S       | auto-fix   |
| 2   | `src/app/api/admin/import/route.ts`    | Security    | `MAX_IMPORT_SIZE` bounds only the compressed upload, so a decompression bomb reached `entry.getData()` and OOM'd the process. Sum the entries' declared uncompressed size and refuse past the new `MAX_IMPORT_UNCOMPRESSED_SIZE` (1GB) before inflating. | S       | auto-fix   |
| 3   | `src/app/api/admin/export/route.ts`    | Correctness | The export `ReadableStream` had no `cancel()`; a client disconnect left archiver zipping the whole DB into a dead controller, throwing on every `enqueue()`. Add `cancel()` → `archive.destroy()` plus an `aborted` guard on the data/end/error handlers. | S       | auto-fix   |
| 4   | `src/components/VersionHistory.tsx`    | Performance | The version-detail view re-ran `highlightCode` for every file on every render (and `useClipboardWithKey` fires two renders per copy click). Memoize per opened version, keyed by filename — same pattern `StashViewer` already uses. | S       | auto-fix   |

## Testing

Full documented chain, once, after all four commits:

- `npm run format:check` — clean
- `npx tsc --noEmit` — clean
- `npm test` — 45 files, 451 passed, 5 skipped
- `npm run build` — succeeds

The reworked CI guard was additionally exercised locally (`node -e "…scripts?.lint…"` correctly reports "no lint script" for this repo).

## Checklist

- [x] Formatting passes (`npm run format:check`)
- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Changes are documented (if applicable) — findings, tie-breaker items and deferred work are recorded in #450

Closes #450

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRjcnMRoobLudTb7BDA15a)_