### PR TITLE
security: hardening sweep (Next.js 16 App Router + MCP)

### DIFF
--- a/src/utils/__tests__/svg-sanitize.test.ts
+++ b/src/utils/__tests__/svg-sanitize.test.ts
@@ -53,6 +53,19 @@ describe('sanitizeSvg', () => {
     expect(out.toLowerCase()).toContain('foreignobject');
   });
 
+  it('removes SMIL animation elements that could rewrite attributes post-sanitise', () => {
+    const out = sanitizeSvg(
+      '<svg><a href="#ok"><animate attributeName="href" values="javascript:alert(1)" /><rect /></a></svg>',
+    );
+    expect(out.toLowerCase()).not.toContain('<animate');
+    expect(out).not.toContain('javascript:');
+    expect(out).toContain('<rect');
+    // camelCase spellings and <set> are covered too.
+    expect(
+      sanitizeSvg('<svg><animateTransform /><animateMotion /><set attributeName="onload" /></svg>'),
+    ).not.toMatch(/animatetransform|animatemotion|<set/i);
+  });
+
   it('keeps benign diagram markup intact', () => {
     const svg =
       '<svg viewBox="0 0 10 10"><style>.n{fill:#fff}</style><marker markerWidth="6" /><g class="n"><text>label</text></g></svg>';

--- a/src/utils/__tests__/svg-sanitize.test.ts
+++ b/src/utils/__tests__/svg-sanitize.test.ts
@@ -32,6 +32,21 @@ describe('sanitizeSvg', () => {
     );
   });
 
+  it('drops script schemes obfuscated with control chars or whitespace', () => {
+    // The HTML parser decodes the entity into a literal TAB inside the
+    // scheme; browsers ignore it when resolving the URL, so the sanitiser
+    // must too. Leading whitespace alone was already handled.
+    expect(sanitizeSvg('<svg><a href="jav&#9;ascript:alert(1)"><rect /></a></svg>')).not.toContain(
+      'alert(1)',
+    );
+    expect(sanitizeSvg('<svg><a href="  JaVaScRiPt:alert(1)"><rect /></a></svg>')).not.toContain(
+      'alert(1)',
+    );
+    expect(sanitizeSvg('<svg><use xlink:href="java\nscript:alert(1)" /></svg>')).not.toContain(
+      'alert(1)',
+    );
+  });
+
   it('removes embedded document elements', () => {
     const out = sanitizeSvg('<svg><foreignObject><iframe src="/x"></iframe></foreignObject></svg>');
     expect(out).not.toContain('iframe');

--- a/src/utils/svg-sanitize.ts
+++ b/src/utils/svg-sanitize.ts
@@ -26,10 +26,30 @@
 const FORBIDDEN_ELEMENTS = 'script, iframe, object, embed, base, link, meta';
 
 /** URL schemes that execute instead of addressing a resource. */
-const UNSAFE_URL = /^\s*(?:javascript|vbscript|data:text\/html)/i;
+const UNSAFE_URL = /^(?:javascript|vbscript|data:text\/html)/;
 
 /** Attributes carrying a URL that must not be a script URL. */
 const URL_ATTRS = new Set(['href', 'xlink:href', 'src', 'action', 'formaction']);
+
+/**
+ * True when an attribute value carries a script-bearing URL scheme.
+ *
+ * Browsers ignore ASCII control characters and whitespace while resolving a
+ * URL, so `jav&#9;ascript:alert(1)` — which the HTML parser decodes into a
+ * literal TAB *inside* the scheme — still executes. A pattern anchored on the
+ * raw value only catches LEADING whitespace and lets that through, so strip
+ * every control char and space first and match the lowercased remainder. This
+ * is the same normalisation `isUnsafeUrl()` in `utils/markdown.ts` applies to
+ * the Markdown surface; keeping the two in step means an obfuscated scheme
+ * cannot survive on one surface after being blocked on the other.
+ *
+ * Only a copy is inspected — the attribute value itself is never rewritten.
+ */
+function isUnsafeUrlValue(value: string): boolean {
+  // Strip ASCII control chars + whitespace (0x00-0x20) and DEL (0x7F).
+  // eslint-disable-next-line no-control-regex
+  return UNSAFE_URL.test(value.replace(/[\x00-\x20\x7f]/g, '').toLowerCase());
+}
 
 /**
  * Strip script elements, inline event handlers (`on*`) and script URLs from an
@@ -51,7 +71,7 @@ export function sanitizeSvg(svg: string): string {
   for (const el of Array.from(root.querySelectorAll('*'))) {
     for (const attr of Array.from(el.attributes)) {
       const name = attr.name.toLowerCase();
-      if (name.startsWith('on') || (URL_ATTRS.has(name) && UNSAFE_URL.test(attr.value))) {
+      if (name.startsWith('on') || (URL_ATTRS.has(name) && isUnsafeUrlValue(attr.value))) {
         el.removeAttribute(attr.name);
       }
     }

--- a/src/utils/svg-sanitize.ts
+++ b/src/utils/svg-sanitize.ts
@@ -25,6 +25,25 @@
 /** Elements that can execute code or load an unrelated document. */
 const FORBIDDEN_ELEMENTS = 'script, iframe, object, embed, base, link, meta';
 
+/**
+ * SMIL animation elements, removed wholesale rather than attribute-filtered.
+ *
+ * `<animate attributeName="href" values="javascript:alert(1)" />` rewrites its
+ * target's attribute AFTER this sanitiser has inspected it, so the `on*` and
+ * URL-scheme checks below cannot see the payload — the same bypass that
+ * `sanitizeHtml()` in `utils/markdown.ts` already strips for the Markdown
+ * surface. SMIL is native to SVG (unlike the HTML fragments Markdown emits),
+ * which makes this the surface where the vector actually works.
+ *
+ * Mermaid animates edges through CSS classes and emits no SMIL, so removing
+ * these elements does not change any diagram this app renders.
+ *
+ * Matched on the lowercased tag name so the camelCase SVG spellings
+ * (`animateTransform`, `animateMotion`) are caught however the parser
+ * normalised them.
+ */
+const ANIMATION_ELEMENTS = new Set(['animate', 'animatetransform', 'animatemotion', 'set']);
+
 /** URL schemes that execute instead of addressing a resource. */
 const UNSAFE_URL = /^(?:javascript|vbscript|data:text\/html)/;
 
@@ -69,6 +88,10 @@ export function sanitizeSvg(svg: string): string {
   root.querySelectorAll(FORBIDDEN_ELEMENTS).forEach((el) => el.remove());
 
   for (const el of Array.from(root.querySelectorAll('*'))) {
+    if (ANIMATION_ELEMENTS.has(el.tagName.toLowerCase())) {
+      el.remove();
+      continue;
+    }
     for (const attr of Array.from(el.attributes)) {
       const name = attr.name.toLowerCase();
       if (name.startsWith('on') || (URL_ATTRS.has(name) && isUnsafeUrlValue(attr.value))) {


### PR DESCRIPTION
Security hardening sweep over the web-app surface (REST routes, `/mcp`, auth layer, middleware, Markdown/SVG render path). Two `safe`, non-breaking fixes; both close a drift between the two HTML/SVG sanitizers that live in this codebase.

## Fixed

| # | Category | Severity | File:Line | Fix |
|---|----------|----------|-----------|-----|
| 1 | XSS (sanitizer bypass) | Medium | `src/utils/svg-sanitize.ts:29` | Scheme detection ran against the raw attribute value, so only *leading* whitespace was tolerated. Browsers also ignore ASCII control chars **inside** a URL, so `jav&#9;ascript:…` (parser-decoded to a literal TAB in the scheme) survived. Now normalises a copy (strip `0x00–0x20` + DEL, lowercase) before matching — the same normalisation `isUnsafeUrl()` in `utils/markdown.ts` already applies. |
| 2 | XSS (sanitizer bypass) | Medium | `src/utils/svg-sanitize.ts:26` | SMIL elements were left in place. `<animate attributeName="href" values="javascript:…">` rewrites its target *after* the sanitiser inspected it, so the payload is invisible to the `on*` / URL-scheme checks. `<set>` does the same statically. `sanitizeHtml()` already strips these for the Markdown surface and documents the bypass; the SVG sanitiser had drifted — and SVG is the surface where SMIL actually works. |

Both are defense-in-depth behind Mermaid's `securityLevel: 'strict'`, which is the first line of defence. Neither changes rendering: no legitimate URL changes scheme under the normalisation, and Mermaid animates edges via CSS classes and emits no SMIL (verified against the pinned `mermaid@11.16.0` dist). Two regression tests added.

## Verification

`format:check` → `tsc --noEmit` → `test` (455 passed, 5 skipped) → `build` — all green.

## Not fixed here

Reported as `security-flag` on the tracking issue: the `mcp` token scope grants full write/delete through the MCP tools (authz change — needs a deliberate decision), and three dependency advisories (`mermaid`, `ip-address`, `undici`) that belong to the Dependabot routine. The deliberately deferred script-restricting CSP stays tracked in #349.

Refs #432


---
_Generated by [Claude Code](https://claude.ai/code/session_01J6xYL4u3TrB76T4ffHQVgn)_