### PR TITLE
ci: add md-only Prettier job for docs changes

### DIFF
--- a/.github/workflows/docs-format.yml
+++ b/.github/workflows/docs-format.yml
@@ -1,0 +1,58 @@
+name: Docs Format
+
+# The only automatic Markdown gate in this repository.
+#
+# `npm run format:check` is `prettier --check .`, which covers Markdown — but
+# `docker-publish.yml` is `workflow_dispatch`-only and the two GitHub-managed
+# workflows (CodeQL, Dependabot) do not run Prettier. Nothing verifies Markdown
+# formatting unless a human remembers to, so a docs-only PR could merge a red
+# `format:check` onto main and stay red indefinitely.
+#
+# Deliberately narrow: Markdown only, no `npm ci`, no build. It does not change
+# `docker-publish.yml`, which stays dispatch-only.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '**.md'
+  push:
+    branches: [main]
+    paths:
+      - '**.md'
+
+concurrency:
+  group: docs-format-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: this job only checks out the repository and runs Prettier.
+permissions:
+  contents: read
+
+jobs:
+  format:
+    name: Prettier (Markdown)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '26'
+
+      # Read the pinned version out of package.json rather than hardcoding it,
+      # so this job can never drift from the Prettier `npm run format` applies.
+      # `.prettierignore` still applies, so the `.claude/` exclusion holds.
+      - name: Resolve pinned Prettier version
+        id: prettier
+        run: echo "version=$(node -p "require('./package.json').devDependencies.prettier.replace(/^[^0-9]*/,'')")" >> "$GITHUB_OUTPUT"
+
+      # Markdown only: the wider docs tree holds files Prettier has no parser
+      # for (`.mmd` and friends), which would fail the run outright.
+      - name: Check Markdown formatting
+        run: npx --yes prettier@${{ steps.prettier.outputs.version }} --check "**/*.md"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,7 @@ Project-intended and common MCPs: `agent_docs/mcp_catalog.md`. Never auto-detect
 
 CI failure handling: `.claude/skills/ci/SKILL.md`. Triggered by `/ci`, "fix CI", "check the build". Auto-routes by run state (none / running / passed / failed / stale). Never auto-reruns; always verifies fixes locally before pushing.
 
-`docker-publish.yml` is the only workflow **file** and it is `workflow_dispatch`-only, so a pushed branch legitimately has zero runs of it and `/ci` reporting "no runs" for it is configuration, not breakage. Two GitHub-managed workflows do run without a file in the repo: **CodeQL** (default setup -- `Analyze (actions)` / `Analyze (javascript-typescript)`, runs on every PR and gates merge) and **Dependabot Updates**. The local Automated Checks above remain the real gate for correctness.
+`docker-publish.yml` is `workflow_dispatch`-only, so a pushed branch legitimately has zero runs of it and `/ci` reporting "no runs" for it is configuration, not breakage. `docs-format.yml` is the one workflow that runs automatically: PRs and pushes to `main` touching `**.md`, Prettier-Markdown only (no `npm ci`, no build) — without it nothing would verify Markdown, even though `format:check` is `prettier --check .` and includes it. `.prettierignore` still applies, so the `.claude/` exclusion holds. Two GitHub-managed workflows also run without a file in the repo: **CodeQL** (default setup -- `Analyze (actions)` / `Analyze (javascript-typescript)`, runs on every PR and gates merge) and **Dependabot Updates**. The local Automated Checks above remain the real gate for correctness.
 
 ## Subagents
 


### PR DESCRIPTION
## Problem

`npm run format:check` is `prettier --check .`, which covers Markdown — but `docker-publish.yml` is `workflow_dispatch`-only and the two GitHub-managed workflows (CodeQL, Dependabot) do not run Prettier. Nothing verifies Markdown formatting automatically, so drift can land on `main` and stay there indefinitely.

That failure mode is not hypothetical: in the sibling repo `ai-hub-group-manager` a docs-only PR merged with zero CI runs and left `format:check` red on `main`.

## Change

New `.github/workflows/docs-format.yml` — the first workflow file here that runs on its own.

| Aspect | Choice | Why |
| --- | --- | --- |
| Trigger | `paths: ["**.md"]` on PR + push to `main` | documentation changes only |
| Scope | `prettier --check "**/*.md"` | the wider docs tree holds files Prettier has no parser for and errors on |
| Install | none; `npx prettier@<version from package.json>` (3.9.6) | no `npm ci`, no `better-sqlite3` native build |
| Version | read from `devDependencies.prettier` at runtime | cannot drift from what `npm run format` applies locally |
| Runner | `ubuntu-latest` | hosted — no fork guard needed |
| Timeout | 5 min | it is one Prettier invocation |

`.prettierignore` still applies, so the deliberate `.claude/` exclusion is untouched. `docker-publish.yml` stays `workflow_dispatch`-only — this changes nothing about publishing.

`CLAUDE.md` § CI updated: "docker-publish.yml is the only workflow file" is no longer accurate.

## Verification

| Check | Result |
| --- | --- |
| YAML parses, triggers `[pull_request, push]`, job `format` | ok |
| `prettier --check "**/*.md"` on this branch (53 files) | green |
| `prettier --check` on the new workflow + `CLAUDE.md` | green |

Part of a fleet-wide rollout: already merged in `ai-hub-group-manager` (#740), `competitive-analysis-app` (#574), `contract-manager` (#594) and `tubetrend` (#356).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2jVud1wuoe6qTRDHFFELY)_