### PR TITLE
ux: best-practice sweep (Next.js 16 + React 19)

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -28,6 +28,12 @@
   --accent-blue: #58a6ff;
   --accent-orange: #d29922;
   --accent-red: #da3633;
+  /* Text-only variant of accent-red: #da3633 as text measured 3.56-4.11:1 on
+     its own tinted panels (.login-error, .mermaid-error-title), below WCAG
+     AA's 4.5:1 (1.4.3). accent-red itself stays untouched — it also serves as
+     the .btn-danger background, where white button text needs the darker red
+     to stay >= 4.5:1. */
+  --accent-red-text: #e25f5c;
   --radius: 6px;
   --radius-lg: 10px;
   --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.3);
@@ -672,7 +678,7 @@ body {
 
 .sidebar-footer-logout-btn:hover {
   background: var(--bg-tertiary);
-  color: var(--accent-red);
+  color: var(--accent-red-text);
 }
 
 /* === Login Screen === */
@@ -720,7 +726,7 @@ body {
 }
 
 .login-error {
-  color: var(--accent-red);
+  color: var(--accent-red-text);
   font-size: 13px;
   padding: 8px 12px;
   background: rgba(218, 54, 51, 0.1);
@@ -1300,7 +1306,7 @@ body {
 }
 
 .btn-remove:hover {
-  color: var(--accent-red);
+  color: var(--accent-red-text);
 }
 
 /* === Tags === */
@@ -3301,7 +3307,7 @@ textarea.code-editor-plain.code-editor-wrap {
 }
 
 .api-delete-btn:hover {
-  color: var(--accent-red) !important;
+  color: var(--accent-red-text) !important;
 }
 
 .api-copy-notice {
@@ -6805,7 +6811,7 @@ textarea.code-editor-plain.code-editor-wrap {
 
 .mermaid-error-title {
   margin-bottom: 4px;
-  color: var(--accent-red);
+  color: var(--accent-red-text);
 }
 
 .mermaid-error-message {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -19,7 +19,10 @@
   --border-light: #353d4a;
   --text-primary: #e6edf3;
   --text-secondary: #9198a1;
-  --text-muted: #656d76;
+  /* #656d76 measured 2.99-3.61:1 against bg-primary/secondary/tertiary — below
+     WCAG AA's 4.5:1 minimum for normal text (1.4.3). This tone clears 4.5:1+
+     on all three while keeping the same muted-gray role. */
+  --text-muted: #838c95;
   --accent-green: #238636;
   --accent-green-hover: #2ea043;
   --accent-blue: #58a6ff;


### PR DESCRIPTION
## Summary

Two isolated WCAG 1.4.3 (AA) text-contrast fixes found by a static UX sweep — no feature changes, no visual redesign.

## Changes

| Kategorie | Aufwand | Empfehlung | Fix |
|---|---|---|---|
| a11y | S | auto-fix | `--text-muted` lightened `#656d76` → `#838c95` (was 2.99-3.61:1, now 5.07-5.54:1 on `--bg-primary`/`--bg-secondary`/`--bg-tertiary`) |
| a11y | S | auto-fix | New `--accent-red-text: #e25f5c` token for the 5 text-only uses of the red/danger color (`.login-error`, `.mermaid-error-title`, and the 3 destructive-hover labels) — was 3.56-4.11:1, now 4.50-5.43:1 on their actual rendered backgrounds. `--accent-red` itself is untouched everywhere it backs `.btn-danger` or a border, so white-on-red button contrast is unaffected. |

Both are single-file (`src/styles/app.css`), CSS-custom-property-only changes — same layout, same component behavior, only a subtle color shift for legibility. Visible screens: the login screen's error banner, the Mermaid fullscreen viewer's syntax-error panel, and any muted/secondary text app-wide (timestamps, placeholders, hints).

Closes #452

## Testing

- `npm run format:check` — pass
- `npx tsc --noEmit` — pass
- `npm test` — 451 passed, 5 skipped
- `npm run build` — succeeds

## Checklist

- [x] Formatting passes (`npm run format:check`)
- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Changes are documented (if applicable)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AxfyWUXtEesbTj6JBXrUyq)_