### PR TITLE
feat: comfort sweep (Next.js 16 App Router + React 19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ AI agents lose context between sessions. ClawStash gives them a persistent memor
 - **Full-text search** — find stashes by content, name, description, or tags
 - **Token-efficient** — MCP tools return summaries first, full content only on demand
 - **Version history** — every change is tracked, diffable, and restorable
+- **Duplicate a stash** — open any stash as a pre-filled new one and use it as a template
 - **GitHub backup** — mirror all stashes into a GitHub repo (scheduled, on change, or manual) with "Sign in with GitHub" or a PAT — see [docs/backup.md](docs/backup.md)
 - **Mermaid diagrams** — `.mmd` files and inline ` ```mermaid ` blocks in Markdown render as diagrams (lazy-loaded, no bundle bloat)
 - **One-click code copy** — every fenced code block in rendered Markdown gets a copy button (keyboard reachable, always visible on touch)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,6 +117,10 @@ export default function App() {
   );
   const [sortMode, setSortMode] = useState<SortMode>(loadSortMode);
   const [selectedStash, setSelectedStash] = useState<Stash | null>(null);
+  // Source stash for "Duplicate": pre-fills the NEW-stash editor with a copy
+  // of an existing stash. Cleared whenever the editor is left or a plain new
+  // stash is started, so a later "New Stash" never resurrects the template.
+  const [duplicateSource, setDuplicateSource] = useState<Stash | null>(null);
   const [search, setSearch] = useState('');
   const [filterTag, setFilterTag] = useState('');
   const [tags, setTags] = useState<TagInfo[]>([]);
@@ -283,6 +287,7 @@ export default function App() {
         e.preventDefault();
         if (!confirmDiscardUnsaved()) return;
         setSelectedStash(null);
+        setDuplicateSource(null);
         setView('new');
         pushUrl('/new');
         setSidebarOpen(false);
@@ -317,6 +322,7 @@ export default function App() {
             // Shortcuts help documents "Esc — back to dashboard"; a dirty
             // new-stash form still asks before discarding (mirrors 'n').
             if (!confirmDiscardUnsaved()) return currentView;
+            setDuplicateSource(null);
             pushUrl('/');
             setSidebarOpen(false);
             return 'home';
@@ -652,6 +658,7 @@ export default function App() {
   const handleNewStash = () => {
     if (!confirmDiscardUnsaved()) return;
     setSelectedStash(null);
+    setDuplicateSource(null);
     setView('new');
     pushUrl('/new');
     setSidebarOpen(false);
@@ -660,6 +667,25 @@ export default function App() {
   const handleEditStash = () => {
     setView('edit');
     if (selectedStash) pushUrl(`/stash/${selectedStash.id}/edit`);
+  };
+
+  /**
+   * Duplicate the stash currently open in the viewer: the original stays
+   * untouched and the NEW-stash editor opens pre-filled with its content.
+   * The name gets a " (copy)" suffix so both are distinguishable in listings;
+   * the suffix is dropped when it would exceed the server's 500-char limit.
+   */
+  const handleDuplicateStash = () => {
+    if (!selectedStash) return;
+    const suffixed = `${selectedStash.name} (copy)`;
+    setDuplicateSource({
+      ...selectedStash,
+      name: suffixed.length > 500 ? selectedStash.name : suffixed,
+    });
+    setSelectedStash(null);
+    setView('new');
+    pushUrl('/new');
+    setSidebarOpen(false);
   };
 
   const handleArchiveStash = async (id: string, archived: boolean) => {
@@ -715,6 +741,9 @@ export default function App() {
   };
 
   const handleSaveStash = async (savedId?: string) => {
+    // The editor is done with the template either way — keeping it would
+    // re-seed the next "New Stash" with the duplicated content.
+    setDuplicateSource(null);
     try {
       const stashId = savedId || selectedStash?.id;
       const isNew = !selectedStash;
@@ -745,6 +774,7 @@ export default function App() {
   const handleGoHome = () => {
     if (!confirmDiscardUnsaved()) return;
     setSelectedStash(null);
+    setDuplicateSource(null);
     setView('home');
     pushUrl('/');
     setSidebarOpen(false);
@@ -991,6 +1021,7 @@ export default function App() {
             <StashViewer
               stash={selectedStash}
               onEdit={handleEditStash}
+              onDuplicate={handleDuplicateStash}
               onDelete={handleDeleteStash}
               onArchive={handleArchiveStash}
               onBack={handleGoHome}
@@ -1012,8 +1043,15 @@ export default function App() {
               // the instance: the form keeps the edited stash's content while
               // the save branch flips to createStash — saving would create a
               // duplicate of the stash being edited.
-              key={view === 'edit' ? `edit-${selectedStash?.id ?? 'none'}` : 'new'}
+              key={
+                view === 'edit'
+                  ? `edit-${selectedStash?.id ?? 'none'}`
+                  : // A duplicate seeds different initial state than a blank
+                    // form, so it needs its own key to force a remount.
+                    `new-${duplicateSource?.id ?? 'blank'}`
+              }
               stash={view === 'edit' ? selectedStash : null}
+              template={view === 'new' ? duplicateSource : null}
               onSave={handleSaveStash}
               onDirtyChange={(dirty) => {
                 editorDirtyRef.current = dirty;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -149,6 +149,12 @@ export default function App() {
   const errorToastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Global success toast for positive feedback (save, archive, restore).
   const [successToast, setSuccessToast] = useState<string | null>(null);
+  // Optional one-click follow-up rendered inside the success toast (e.g. the
+  // "Undo" for an accidental archive). Cleared together with the toast.
+  const [successAction, setSuccessAction] = useState<{
+    label: string;
+    onClick: () => void;
+  } | null>(null);
   const successToastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Mirror modal-open state into a ref so the dependency-free global hotkey
@@ -523,20 +529,42 @@ export default function App() {
    */
   const showError = useCallback((message: string) => {
     setSuccessToast(null);
+    setSuccessAction(null);
     if (successToastTimerRef.current) clearTimeout(successToastTimerRef.current);
     setErrorToast(message);
     if (errorToastTimerRef.current) clearTimeout(errorToastTimerRef.current);
     errorToastTimerRef.current = setTimeout(() => setErrorToast(null), 4000);
   }, []);
 
-  /** Show a transient success toast that auto-dismisses after 3 s. */
-  const showSuccess = useCallback((message: string) => {
-    setErrorToast(null);
-    if (errorToastTimerRef.current) clearTimeout(errorToastTimerRef.current);
-    setSuccessToast(message);
+  /** Dismiss the success toast and drop any follow-up action it carried. */
+  const dismissSuccess = useCallback(() => {
     if (successToastTimerRef.current) clearTimeout(successToastTimerRef.current);
-    successToastTimerRef.current = setTimeout(() => setSuccessToast(null), 3000);
+    setSuccessToast(null);
+    setSuccessAction(null);
   }, []);
+
+  /**
+   * Show a transient success toast that auto-dismisses after 3 s. With an
+   * `action` (e.g. "Undo") it stays up for 6 s — 3 s is not enough time to
+   * notice a toast, read it and click it.
+   */
+  const showSuccess = useCallback(
+    (message: string, action?: { label: string; onClick: () => void }) => {
+      setErrorToast(null);
+      if (errorToastTimerRef.current) clearTimeout(errorToastTimerRef.current);
+      setSuccessToast(message);
+      setSuccessAction(action ?? null);
+      if (successToastTimerRef.current) clearTimeout(successToastTimerRef.current);
+      successToastTimerRef.current = setTimeout(
+        () => {
+          setSuccessToast(null);
+          setSuccessAction(null);
+        },
+        action ? 6000 : 3000,
+      );
+    },
+    [],
+  );
 
   // Generation counter so an older in-flight listStashes() resolution
   // cannot overwrite results from a newer typed-search. Without this, a
@@ -695,7 +723,13 @@ export default function App() {
         setSelectedStash(updated);
       }
       loadStashes();
-      showSuccess(archived ? 'Stash archived.' : 'Stash unarchived.');
+      // Archiving hides the stash from the default listing, so an accidental
+      // click used to mean hunting it down behind the "show archived" filter.
+      // Offer the reverse operation right in the confirmation.
+      showSuccess(archived ? 'Stash archived.' : 'Stash unarchived.', {
+        label: 'Undo',
+        onClick: () => handleArchiveStash(id, !archived),
+      });
     } catch (err) {
       console.error('Failed to archive stash:', err);
       showError(archived ? 'Failed to archive stash.' : 'Failed to unarchive stash.');
@@ -1106,13 +1140,30 @@ export default function App() {
           className="app-success-toast"
           role="status"
           aria-live="polite"
-          onClick={() => setSuccessToast(null)}
+          onClick={dismissSuccess}
           title="Click to dismiss"
         >
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
             <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z" />
           </svg>
-          {successToast}
+          <span className="app-toast-message">{successToast}</span>
+          {successAction && (
+            <button
+              type="button"
+              className="app-toast-action"
+              onClick={(e) => {
+                // The toast itself dismisses on click — without this the
+                // action would fire and immediately be undone visually.
+                e.stopPropagation();
+                const run = successAction.onClick;
+                dismissSuccess();
+                run();
+              }}
+              title={`${successAction.label} — reverses the action just confirmed`}
+            >
+              {successAction.label}
+            </button>
+          )}
         </div>
       )}
       {errorToast && (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,6 +7,8 @@ import { formatDate } from '../utils/format';
 import { splitHighlight } from '../utils/highlight';
 import { sortStashes } from '../utils/sort';
 import { sortStashesWithFavorites } from '../utils/favorites';
+import { buildStashUrl } from '../utils/stash-url';
+import { isModifiedClick } from '../utils/link-click';
 
 interface Props {
   stashes: StashListItem[];
@@ -605,18 +607,26 @@ export default function Sidebar({
 
           <div className="sidebar-list">
             {orderedStashes.map((stash) => (
-              <div
+              // A real link, so a row can be opened in a new tab the way every
+              // other list on the web can (Ctrl/Cmd+click, middle-click,
+              // context menu) — plain clicks still navigate inside the SPA.
+              <a
                 key={stash.id}
                 className={`sidebar-item ${selectedId === stash.id ? 'active' : ''}`}
-                onClick={() => onSelectStash(stash.id)}
+                href={buildStashUrl('', stash.id)}
+                onClick={(e) => {
+                  if (isModifiedClick(e)) return;
+                  e.preventDefault();
+                  onSelectStash(stash.id);
+                }}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
+                  // Enter activates the link natively; Space would scroll the
+                  // list instead, so keep the explicit handler for it.
+                  if (e.key === ' ') {
                     e.preventDefault();
                     onSelectStash(stash.id);
                   }
                 }}
-                role="button"
-                tabIndex={0}
                 aria-current={selectedId === stash.id ? 'true' : undefined}
                 title={`${stash.name || stash.files[0]?.filename || 'Untitled'} — ${stash.files.length} file${stash.files.length !== 1 ? 's' : ''}`}
               >
@@ -632,7 +642,7 @@ export default function Sidebar({
                 <div className="sidebar-item-footer">
                   <span className="sidebar-item-date">{formatDate(stash.updated_at)}</span>
                 </div>
-              </div>
+              </a>
             ))}
             {stashes.length === 0 && <div className="sidebar-empty">No stashes found</div>}
           </div>

--- a/src/components/StashCard.tsx
+++ b/src/components/StashCard.tsx
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 import type { StashListItem, LayoutMode } from '../types';
 import { renderDescriptionMarkdown } from '../utils/markdown';
 import { formatBytes } from '../utils/format';
+import { buildStashUrl } from '../utils/stash-url';
+import { isModifiedClick } from '../utils/link-click';
 import RelativeTime from './shared/RelativeTime';
 import { StarIcon } from './shared/icons';
 
@@ -37,6 +39,9 @@ export default function StashCard({
 }: Props) {
   const languages = getUniqueLanguages(stash);
   const title = stash.name || stash.files[0]?.filename || 'Untitled';
+  // Same deep link the viewer's "Copy Link" produces — as a real href so the
+  // card can be opened in a new tab (Ctrl/Cmd+click, middle-click, context menu).
+  const href = buildStashUrl('', stash.id);
   const fileCount = stash.files.length;
   const sizeLabel = formatBytes(stash.total_size);
   // Memoize the rendered markdown — `renderDescriptionMarkdown` runs a DOMParser
@@ -55,23 +60,32 @@ export default function StashCard({
     // handler purely as a pointer convenience, which needs no ARIA role.
     <div
       className={`stash-card ${layout}${stash.archived ? ' stash-card-archived' : ''}`}
-      onClick={onClick}
+      onClick={(e) => {
+        // A modified click means "open in a new tab" — the title link handles
+        // it natively; navigating in place here would defeat it.
+        if (isModifiedClick(e)) return;
+        onClick();
+      }}
       title={`Open stash: ${title}`}
     >
       <div className="stash-card-header">
-        <button
-          type="button"
+        <a
           className="stash-card-title"
+          href={href}
           onClick={(e) => {
             // The container's own handler would otherwise open the stash a
             // second time (same target, but it also fires on Enter/Space).
             e.stopPropagation();
+            // Ctrl/Cmd/Shift-click and middle-click stay with the browser so
+            // the stash opens in a new tab / window.
+            if (isModifiedClick(e)) return;
+            e.preventDefault();
             onClick();
           }}
           aria-label={`Open stash: ${title}`}
         >
           {title}
-        </button>
+        </a>
         {stash.archived && <span className="stash-card-archived-badge">Archived</span>}
         <button
           type="button"

--- a/src/components/StashViewer.tsx
+++ b/src/components/StashViewer.tsx
@@ -29,6 +29,11 @@ import StashBackupControls from './StashBackupControls';
 interface Props {
   stash: Stash;
   onEdit: () => void;
+  /**
+   * Open the editor pre-filled with a copy of this stash. Reusing an existing
+   * stash as a template previously meant copying every file by hand.
+   */
+  onDuplicate: () => void;
   onDelete: (id: string) => void;
   onArchive: (id: string, archived: boolean) => void;
   onBack: () => void;
@@ -432,6 +437,7 @@ function ApiOpenLink({ path, label }: { path: string; label: string }) {
 export default function StashViewer({
   stash,
   onEdit,
+  onDuplicate,
   onDelete,
   onArchive,
   onBack,
@@ -941,6 +947,17 @@ export default function StashViewer({
               <path d="M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 0 1-.927-.928l.929-3.25c.081-.286.235-.547.445-.758ZM11.189 4l1.811 1.811 1.72-1.72a.25.25 0 0 0 0-.354l-1.086-1.086a.25.25 0 0 0-.354 0Zm.528 3.283L9.906 5.472l-6.1 6.1a.25.25 0 0 0-.063.108l-.558 1.953 1.953-.558a.249.249 0 0 0 .108-.063Z" />
             </svg>
             Edit
+          </button>
+          <button
+            className="btn btn-secondary"
+            onClick={onDuplicate}
+            title="Duplicate this stash — opens a new stash pre-filled with its content"
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+              <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z" />
+              <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z" />
+            </svg>
+            Duplicate
           </button>
           <button
             className="btn btn-secondary"

--- a/src/components/__tests__/StashCard.test.tsx
+++ b/src/components/__tests__/StashCard.test.tsx
@@ -44,13 +44,53 @@ describe('StashCard ARIA structure (#132)', () => {
 
   it('exposes the title as the keyboard-reachable primary action', () => {
     const { container, onClick } = renderCard();
-    const title = container.querySelector('button.stash-card-title') as HTMLButtonElement;
+    const title = container.querySelector('a.stash-card-title') as HTMLAnchorElement;
     expect(title).not.toBeNull();
     expect(title.textContent).toBe('My stash');
 
     title.click();
-    // Exactly once: the title button stops the click from also reaching the
+    // Exactly once: the title link stops the click from also reaching the
     // container's pointer-convenience handler.
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('StashCard new-tab support', () => {
+  it('renders the title as a link to the stash deep link', () => {
+    const { container } = renderCard();
+    const title = container.querySelector('a.stash-card-title') as HTMLAnchorElement;
+    expect(title.getAttribute('href')).toBe('/stash/abc');
+  });
+
+  it('navigates in-app on a plain click and prevents the default navigation', () => {
+    const { container, onClick } = renderCard();
+    const title = container.querySelector('a.stash-card-title') as HTMLAnchorElement;
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    title.dispatchEvent(event);
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('leaves a Ctrl/Cmd-click to the browser so the stash opens in a new tab', () => {
+    const { container, onClick } = renderCard();
+    const title = container.querySelector('a.stash-card-title') as HTMLAnchorElement;
+    // Capture-phase cancel: jsdom cannot follow a link and would log
+    // "Not implemented: navigation". The component's own handler ignores
+    // defaultPrevented, so this only suppresses the (unimplemented) navigation.
+    const stopNavigation = (e: Event) => e.preventDefault();
+    document.addEventListener('click', stopNavigation, true);
+    title.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true, ctrlKey: true }),
+    );
+    document.removeEventListener('click', stopNavigation, true);
+    // No in-app navigation: the browser gets to open the href in a new tab.
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate in-app when the card body is Ctrl/Cmd-clicked', () => {
+    const { container, onClick } = renderCard();
+    const card = container.querySelector('.stash-card') as HTMLElement;
+    card.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, metaKey: true }));
+    expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/src/components/__tests__/StashViewer.favorite.test.tsx
+++ b/src/components/__tests__/StashViewer.favorite.test.tsx
@@ -34,6 +34,7 @@ function renderViewer(isFavorite: boolean, onToggleFavorite = vi.fn()) {
     <StashViewer
       stash={STASH}
       onEdit={vi.fn()}
+      onDuplicate={vi.fn()}
       onDelete={vi.fn()}
       onArchive={vi.fn()}
       onBack={vi.fn()}

--- a/src/components/editor/StashEditor.tsx
+++ b/src/components/editor/StashEditor.tsx
@@ -11,6 +11,12 @@ import type { MetadataEntry } from './MetadataEditor';
 
 interface Props {
   stash: Stash | null;
+  /**
+   * Pre-fill a NEW stash from an existing one ("Duplicate"). Only read when
+   * `stash` is null — the save branch keys on `stash`, so a template always
+   * creates a new stash instead of overwriting the one it was copied from.
+   */
+  template?: Stash | null;
   onSave: (savedId?: string) => void;
   onCancel: () => void;
   /**
@@ -73,16 +79,24 @@ function InfoIcon({ tooltip }: { tooltip: string }) {
   );
 }
 
-export default function StashEditor({ stash, onSave, onCancel, onDirtyChange }: Props) {
-  const [name, setName] = useState(stash?.name || '');
-  const [description, setDescription] = useState(stash?.description || '');
-  const [tags, setTags] = useState<string[]>(stash?.tags || []);
+export default function StashEditor({ stash, template, onSave, onCancel, onDirtyChange }: Props) {
+  // The stash the form is seeded from: the edited stash, or — when creating —
+  // the optional duplicate template. Everything below reads `source` for its
+  // INITIAL value only; `stash` alone still decides create vs. update.
+  const source = stash ?? template ?? null;
+  const [name, setName] = useState(source?.name || '');
+  const [description, setDescription] = useState(source?.description || '');
+  const [tags, setTags] = useState<string[]>(source?.tags || []);
   const [metadataEntries, setMetadataEntries] = useState<MetadataEntry[]>(
-    stash && Object.keys(stash.metadata).length > 0 ? metadataToEntries(stash.metadata) : [],
+    source && Object.keys(source.metadata).length > 0 ? metadataToEntries(source.metadata) : [],
   );
   const [files, setFiles] = useState<FileInput[]>(
-    stash
-      ? stash.files.map((f) => ({ filename: f.filename, content: f.content, language: f.language }))
+    source
+      ? source.files.map((f) => ({
+          filename: f.filename,
+          content: f.content,
+          language: f.language,
+        }))
       : [{ filename: '', content: '', language: '' }],
   );
   const [saving, setSaving] = useState(false);
@@ -97,7 +111,9 @@ export default function StashEditor({ stash, onSave, onCancel, onDirtyChange }: 
   const [wrapLines, setWrapLines] = useState<boolean>(getEditorWrapPreference);
   const [availableTags, setAvailableTags] = useState<TagInfo[]>([]);
   const [availableMetaKeys, setAvailableMetaKeys] = useState<string[]>([]);
-  const [firstFileManuallyEdited, setFirstFileManuallyEdited] = useState(!!stash);
+  // A duplicate arrives with real filenames too, so the name→filename
+  // auto-fill must stay off for it as well.
+  const [firstFileManuallyEdited, setFirstFileManuallyEdited] = useState(!!source);
   // Keep a ref to handleSave so the Ctrl/Cmd+S listener always calls the
   // latest version without being recreated on every render.
   const handleSaveRef = useRef<() => void>(() => {});
@@ -143,7 +159,7 @@ export default function StashEditor({ stash, onSave, onCancel, onDirtyChange }: 
   const fileIdsInitialized = useRef(false);
   if (!fileIdsInitialized.current) {
     fileIdsInitialized.current = true;
-    const initialFiles = stash ? stash.files : [{ filename: '', content: '', language: '' }];
+    const initialFiles = source ? source.files : [{ filename: '', content: '', language: '' }];
     fileIds.current = initialFiles.map(() => fileIdCounter.current++);
   }
 
@@ -380,7 +396,7 @@ export default function StashEditor({ stash, onSave, onCancel, onDirtyChange }: 
   return (
     <div className="stash-editor">
       <div className="editor-header">
-        <h2>{stash ? 'Edit Stash' : 'New Stash'}</h2>
+        <h2>{stash ? 'Edit Stash' : template ? 'Duplicate Stash' : 'New Stash'}</h2>
         <div className="editor-header-actions">
           {confirmCancel ? (
             <span className="cancel-confirm-inline">

--- a/src/components/editor/__tests__/StashEditor.duplicate.test.tsx
+++ b/src/components/editor/__tests__/StashEditor.duplicate.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import StashEditor from '../StashEditor';
+import type { Stash } from '../../../types';
+
+// The editor loads tag / metadata-key suggestions on mount. Stub fetch so the
+// test neither hits the network nor depends on the rejection timing.
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve(new Response('[]', { status: 200 }))),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+});
+
+const STASH: Stash = {
+  id: 'abc',
+  name: 'Deploy notes',
+  description: 'How we ship',
+  tags: ['ops'],
+  metadata: { owner: 'fo0' },
+  version: 3,
+  archived: false,
+  backup_enabled: true,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  files: [
+    {
+      id: 'f1',
+      stash_id: 'abc',
+      filename: 'deploy.md',
+      content: '# Deploy',
+      language: 'markdown',
+      sort_order: 0,
+    },
+  ],
+};
+
+function values(container: HTMLElement, selector: string): string[] {
+  return Array.from(container.querySelectorAll<HTMLInputElement>(selector)).map((el) => el.value);
+}
+
+describe('StashEditor duplicate template', () => {
+  it('pre-fills a new stash from the template', () => {
+    const { container } = render(
+      <StashEditor
+        stash={null}
+        template={{ ...STASH, name: 'Deploy notes (copy)' }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(container.querySelector('h2')?.textContent).toBe('Duplicate Stash');
+    // Name + description + the file row come from the template.
+    expect(values(container, 'input')).toContain('Deploy notes (copy)');
+    expect(values(container, 'input')).toContain('deploy.md');
+    expect(
+      Array.from(container.querySelectorAll('textarea')).some((t) =>
+        t.value.includes('How we ship'),
+      ),
+    ).toBe(true);
+  });
+
+  it('renders a blank form without a template', () => {
+    const { container } = render(
+      <StashEditor stash={null} template={null} onSave={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(container.querySelector('h2')?.textContent).toBe('New Stash');
+    expect(values(container, 'input').every((v) => v === '')).toBe(true);
+  });
+
+  it('ignores the template while editing an existing stash', () => {
+    const { container } = render(
+      <StashEditor
+        stash={STASH}
+        template={{ ...STASH, id: 'other', name: 'Should not win' }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(container.querySelector('h2')?.textContent).toBe('Edit Stash');
+    expect(values(container, 'input')).toContain('Deploy notes');
+    expect(values(container, 'input')).not.toContain('Should not win');
+  });
+});

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7027,6 +7027,35 @@ textarea.code-editor-plain.code-editor-wrap {
   max-width: min(360px, calc(100vw - 48px));
 }
 
+/* Message column of a toast — keeps a long text from squeezing the action. */
+.app-toast-message {
+  flex: 1;
+  min-width: 0;
+}
+
+/* One-click follow-up inside the success toast (e.g. "Undo" after archiving). */
+.app-toast-action {
+  flex-shrink: 0;
+  padding: 3px 10px;
+  border: 1px solid currentColor;
+  border-radius: var(--radius);
+  background: transparent;
+  color: inherit;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.app-toast-action:hover {
+  background: rgba(63, 185, 80, 0.15);
+}
+
+.app-toast-action:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+
 /* === Global Error Toast === */
 .app-error-toast {
   position: fixed;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -575,7 +575,12 @@ body {
   padding: 0 8px;
 }
 
+/* Rendered as an <a href="/stash/:id"> so rows can be opened in a new tab;
+   the link resets keep the original row look. */
 .sidebar-item {
+  display: block;
+  color: inherit;
+  text-decoration: none;
   padding: 10px 12px;
   border-radius: var(--radius);
   cursor: pointer;
@@ -1687,7 +1692,10 @@ body {
 }
 
 /* Real <button> (the card's primary action) reset back to plain text. */
+/* An <a href="/stash/:id"> (new-tab support) styled as the plain card title. */
 .stash-card-title {
+  display: block;
+  text-decoration: none;
   font-size: 14px;
   font-weight: 500;
   color: var(--text-primary);

--- a/src/utils/__tests__/link-click.test.ts
+++ b/src/utils/__tests__/link-click.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { isModifiedClick } from '../link-click';
+
+describe('isModifiedClick', () => {
+  it('treats a plain primary click as in-app navigation', () => {
+    expect(isModifiedClick({ button: 0 })).toBe(false);
+    expect(isModifiedClick({})).toBe(false);
+  });
+
+  it('leaves modified clicks to the browser', () => {
+    expect(isModifiedClick({ button: 0, ctrlKey: true })).toBe(true);
+    expect(isModifiedClick({ button: 0, metaKey: true })).toBe(true);
+    expect(isModifiedClick({ button: 0, shiftKey: true })).toBe(true);
+    expect(isModifiedClick({ button: 0, altKey: true })).toBe(true);
+  });
+
+  it('leaves non-primary buttons (middle-click) to the browser', () => {
+    expect(isModifiedClick({ button: 1 })).toBe(true);
+    expect(isModifiedClick({ button: 2 })).toBe(true);
+  });
+});

--- a/src/utils/link-click.ts
+++ b/src/utils/link-click.ts
@@ -1,0 +1,28 @@
+/**
+ * Click helpers for in-app links.
+ *
+ * Stash rows and cards navigate through the SPA router, but they are rendered
+ * as real `<a href>` elements so the browser's own "open in a new tab"
+ * affordances (Ctrl/Cmd+click, middle-click, Shift+click, context menu) keep
+ * working. `isModifiedClick` tells the click handler when to step aside and
+ * let the browser handle the navigation itself.
+ */
+
+/** The subset of a mouse/click event this module needs — keeps it testable. */
+export interface ClickLike {
+  button?: number;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+}
+
+/**
+ * True when the click carries a modifier (or is not the primary button), i.e.
+ * the user asked the browser for a new tab / new window / download rather than
+ * for in-app navigation.
+ */
+export function isModifiedClick(e: ClickLike): boolean {
+  if (typeof e.button === 'number' && e.button !== 0) return true;
+  return Boolean(e.metaKey || e.ctrlKey || e.shiftKey || e.altKey);
+}


### PR DESCRIPTION
## Summary

Autonomous feature comfort sweep of the web GUI: three end-user comfort/quality features, one commit each. No refactorings, no dependency changes.

## Changes

| # | Bereich/Datei | Kategorie | Feature | Nutzen | Aufwand | Empfehlung |
|---|---------------|-----------|---------|--------|---------|------------|
| 1 | `StashViewer.tsx`, `editor/StashEditor.tsx`, `App.tsx` | Komfort | **Duplicate stash** — viewer action opens the new-stash editor pre-filled from the current stash (name suffixed `(copy)`); the original is untouched and the save branch still creates | Reusing a stash as a template meant copying every file, tag and metadata entry by hand | M | auto-build |
| 2 | `StashCard.tsx`, `Sidebar.tsx`, `utils/link-click.ts`, `styles/app.css` | Komfort | **Open a stash in a new tab** — dashboard cards and sidebar rows are real `/stash/:id` links; plain clicks still route inside the SPA, modified clicks (Ctrl/Cmd, Shift, middle-click, context menu) go to the browser | Comparing two stashes previously meant navigating back and forth | M | auto-build |
| 3 | `App.tsx`, `styles/app.css` | Qualität | **Undo after archiving** — the success toast carries an `Undo` action and stays up 6 s when it does | Archiving hides the stash from the default listing; an accidental click meant hunting it down behind the "show archived" filter | S | auto-build |

## Testing

New/extended tests: `src/components/editor/__tests__/StashEditor.duplicate.test.tsx`, `src/utils/__tests__/link-click.test.ts`, `src/components/__tests__/StashCard.test.tsx` (href, plain-click interception, modified click left to the browser).

Full local chain green on the final commit: `npm ci` → `npm run format:check` → `npx tsc --noEmit` → `npm test` (465 passed, 5 skipped, 47 files) → `npm run build`.

## Checklist

- [x] Formatting passes (`npm run format:check`)
- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Changes are documented (if applicable) — README feature list mentions the duplicate action

Closes #482


---
_Generated by [Claude Code](https://claude.ai/code/session_019nqU131JbCUbPtTgLMXt7o)_