### PR TITLE
refactor: best-practice sweep (Next.js 16 App Router + React 19 + SQLite/MCP)

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -29,6 +29,17 @@ import type {
 
 const BASE = '/api/stashes';
 
+/**
+ * Encode a value for use as a single URL path segment.
+ *
+ * Stash and token ids are server-generated UUIDs and versions are numbers, so
+ * this is a no-op for every call the app makes today. It is here because
+ * interpolating an unescaped value into a path is a latent bug the moment an
+ * id can carry `/`, `?` or `#` — and because `getBackupStatus` already encodes
+ * its query parameter, so the path segments were the one inconsistent surface.
+ */
+const seg = (value: string | number): string => encodeURIComponent(String(value));
+
 let _authToken = '';
 
 export function setAuthToken(token: string) {
@@ -75,7 +86,7 @@ export const api = {
   },
 
   getStash(id: string): Promise<Stash> {
-    return request(`${BASE}/${id}`, { headers: getHeaders() });
+    return request(`${BASE}/${seg(id)}`, { headers: getHeaders() });
   },
 
   createStash(input: CreateStashInput): Promise<Stash> {
@@ -83,7 +94,7 @@ export const api = {
   },
 
   updateStash(id: string, input: UpdateStashInput): Promise<Stash> {
-    return request(`${BASE}/${id}`, {
+    return request(`${BASE}/${seg(id)}`, {
       method: 'PATCH',
       headers: getHeaders(),
       body: JSON.stringify(input),
@@ -91,11 +102,11 @@ export const api = {
   },
 
   deleteStash(id: string): Promise<void> {
-    return request(`${BASE}/${id}`, { method: 'DELETE', headers: getHeaders() });
+    return request(`${BASE}/${seg(id)}`, { method: 'DELETE', headers: getHeaders() });
   },
 
   archiveStash(id: string, archived: boolean): Promise<Stash> {
-    return request(`${BASE}/${id}`, {
+    return request(`${BASE}/${seg(id)}`, {
       method: 'PATCH',
       headers: getHeaders(),
       body: JSON.stringify({ archived }),
@@ -116,15 +127,15 @@ export const api = {
 
   getAccessLog(id: string, limit?: number): Promise<AccessLogEntry[]> {
     const qs = limit ? `?limit=${limit}` : '';
-    return request(`${BASE}/${id}/access-log${qs}`, { headers: getHeaders() });
+    return request(`${BASE}/${seg(id)}/access-log${qs}`, { headers: getHeaders() });
   },
 
   getVersions(id: string): Promise<StashVersionListItem[]> {
-    return request(`${BASE}/${id}/versions`, { headers: getHeaders() });
+    return request(`${BASE}/${seg(id)}/versions`, { headers: getHeaders() });
   },
 
   getVersion(id: string, version: number): Promise<StashVersion> {
-    return request(`${BASE}/${id}/versions/${version}`, { headers: getHeaders() });
+    return request(`${BASE}/${seg(id)}/versions/${seg(version)}`, { headers: getHeaders() });
   },
 
   getVersionDiff(
@@ -132,11 +143,13 @@ export const api = {
     v1: number,
     v2: number,
   ): Promise<{ v1: StashVersion; v2: StashVersion }> {
-    return request(`${BASE}/${id}/versions/diff?v1=${v1}&v2=${v2}`, { headers: getHeaders() });
+    return request(`${BASE}/${seg(id)}/versions/diff?v1=${seg(v1)}&v2=${seg(v2)}`, {
+      headers: getHeaders(),
+    });
   },
 
   restoreVersion(id: string, version: number): Promise<Stash> {
-    return request(`${BASE}/${id}/versions/${version}/restore`, {
+    return request(`${BASE}/${seg(id)}/versions/${seg(version)}/restore`, {
       method: 'POST',
       headers: getHeaders(),
     });
@@ -196,7 +209,7 @@ export const api = {
   },
 
   deleteToken(id: string): Promise<void> {
-    return request(`/api/tokens/${id}`, { method: 'DELETE', headers: getHeaders() });
+    return request(`/api/tokens/${seg(id)}`, { method: 'DELETE', headers: getHeaders() });
   },
 
   // Admin auth
@@ -329,7 +342,7 @@ export const api = {
   },
 
   getBackupStatus(stashId?: string): Promise<BackupStatusResponse> {
-    const qs = stashId ? `?stashId=${encodeURIComponent(stashId)}` : '';
+    const qs = stashId ? `?stashId=${seg(stashId)}` : '';
     return request(`/api/backup/status${qs}`, { headers: getHeaders() });
   },
 
@@ -349,7 +362,7 @@ export const api = {
   },
 
   setStashBackupEnabled(id: string, enabled: boolean): Promise<Stash> {
-    return request(`${BASE}/${id}`, {
+    return request(`${BASE}/${seg(id)}`, {
       method: 'PATCH',
       headers: getHeaders(),
       body: JSON.stringify({ backup_enabled: enabled }),

--- a/src/components/shared/RelativeTime.tsx
+++ b/src/components/shared/RelativeTime.tsx
@@ -10,6 +10,36 @@ interface Props {
 const RELATIVE_TICK_MS = 60 * 1000;
 
 /**
+ * One shared interval for every mounted `<RelativeTime>`.
+ *
+ * The dashboard renders one instance per stash card (STASH_PAGE_SIZE = 50, more
+ * after "Load more") and the viewer's access-log tab adds one per entry, so a
+ * per-instance `setInterval` meant dozens of independent timers waking the main
+ * thread at staggered offsets — dozens of separate re-render passes per minute
+ * instead of one. A single module-level timer notifies all subscribers together
+ * and stops itself when the last instance unmounts.
+ */
+const tickSubscribers = new Set<() => void>();
+let tickTimer: ReturnType<typeof setInterval> | null = null;
+
+function subscribeToTick(listener: () => void): () => void {
+  tickSubscribers.add(listener);
+  if (tickTimer === null) {
+    tickTimer = setInterval(() => {
+      // Iterate a copy: a listener may unsubscribe while being notified.
+      for (const notify of [...tickSubscribers]) notify();
+    }, RELATIVE_TICK_MS);
+  }
+  return () => {
+    tickSubscribers.delete(listener);
+    if (tickSubscribers.size === 0 && tickTimer !== null) {
+      clearInterval(tickTimer);
+      tickTimer = null;
+    }
+  };
+}
+
+/**
  * Displays a relative timestamp ("3d ago") that toggles to the full locale
  * date-time on click. Click again to switch back. The full date is always
  * visible as a tooltip regardless of toggle state.
@@ -23,10 +53,7 @@ export default function RelativeTime({ dateStr, className }: Props) {
   // forever — the state value is unused, only the re-render matters.
   const [, setTick] = useState(0);
 
-  useEffect(() => {
-    const interval = setInterval(() => setTick((t) => t + 1), RELATIVE_TICK_MS);
-    return () => clearInterval(interval);
-  }, []);
+  useEffect(() => subscribeToTick(() => setTick((t) => t + 1)), []);
 
   const toggle = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/server/stores/search-store.ts
+++ b/src/server/stores/search-store.ts
@@ -309,8 +309,16 @@ export class SearchStore {
       }
     }
 
-    const stashes: SearchStashItem[] = rows.map((row) => {
-      const stashRow = stashRowsById.get(row.stash_id) as Record<string, unknown>;
+    const stashes: SearchStashItem[] = rows.flatMap((row) => {
+      const stashRow = stashRowsById.get(row.stash_id);
+      // The FTS hit and the batched `stashes` fetch are two separate
+      // statements. A stash deleted between them (the stdio MCP server runs in
+      // its own process against the same file) leaves a hit with no row, and
+      // the previous unchecked `as Record<string, unknown>` cast hid that from
+      // the compiler: `rowToStashListItem(undefined)` then threw a TypeError
+      // and turned the whole search into a 500. Drop the stale hit instead —
+      // `total` still reports the count the JOINed COUNT(*) saw.
+      if (!stashRow) return [];
       const item = rowToStashListItem(stashRow);
       const files = filesByStash.get(item.id) ?? [];
       const total_size = files.reduce((sum, f) => sum + f.size, 0);
@@ -330,13 +338,15 @@ export class SearchStore {
       if (row.content_snippet && row.content_snippet.includes(FTS_SNIPPET_OPEN))
         snippets.file_content = formatSnippet(row.content_snippet);
 
-      return {
-        ...item,
-        total_size,
-        files,
-        relevance: Math.abs(row.rank),
-        snippets: Object.keys(snippets).length > 0 ? snippets : undefined,
-      };
+      return [
+        {
+          ...item,
+          total_size,
+          files,
+          relevance: Math.abs(row.rank),
+          snippets: Object.keys(snippets).length > 0 ? snippets : undefined,
+        },
+      ];
     });
 
     return { stashes, total: countRow.count, query };


### PR DESCRIPTION
## Summary

Best-practice sweep across the Next.js App Router / React / SQLite-MCP surfaces. Three behaviour-equivalent fixes, one commit each: a latent 500 in FTS search, inconsistent URL encoding in the REST client, and a per-instance timer in `RelativeTime`.

Findings that could not be fixed without changing behaviour (access-log scope gating, unbounded `access_log` growth) or that exceed the sweep's per-finding size ceiling (`node:` import prefixes across 18 files, the duplicated graph canvases) are recorded on the issue instead.

Closes #488

## Changes

| # | File | Category | Finding → Fix | Effort | Recommendation |
|---|------|----------|---------------|--------|----------------|
| 1 | `src/server/stores/search-store.ts` | Correctness | `searchStashes` cast the batched stash lookup with `as Record<string, unknown>`, so an FTS hit whose `stashes` row vanished between the MATCH query and the follow-up `IN (…)` fetch hit `rowToStashListItem(undefined)` → `TypeError` → 500 on `/api/stashes?search=`. The window is real because the stdio MCP server runs in its own process against the same SQLite file. → Drop the cast, skip the stale hit; `total` still reports the JOINed `COUNT(*)`. | S | auto-fix |
| 2 | `src/api.ts` | Correctness | Eleven call sites interpolated ids/versions into REST paths unencoded while `getBackupStatus` already encoded its query parameter. → Single `seg()` helper over every dynamic path segment. No-op for today's server-generated UUIDs; removes the latent break once an id can carry `/`, `?` or `#`. | S | auto-fix |
| 3 | `src/components/shared/RelativeTime.tsx` | Performance | Each instance owned a 60 s `setInterval`; the dashboard renders one per stash card (`STASH_PAGE_SIZE = 50`) and the access-log tab one per entry — dozens of timers at staggered offsets, dozens of separate re-render passes a minute. → Module-level ticker with a subscriber `Set`, started on first mount and cleared on last unmount. Same cadence, same rendered label. | S | auto-fix |

No feature changes, no dependency changes, no style-only diffs outside the findings. `.claude/**`, `CLAUDE.md`, `AGENTS.md` and `agent_docs/**` are untouched.

## Testing

Full chain from `CLAUDE.md → Commands` (the real gate — `docker-publish.yml` is `workflow_dispatch`-only), run once after all three commits:

```
npm ci                  exit 0
npm run format:check    exit 0
npx tsc --noEmit        exit 0
npm test                exit 0   47 files, 465 passed / 5 skipped
npm run build           exit 0
```

Baseline before the changes was identical (465 passed / 5 skipped), so the suite is unchanged, not merely still green.

## Checklist

- [x] Formatting passes (`npm run format:check`)
- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Changes are documented (if applicable) — behaviour-equivalent internals only; each fix carries its rationale as a code comment, no user-facing doc surface changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGcB7rozJHWJzByNMaraU4)_